### PR TITLE
Provide units for coordinates if not present in data

### DIFF
--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -55,13 +55,31 @@ def calc_aij_relative_flux(star_data, comp_stars,
     """
 
     # Match comparison star list to instrumental magnitude information
-    star_data_coords = SkyCoord(ra=star_data['RA'], dec=star_data['Dec'])
+    if star_data['RA'].unit is None:
+        unit = 'degree'
+    else:
+        # Pulled this from the source code -- None is ok but need
+        # to match the number of coordinates.
+        unit = [None, None]
+
+    star_data_coords = SkyCoord(ra=star_data['RA'], dec=star_data['Dec'],
+                                unit=unit)
 
     if coord_column is not None:
         comp_coords = comp_stars[coord_column]
     else:
-        comp_coords = SkyCoord(ra=comp_stars['RA'], dec=comp_stars['Dec'])
+        if comp_stars['RA'].unit is None:
+            unit = 'degree'
+        else:
+            # Pulled this from the source code -- None is ok but need
+            # to match the number of coordinates.
+            unit = [None, None]
+        comp_coords = SkyCoord(ra=comp_stars['RA'], dec=comp_stars['Dec'],
+                               unit=unit)
 
+    # Check for matches of stars in star data to the stars in comp_stars
+    # and eliminate as comps any stars for which the separation is bigger
+    # than 1.2 arcsec in any of the frames.
     index, d2d, _ = star_data_coords.match_to_catalog_sky(comp_coords)
 
     # Not sure this is really close enough for a good match...

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -57,14 +57,26 @@ def _raw_photometry_table():
     return expected_flux_ratios, expected_flux_error, raw_table, raw_table[1:4]
 
 
+@pytest.mark.parametrize('comp_ra_dec_have_units', [True, False])
+@pytest.mark.parametrize('star_ra_dec_have_units', [True, False])
 @pytest.mark.parametrize('in_place', [True, False])
-def test_relative_flux_calculation(in_place):
+def test_relative_flux_calculation(in_place,
+                                   star_ra_dec_have_units,
+                                   comp_ra_dec_have_units):
     expected_flux, expected_error, input_table, comp_star = _raw_photometry_table()
 
     # Try doing it all at once
     n_times = len(np.unique(input_table['date-obs']))
     all_expected_flux = _repeat(expected_flux, n_times)
     all_expected_error = _repeat(expected_error, n_times)
+
+    if not star_ra_dec_have_units:
+        input_table['RA'] = input_table['RA'].data
+        input_table['Dec'] = input_table['Dec'].data
+
+    if not comp_ra_dec_have_units:
+        comp_star['RA'] = comp_star['RA'].data
+        comp_star['Dec'] = comp_star['Dec'].data
 
     output_table = calc_aij_relative_flux(input_table, comp_star,
                                           in_place=in_place)


### PR DESCRIPTION
If photometry, etc, are saved as CSV then unit information is lost. This accommodates that.