### PR TITLE
Additional edits to docstrings of classes in stellarphot

### DIFF
--- a/stellarphot/analysis/exotic.py
+++ b/stellarphot/analysis/exotic.py
@@ -47,12 +47,16 @@ class MyValid(ipw.Button):
     ----------
 
     value : bool
-        Current value of the indicator.
+        Current value of the indicator. Initizlized to False.
 
     """
     value = Bool(False, help="Bool value").tag(sync=True)
 
     def __init__(self, **kwd):
+        """
+        Initialize the indicator by passing all keyword arguments to the
+        ipywidgets.Button constructor.
+        """
         super().__init__(**kwd)
         self.layout.width = '40px'
         self._set_properties(None)

--- a/stellarphot/analysis/exotic.py
+++ b/stellarphot/analysis/exotic.py
@@ -43,6 +43,13 @@ class MyValid(ipw.Button):
     A class containing a more compact indicator of valid entries based on ipywidgets
     buton value.
 
+    Parameters
+    ----------
+
+    **kwd :
+        All keyword arguments used to initialize an instance of this class are
+        passed to the ipywidgets.Button constructor.
+
     Attributes
     ----------
 
@@ -53,10 +60,6 @@ class MyValid(ipw.Button):
     value = Bool(False, help="Bool value").tag(sync=True)
 
     def __init__(self, **kwd):
-        """
-        Initialize the indicator by passing all keyword arguments to the
-        ipywidgets.Button constructor.
-        """
         super().__init__(**kwd)
         self.layout.width = '40px'
         self._set_properties(None)

--- a/stellarphot/analysis/transit_fitting.py
+++ b/stellarphot/analysis/transit_fitting.py
@@ -96,39 +96,17 @@ class TransitModelFit:
 
     Attributes
     ----------
-    airmass : array-like
-        Airmass at each time. Must be set before fitting.
 
     BIC : float
         Bayesian Information Criterion for the fit. This is calculated
         after the fit is performed.
 
-    data : array-like
-        Observed fluxes. Must be set before fitting.
-
-    model : `astropy.modeling.Model`
-        The model used for fitting. This is a combination of the batman
-        transit model and any other trends that are included in the fit.
-        This is set up when the ``setup_model`` method is called.
-
     n_fit_parameters : int
         Number of parameters that were fit. This is calculated after the
         fit is performed.
 
-    spp : array-like
-        Sky per pixel at each time. Must be set before fitting.
-
-    times : array-like
-        Times at which the light curve is observed. Must be set before
-        fitting.
-
     width : array-like
         Width of the star in pixels at each time. Must be set before fitting.
-
-    weights : array-like
-        Weights to use for fitting. If not provided, all weights are
-        set to 1.
-
     """
     def __init__(self, batman_params=None):
         """
@@ -175,6 +153,11 @@ class TransitModelFit:
 
     @property
     def times(self):
+        """
+        times : array-like
+            Times at which the light curve is observed. Must be set before
+            fitting.
+        """
         return self._times
 
     @times.setter
@@ -192,6 +175,10 @@ class TransitModelFit:
 
     @property
     def airmass(self):
+        """
+        airmass : array-like
+            Airmass at each time. Must be set before fitting.
+        """
         return self._airmass
 
     @airmass.setter
@@ -208,6 +195,11 @@ class TransitModelFit:
 
     @property
     def width(self):
+        """
+        weights : array-like
+            Weights to use for fitting. If not provided, all weights are
+            set to 1.
+        """
         return self._width
 
     @width.setter
@@ -224,6 +216,10 @@ class TransitModelFit:
 
     @property
     def spp(self):
+        """
+        spp : array-like
+            Sky per pixel at each time. Must be set before fitting.
+        """
         return self._spp
 
     @spp.setter
@@ -240,6 +236,10 @@ class TransitModelFit:
 
     @property
     def data(self):
+        """
+        data : array-like
+            Observed fluxes. Must be set before fitting.
+        """
         return self._data
 
     @data.setter
@@ -251,6 +251,12 @@ class TransitModelFit:
 
     @property
     def model(self):
+        """
+        model : `astropy.modeling.Model`
+            The model used for fitting. This is a combination of the batman
+            transit model and any other trends that are included in the fit.
+            This is set up when the ``setup_model`` method is called.
+        """
         return self._model
 
     def _set_default_batman_params(self):

--- a/stellarphot/analysis/transit_fitting.py
+++ b/stellarphot/analysis/transit_fitting.py
@@ -94,6 +94,12 @@ class TransitModelFit:
     """
     Transit model fits to observed light curves.
 
+    Parameters
+    ----------
+    batman_params : batman.TransitParams
+        Parameters for the batman transit model. If not provided, the
+        default parameters will be used.
+
     Attributes
     ----------
 
@@ -109,15 +115,6 @@ class TransitModelFit:
         Width of the star in pixels at each time. Must be set before fitting.
     """
     def __init__(self, batman_params=None):
-        """
-        Initialize the transit model fit.
-
-        Parameters
-        ----------
-        batman_params : batman.TransitParams
-            Parameters for the batman transit model. If not provided, the
-            default parameters will be used.
-        """
         self._batman_params = batman.TransitParams()
         self._set_default_batman_params()
         self._times = None

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -7,6 +7,20 @@ class Camera:
     """
     A class to represent a CCD-based camera.
 
+    Parameters
+    ----------
+
+    gain : `astropy.quantity.Quantity`
+        The gain of the camera in units such that the unit of the product `gain`
+        times the image data matches the unit of the `read_noise`.
+
+    read_noise : `astropy.quantity.Quantity`
+        The read noise of the camera in units of electrons.
+
+    dark_current : `astropy.quantity.Quantity`
+        The dark current of the camera in units such that, when multiplied by
+        exposure time, the unit matches the unit of the `read_noise`.
+
     Attributes
     ----------
 
@@ -44,22 +58,6 @@ class Camera:
     def __init__(self, gain=1.0 * u.electron / u.adu,
                  read_noise=1.0 * u.electron,
                  dark_current=0.01 * u.electron / u.second):
-        """
-        Initialize a Camera object instance by passing the required parameters.
-
-        Parameters
-        ----------
-        gain : `astropy.quantity.Quantity`
-            The gain of the camera in units such that the unit of the product `gain`
-            times the image data matches the unit of the `read_noise`.
-
-        read_noise : `astropy.quantity.Quantity`
-            The read noise of the camera in units of electrons.
-
-        dark_current : `astropy.quantity.Quantity`
-            The dark current of the camera in units such that, when multiplied by
-            exposure time, the unit matches the unit of the `read_noise`.
-        """
         super().__init__()
         self.gain = gain
         self.read_noise = read_noise

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -45,7 +45,7 @@ class Camera:
                  read_noise=1.0 * u.electron,
                  dark_current=0.01 * u.electron / u.second):
         """
-        Initializes a Camera object instance.
+        Initialize a Camera object instance by passing the required parameters.
 
         Parameters
         ----------

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -511,14 +511,39 @@ class Star(object):
     """
     A class for storing photometry for a single star.
 
-    Parameters
+    Attributes
     ----------
 
-    table : `astropy.table.Table`
-        Table of photometry for a single star.
+    airmass
 
-    id_num : int
+    bjd_tdb
+
+    counts
+
+    dec
+
+    error
+
+    exposure
+
+    id: int
         ID number of the star.
+
+    jd_utc_start
+
+    magnitude
+
+    magnitude_error
+
+    mjd_start
+
+    peak
+
+    ra
+
+    sky_per_pixel
+
+    snr
 
     """
     def __init__(self, table, id_num):
@@ -537,15 +562,7 @@ class Star(object):
         """
         self._table = table
         self._table['DEC'].unit = u.degree
-        self._id = id_num
-
-    @property
-    def id(self):
-        """
-        id: int
-            ID number of the star.
-        """
-        return self._id
+        self.id = id_num
 
     @property
     def airmass(self):

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -527,7 +527,7 @@ class Star(object):
         Airmass at the time of observation.
 
     bjd_tdb : `astropy.units.Quantity`
-        Barycentric Dynamical Time taking into account relativity.
+        Midpoint of the exposure as barycentric Julian date in Barycentric Dynamical Time.
 
     counts : `astropy.units.Quantity`
         Net counts in the aperture.

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -35,7 +35,7 @@ class ApertureAIJ:
     """
     def __init__(self):
         """
-        Initialize and set default values for the attributes of the aperture object instance.
+        Default values for the attributes set when instantiating an aperture object.
         """
 
         # Outer annulus radius
@@ -115,7 +115,7 @@ class MultiApertureAIJ:
     """
     def __init__(self):
         """
-        Initialize and set default values for the attributes of the multi-aperture object instance.
+        The default valies of attributes are set when multi-aperture object instance is instantiated.
         """
         # Default values for these chosen to match AIJ defaults
         # They are not used by stellarphot
@@ -522,6 +522,10 @@ class Star(object):
 
     """
     def __init__(self, table, id_num):
+        """
+        Initialize a `Star` object by passing it a table of photometry and an
+        ID number.
+        """
         self._table = table
         self._table['DEC'].unit = u.degree
         self._id = id_num

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -313,6 +313,7 @@ class ApertureFileAIJ:
 
         Returns
         -------
+
         apAIJ: `~stellarphot.io.ApertureFileAIJ`
             ApertureFileAIJ object representing the aperture table.
         """
@@ -514,36 +515,36 @@ class Star(object):
     Attributes
     ----------
 
-    airmass
+    airmass : `astropy.units.Quantity`
 
-    bjd_tdb
+    bjd_tdb : `astropy.units.Quantity`
 
-    counts
+    counts : `astropy.units.Quantity`
 
-    dec
+    dec : `astropy.units.Quantity`
 
-    error
+    error : `astropy.units.Quantity`
 
-    exposure
+    exposure : `astropy.units.Quantity`
 
-    id: int
+    id : int
         ID number of the star.
 
-    jd_utc_start
+    jd_utc_start : `astropy.units.Quantity`
 
-    magnitude
+    magnitude : `astropy.units.Quantity`
 
-    magnitude_error
+    magnitude_error : `astropy.units.Quantity`
 
-    mjd_start
+    mjd_start : `astropy.units.Quantity`
 
-    peak
+    peak : `astropy.units.Quantity`
 
-    ra
+    ra : `astropy.units.Quantity`
 
-    sky_per_pixel
+    sky_per_pixel : `astropy.units.Quantity`
 
-    snr
+    snr : `astropy.units.Quantity`
 
     """
     def __init__(self, table, id_num):
@@ -567,80 +568,70 @@ class Star(object):
     @property
     def airmass(self):
         """
-        airmass : `astropy.units.Quantity`
-            Airmass at the time of observation.
+        Airmass at the time of observation.
         """
         return self._table['AIRMASS']
 
     @property
     def counts(self):
         """
-        counts : `astropy.units.Quantity`
-            Net counts in the aperture.
+        Net counts in the aperture.
         """
         return self._table['Source-Sky']
 
     @property
     def ra(self):
         """
-        ra : `astropy.units.Quantity`
-            Right ascension of the star.
+        Right ascension of the star.
         """
         return self._table['RA'] / 24 * 360 * u.degree
 
     @property
     def dec(self):
         """
-        dec : `astropy.units.Quantity`
-            Declination of the star.
+        Declination of the star.
         """
         return self._table['DEC']
 
     @property
     def error(self):
         """
-        error : `astropy.units.Quantity`
-            Error in the net counts.
+        Error in the net counts.
         """
         return self._table['Source_Error']
 
     @property
     def sky_per_pixel(self):
         """
-        sky_per_pixel : `astropy.units.Quantity`
-            Sky brightness per pixel.
+        Sky brightness per pixel.
         """
         return self._table['Sky/Pixel']
 
     @property
     def peak(self):
         """
-        peak : `astropy.units.Quantity`
-            Peak counts in the aperture.
+        Peak counts in the aperture.
         """
         return self._table['Peak']
 
     @property
     def jd_utc_start(self):
         """
-        jd_utc_start : `astropy.units.Quantity`
-            Julian date of the start of the observation.
+        Julian date of the start of the observation.
         """
         return self._table['JD_UTC']
 
     @property
     def mjd_start(self):
         """
-        mjd_start : `astropy.units.Quantity`
-            Modified Julian date of the start of the observation.
-"""
+        Modified Julian date of the start of the observation.
+        """
         return self._table['J.D.-2400000'] - 0.5
 
     @property
     def exposure(self):
         """
-        exposure : `astropy.units.Quantity`
-            Exposure time of the observation.
+        Exposure time of the observation.
         """
         try:
             return self._table['EXPOSURE']
@@ -650,31 +641,27 @@ class Star(object):
     @property
     def magnitude(self):
         """
-        magnitude : `astropy.units.Quantity`
-            Magnitude of the star.
+        Magnitude of the star.
         """
         return -2.5 * np.log10(self.counts) + 2.5 * np.log10(self.exposure)
 
     @property
     def snr(self):
         """
-        snr : `astropy.units.Quantity`
-            Signal-to-noise ratio of the star.
+        Signal-to-noise ratio of the star.
         """
         return self.counts / self.error
 
     @property
     def magnitude_error(self):
         """
-        magnitude_error : `astropy.units.Quantity`
-            Error in the magnitude of the star.
+        Error in the magnitude of the star.
         """
         return 1.0857 / self.snr
 
     @property
     def bjd_tdb(self):
         """
-        bjd_tdb : `astropy.units.Quantity`
-            Midpoint of the exposure as barycentric Julian date in Barycentric Dynamical Time.
+        Midpoint of the exposure as barycentric Julian date in Barycentric Dynamical Time.
         """
         return self._table['BJD_TDB']

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -520,109 +520,98 @@ class Star(object):
     id_num : int
         ID number of the star.
 
-    Attributes
-    ----------
-
-    airmass : `astropy.units.Quantity`
-        Airmass at the time of observation.
-
-    bjd_tdb : `astropy.units.Quantity`
-        Midpoint of the exposure as barycentric Julian date in Barycentric Dynamical Time.
-
-    counts : `astropy.units.Quantity`
-        Net counts in the aperture.
-
-    dec : `astropy.units.Quantity`
-        Declination of the star.
-
-    error : `astropy.units.Quantity`
-        Error in the net counts.
-
-    exposure : `astropy.units.Quantity`
-        Exposure time of the observation.
-
-    id: int
-        ID number of the star.
-
-    jd_utc_end : `astropy.units.Quantity`
-        Julian date of the end of the observation.
-
-    jd_utc_mid : `astropy.units.Quantity`
-        Julian date of the middle of the observation.
-
-    jd_utc_start : `astropy.units.Quantity`
-        Julian date of the start of the observation.
-
-    magnitude : `astropy.units.Quantity`
-        Magnitude of the star.
-
-    magnitude_error : `astropy.units.Quantity`
-        Error in the magnitude of the star.
-
-    mjd_utc_end : `astropy.units.Quantity`
-        Modified Julian date of the end of the observation.
-
-    mjd_utc_mid : `astropy.units.Quantity`
-        Modified Julian date of the middle of the observation.
-
-    mjd_utc_start : `astropy.units.Quantity`
-        Modified Julian date of the start of the observation.
-
-    peak : `astropy.units.Quantity`
-        Peak counts in the aperture.
-
-    ra : `astropy.units.Quantity`
-        Right ascension of the star.
-
-    sky_per_pixel : `astropy.units.Quantity`
-        Sky brightness per pixel.
-
-    snr : `astropy.units.Quantity`
-        Signal-to-noise ratio of the star.
     """
     def __init__(self, table, id_num):
         self._table = table
         self._table['DEC'].unit = u.degree
-        self.id = id_num
+        self._id = id_num
+
+    @property
+    def id(self):
+        """
+        id: int
+            ID number of the star.
+        """
+        return self._id
 
     @property
     def airmass(self):
+        """
+        airmass : `astropy.units.Quantity`
+            Airmass at the time of observation.
+        """
         return self._table['AIRMASS']
 
     @property
     def counts(self):
+        """
+        counts : `astropy.units.Quantity`
+            Net counts in the aperture.
+        """
         return self._table['Source-Sky']
 
     @property
     def ra(self):
+        """
+        ra : `astropy.units.Quantity`
+            Right ascension of the star.
+        """
         return self._table['RA'] / 24 * 360 * u.degree
 
     @property
     def dec(self):
+        """
+        dec : `astropy.units.Quantity`
+            Declination of the star.
+        """
         return self._table['DEC']
 
     @property
     def error(self):
+        """
+        error : `astropy.units.Quantity`
+            Error in the net counts.
+        """
         return self._table['Source_Error']
 
     @property
     def sky_per_pixel(self):
+        """
+        sky_per_pixel : `astropy.units.Quantity`
+            Sky brightness per pixel.
+        """
         return self._table['Sky/Pixel']
 
     @property
     def peak(self):
+        """
+        peak : `astropy.units.Quantity`
+            Peak counts in the aperture.
+        """
         return self._table['Peak']
 
     @property
     def jd_utc_start(self):
+        """
+        jd_utc_start : `astropy.units.Quantity`
+            Julian date of the start of the observation.
+        """
         return self._table['JD_UTC']
 
     @property
     def mjd_start(self):
+        """
+        mjd_start : `astropy.units.Quantity`
+            Modified Julian date of the start of the observation.
+"""
         return self._table['J.D.-2400000'] - 0.5
 
     @property
     def exposure(self):
+        """
+        exposure : `astropy.units.Quantity`
+            Exposure time of the observation.
+        """
         try:
             return self._table['EXPOSURE']
         except KeyError:
@@ -630,16 +619,32 @@ class Star(object):
 
     @property
     def magnitude(self):
+        """
+        magnitude : `astropy.units.Quantity`
+            Magnitude of the star.
+        """
         return -2.5 * np.log10(self.counts) + 2.5 * np.log10(self.exposure)
 
     @property
     def snr(self):
+        """
+        snr : `astropy.units.Quantity`
+            Signal-to-noise ratio of the star.
+        """
         return self.counts / self.error
 
     @property
     def magnitude_error(self):
+        """
+        magnitude_error : `astropy.units.Quantity`
+            Error in the magnitude of the star.
+        """
         return 1.0857 / self.snr
 
     @property
     def bjd_tdb(self):
+        """
+        bjd_tdb : `astropy.units.Quantity`
+            Midpoint of the exposure as barycentric Julian date in Barycentric Dynamical Time.
+        """
         return self._table['BJD_TDB']

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -34,10 +34,6 @@ class ApertureAIJ:
 
     """
     def __init__(self):
-        """
-        Default values for the attributes set when instantiating an aperture object.
-        """
-
         # Outer annulus radius
         self.rback2 = 41.0
 
@@ -114,9 +110,6 @@ class MultiApertureAIJ:
         List of y positions of the apertures.
     """
     def __init__(self):
-        """
-        The default valies of attributes are set when multi-aperture object instance is instantiated.
-        """
         # Default values for these chosen to match AIJ defaults
         # They are not used by stellarphot
         self.naperturesmax = 1000
@@ -204,9 +197,6 @@ class ApertureFileAIJ:
         Multi-aperture information.
     """
     def __init__(self):
-        """
-        Initialize the AstroImageJ aperture file instance.
-        """
         self.aperture = ApertureAIJ()
         self.multiaperture = MultiApertureAIJ()
 
@@ -512,6 +502,15 @@ class Star(object):
     """
     A class for storing photometry for a single star.
 
+    Parameters
+    ----------
+
+    table : `astropy.table.Table`
+        Table of photometry for a single star.
+
+    id_num : int
+        ID number of the star.
+
     Attributes
     ----------
 
@@ -548,19 +547,6 @@ class Star(object):
 
     """
     def __init__(self, table, id_num):
-        """
-        Initialize a `Star` object by passing it a table of photometry and an
-        ID number.
-
-        Parameters
-        ----------
-
-        table : `astropy.table.Table`
-            Table of photometry for a single star.
-
-        id_num : int
-            ID number of the star.
-        """
         self._table = table
         self._table['DEC'].unit = u.degree
         self.id = id_num

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -525,6 +525,15 @@ class Star(object):
         """
         Initialize a `Star` object by passing it a table of photometry and an
         ID number.
+
+        Parameters
+        ----------
+
+        table : `astropy.table.Table`
+            Table of photometry for a single star.
+
+        id_num : int
+            ID number of the star.
         """
         self._table = table
         self._table['DEC'].unit = u.degree

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -31,49 +31,49 @@ class TessSubmission:
     Parameters
     ----------
 
-    telescope_code: str
+    telescope_code : str
         The telescope code, e.g. "SRO" or "TJO"
 
-    filter: str
+    filter : str
         The filter used for the observations, e.g. "Ic" or "Rc"
 
-    utc_start: str
+    utc_start : str
         The UTC date of the first observation, in YYYYMMDD format
 
-    tic_id: int
+    tic_id : int
         The TIC ID of the target
 
-    planet_number: int
+    planet_number : int
         The planet number, if applicable
 
     Attributes
     ----------
 
-    apertures
+    apertures : str
 
-    base_name
+    base_name : str
 
-    field_image
+    field_image : str
 
-    field_image_zoom
+    field_image_zoom : str
 
     filter: str
         The filter used for the observations, e.g. "Ic" or "Rc"
 
-    planet_number: int
+    planet_number : int
         The planet number, if applicable
 
-    seeing_profile
+    seeing_profile : str
 
-    tic_coord
+    tic_coord : `astropy.coordinates.SkyCoord`
 
-    tic_id: int
+    tic_id : int
         The TIC ID of the target
 
-    telescope_code: str
+    telescope_code : str
         The telescope code, e.g. "SRO" or "TJO"
 
-    utc_start: str
+    utc_start : str
         The UTC date of the first observation, in YYYYMMDD format
 
     """
@@ -93,13 +93,13 @@ class TessSubmission:
 
         Parameters
         ----------
-        header: `astropy.io.fits.Header`
+        header : `astropy.io.fits.Header`
             The FITS header to parse
 
-        telescope_code: str
+        telescope_code : str
             The telescope code, e.g. "SRO" or "TJO"
 
-        planet: int
+        planet : int
             The planet number, if applicable
         """
 
@@ -176,8 +176,7 @@ class TessSubmission:
     @property
     def base_name(self):
         """
-        base_name: str
-            The base name of the submission, e.g. "TIC123456789-01_20200101_SRO_Ic"
+        The base name of the submission, e.g. "TIC123456789-01_20200101_SRO_Ic"
         """
         if self._valid():
             pieces = [
@@ -191,40 +190,35 @@ class TessSubmission:
     @property
     def seeing_profile(self):
         """
-        seeing_profile: str
-            The name of the seeing profile file, e.g. "TIC123456789-01_20200101_SRO_Ic_seeing-profile.png"
+        The name of the seeing profile file, e.g. "TIC123456789-01_20200101_SRO_Ic_seeing-profile.png"
         """
         return self.base_name + "_seeing-profile.png"
 
     @property
     def field_image(self):
         """
-        field_image: str
-            The name of the field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field.png"
+        The name of the field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field.png"
         """
         return self.base_name + "_field.png"
 
     @property
     def field_image_zoom(self):
         """
-
-            The name of the zoomed-in field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field-zoom.png"
+        The name of the zoomed-in field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field-zoom.png"
         """
         return self.base_name + "_field-zoom.png"
 
     @property
     def apertures(self):
         """
-        apertures: str
-            The name of the apertures file, e.g. "TIC123456789-01_20200101_SRO_Ic_measurements.apertures"
+        The name of the apertures file, e.g. "TIC123456789-01_20200101_SRO_Ic_measurements.apertures"
         """
         return self.base_name + "_measurements.apertures"
 
     @property
     def tic_coord(self):
         """
-        tic_coord: `astropy.coordinates.SkyCoord`
-            The SkyCoord of the target, from the TIC catalog.
+        The SkyCoord of the target, from the TIC catalog.
         """
         if not self._tic_info:
             self._tic_info = get_tic_info(self.tic_id)
@@ -255,27 +249,29 @@ class TOI:
     Attributes
     ----------
 
-    coord
+    coord : `astropy.coordinates.SkyCoord`
 
-    depth
+    depth : float
 
-    depth_error
+    depth_error : float
 
-    duration
+    duration : float
 
-    duration_error
+    duration_error : float
 
-    epoch
+    epoch : float
 
-    period
+    epoch_error : float
 
-    period_error
+    period : float
 
-    tess_mag
+    period_error : float
 
-    tess_mag_error
+    tess_mag : float
 
-    tic_id
+    tess_mag_error : float
+
+    tic_id : int
     """
     def __init__(self, tic_id, toi_table=DEFAULT_TABLE_LOCATION, allow_download=True):
         """
@@ -284,13 +280,13 @@ class TOI:
         Parameters
         ----------
 
-        tic_id: int
+        tic_id : int
             The TIC ID of the target.
 
-        toi_table: str, optional
+        toi_table : str, optional
             The path to the TOI table. If not provided, the default table will be downloaded.
 
-        allow_download: bool, optional
+        allow_download : bool, optional
             Whether to allow the default table to be downloaded if it is not found.
         """
         path = Path(toi_table)
@@ -308,96 +304,84 @@ class TOI:
     @property
     def tess_mag(self):
         """
-        tess_mag: float
-            The TESS magnitude of the target.
+        The TESS magnitude of the target.
         """
         return self._toi_table['TESS Mag'][0]
 
     @property
     def tess_mag_error(self):
         """
-        tess_mag_error: float
-            The uncertainty in the TESS magnitude.
+        The uncertainty in the TESS magnitude.
         """
         return self._toi_table['TESS Mag err'][0]
 
     @property
     def depth(self):
         """
-        depth: float
-            The transit depth of the target in parts per thousand.
+        The transit depth of the target in parts per thousand.
         """
         return self._toi_table['Depth (ppm)'][0] / 1000
 
     @property
     def depth_error(self):
         """
-        depth_error: float
-            The uncertainty in the transit depth in parts per thousand.
+        The uncertainty in the transit depth in parts per thousand.
         """
         return self._toi_table['Depth (ppm) err'][0] / 1000
 
     @property
     def epoch(self):
         """
-        epoch: float
-            The epoch of the transit.
+        The epoch of the transit.
         """
         return Time(self._toi_table['Epoch (BJD)'][0], scale='tdb', format='jd')
 
     @property
     def epoch_error(self):
         """
-        epoch_error: float
-            The uncertainty in the epoch of the transit.
+        The uncertainty in the epoch of the transit.
         """
         return self._toi_table['Epoch (BJD) err'][0] * u.day
 
     @property
     def period(self):
         """
-        period: float
-            The period of the transit.
+        The period of the transit.
         """
         return self._toi_table['Period (days)'][0] * u.day
 
     @property
     def period_error(self):
         """
-        period_error: float
-            The uncertainty in the period of the transit.
+        The uncertainty in the period of the transit.
         """
         return self._toi_table['Period (days) err'][0] * u.day
 
     @property
     def duration(self):
         """
-        duration: float
-            The duration of the transit.
+        The duration of the transit.
         """
         return self._toi_table['Duration (hours)'][0] * u.hour
 
     @property
     def duration_error(self):
         """
-        duration_error: float
-            The uncertainty in the duration of the transit.
+        The uncertainty in the duration of the transit.
         """
         return self._toi_table['Duration (hours) err'][0] * u.hour
 
     @property
     def coord(self):
         """
-        coord: `astropy.coordinates.SkyCoord`
-            The coordinates of the target.
+        The coordinates of the target.
         """
         return SkyCoord(ra=self._tic_info['ra'][0], dec=self._tic_info['dec'][0], unit='degree')
 
     @property
     def tic_id(self):
         """
-        tic_id: int
-            The TIC ID of the target.
+        The TIC ID of the target.
         """
         return self._tic_info['ID'][0]
 

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -31,13 +31,13 @@ class TessSubmission:
     Parameters
     ----------
 
-    telescope_code: String
+    telescope_code: str
         The telescope code, e.g. "SRO" or "TJO"
 
-    filter: String
+    filter: str
         The filter used for the observations, e.g. "Ic" or "Rc"
 
-    utc_start: String
+    utc_start: str
         The UTC date of the first observation, in YYYYMMDD format
 
     tic_id: int
@@ -45,6 +45,37 @@ class TessSubmission:
 
     planet_number: int
         The planet number, if applicable
+
+    Attributes
+    ----------
+
+    apertures
+
+    base_name
+
+    field_image
+
+    field_image_zoom
+
+    filter: str
+        The filter used for the observations, e.g. "Ic" or "Rc"
+
+    planet_number: int
+        The planet number, if applicable
+
+    seeing_profile
+
+    tic_coord
+
+    tic_id: int
+        The TIC ID of the target
+
+    telescope_code: str
+        The telescope code, e.g. "SRO" or "TJO"
+
+    utc_start: str
+        The UTC date of the first observation, in YYYYMMDD format
+
     """
     telescope_code: str
     filter: str
@@ -176,7 +207,7 @@ class TessSubmission:
     @property
     def field_image_zoom(self):
         """
-        field_image_zoom: str
+
             The name of the zoomed-in field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field-zoom.png"
         """
         return self.base_name + "_field-zoom.png"
@@ -220,6 +251,31 @@ class TessSubmission:
 class TOI:
     """
     A class to hold information about a TOI (TESS Object of Interest).
+
+    Attributes
+    ----------
+
+    coord
+
+    depth
+
+    depth_error
+
+    duration
+
+    duration_error
+
+    epoch
+
+    period
+
+    period_error
+
+    tess_mag
+
+    tess_mag_error
+
+    tic_id
     """
     def __init__(self, tic_id, toi_table=DEFAULT_TABLE_LOCATION, allow_download=True):
         """
@@ -236,7 +292,6 @@ class TOI:
 
         allow_download: bool, optional
             Whether to allow the default table to be downloaded if it is not found.
-
         """
         path = Path(toi_table)
         if not path.is_file():
@@ -368,7 +423,6 @@ class TessTargetFile:
 
     aperture_server : str, optional
         The URL of the aperture server. default: https://www.astro.louisville.edu/
-
 
     Attributes
     ----------

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -349,7 +349,7 @@ class TOI:
 @dataclass
 class TessTargetFile:
     """
-    A data class to hold information about a TESS target file.
+    A class to hold information about a TESS target file.
 
     Parameters
     ----------

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -246,6 +246,18 @@ class TOI:
     """
     A class to hold information about a TOI (TESS Object of Interest).
 
+    Parameters
+    ----------
+
+    tic_id : int
+        The TIC ID of the target.
+
+    toi_table : str, optional
+        The path to the TOI table. If not provided, the default table will be downloaded.
+
+    allow_download : bool, optional
+        Whether to allow the default table to be downloaded if it is not found.
+
     Attributes
     ----------
 
@@ -274,21 +286,6 @@ class TOI:
     tic_id : int
     """
     def __init__(self, tic_id, toi_table=DEFAULT_TABLE_LOCATION, allow_download=True):
-        """
-        Initialize a TOI object.
-
-        Parameters
-        ----------
-
-        tic_id : int
-            The TIC ID of the target.
-
-        toi_table : str, optional
-            The path to the TOI table. If not provided, the default table will be downloaded.
-
-        allow_download : bool, optional
-            Whether to allow the default table to be downloaded if it is not found.
-        """
         path = Path(toi_table)
         if not path.is_file():
             if not allow_download:

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -45,27 +45,6 @@ class TessSubmission:
 
     planet_number: int
         The planet number, if applicable
-
-
-    Attributes
-    ----------
-    base_name: str
-        The base name of the submission, e.g. "TIC123456789-01_20200101_SRO_Ic"
-
-    seeing_profile: str
-        The name of the seeing profile file, e.g. "TIC123456789-01_20200101_SRO_Ic_seeing-profile.png"
-
-    field_image: str
-        The name of the field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field.png"
-
-    field_image_zoom: str
-        The name of the zoomed-in field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field-zoom.png"
-
-    apertures: str
-        The name of the apertures file, e.g. "TIC123456789-01_20200101_SRO_Ic_measurements.apertures"
-
-    tic_coord: `astropy.coordinates.SkyCoord`
-        The SkyCoord of the target, from the TIC catalog.
     """
     telescope_code: str
     filter: str
@@ -165,6 +144,10 @@ class TessSubmission:
 
     @property
     def base_name(self):
+        """
+        base_name: str
+            The base name of the submission, e.g. "TIC123456789-01_20200101_SRO_Ic"
+        """
         if self._valid():
             pieces = [
                 f"TIC{self.tic_id}-{self.planet_number:02d}",
@@ -176,27 +159,51 @@ class TessSubmission:
 
     @property
     def seeing_profile(self):
+        """
+        seeing_profile: str
+            The name of the seeing profile file, e.g. "TIC123456789-01_20200101_SRO_Ic_seeing-profile.png"
+        """
         return self.base_name + "_seeing-profile.png"
 
     @property
     def field_image(self):
+        """
+        field_image: str
+            The name of the field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field.png"
+        """
         return self.base_name + "_field.png"
 
     @property
     def field_image_zoom(self):
+        """
+        field_image_zoom: str
+            The name of the zoomed-in field image file, e.g. "TIC123456789-01_20200101_SRO_Ic_field-zoom.png"
+        """
         return self.base_name + "_field-zoom.png"
 
     @property
     def apertures(self):
+        """
+        apertures: str
+            The name of the apertures file, e.g. "TIC123456789-01_20200101_SRO_Ic_measurements.apertures"
+        """
         return self.base_name + "_measurements.apertures"
 
     @property
     def tic_coord(self):
+        """
+        tic_coord: `astropy.coordinates.SkyCoord`
+            The SkyCoord of the target, from the TIC catalog.
+        """
         if not self._tic_info:
             self._tic_info = get_tic_info(self.tic_id)
         return SkyCoord(ra=self._tic_info['ra'][0], dec=self._tic_info['dec'][0], unit='degree')
 
     def invalid_parts(self):
+        """
+        Prints a string identifying parts of the submission that are invalid.
+        If submission valid, returns nothing.
+        """
         if self._valid():
             return
 
@@ -211,46 +218,8 @@ class TessSubmission:
 
 
 class TOI:
-    """ A class to hold information about a TOI (TESS Object of Interest).
-
-    Attributes
-    ----------
-
-    coord: `astropy.coordinates.SkyCoord`
-        The coordinates of the target.
-
-    depth: float
-        The transit depth of the target.
-
-    depth_error: float
-        The uncertainty in the transit depth.
-
-    duration: float
-        The duration of the transit.
-
-    duration_error: float
-        The uncertainty in the duration of the transit.
-
-    epoch: float
-        The epoch of the transit.
-
-    epoch_error: float
-        The uncertainty in the epoch of the transit.
-
-    period: float
-        The period of the transit.
-
-    period_error: float
-        The uncertainty in the period of the transit.
-
-    tess_mag: float
-        The TESS magnitude of the target.
-
-    tess_mag_error: float
-        The uncertainty in the TESS magnitude.
-
-    tic_id: int
-        The TIC ID of the target.
+    """
+    A class to hold information about a TOI (TESS Object of Interest).
     """
     def __init__(self, tic_id, toi_table=DEFAULT_TABLE_LOCATION, allow_download=True):
         """
@@ -283,62 +252,104 @@ class TOI:
 
     @property
     def tess_mag(self):
+        """
+        tess_mag: float
+            The TESS magnitude of the target.
+        """
         return self._toi_table['TESS Mag'][0]
 
     @property
     def tess_mag_error(self):
+        """
+        tess_mag_error: float
+            The uncertainty in the TESS magnitude.
+        """
         return self._toi_table['TESS Mag err'][0]
 
     @property
     def depth(self):
         """
-        Depth, parts per thousand.
+        depth: float
+            The transit depth of the target in parts per thousand.
         """
         return self._toi_table['Depth (ppm)'][0] / 1000
 
     @property
     def depth_error(self):
         """
-        Error in depth, parts per thousand.
+        depth_error: float
+            The uncertainty in the transit depth in parts per thousand.
         """
         return self._toi_table['Depth (ppm) err'][0] / 1000
 
     @property
     def epoch(self):
+        """
+        epoch: float
+            The epoch of the transit.
+        """
         return Time(self._toi_table['Epoch (BJD)'][0], scale='tdb', format='jd')
 
     @property
     def epoch_error(self):
+        """
+        epoch_error: float
+            The uncertainty in the epoch of the transit.
+        """
         return self._toi_table['Epoch (BJD) err'][0] * u.day
 
     @property
     def period(self):
+        """
+        period: float
+            The period of the transit.
+        """
         return self._toi_table['Period (days)'][0] * u.day
 
     @property
     def period_error(self):
+        """
+        period_error: float
+            The uncertainty in the period of the transit.
+        """
         return self._toi_table['Period (days) err'][0] * u.day
 
     @property
     def duration(self):
+        """
+        duration: float
+            The duration of the transit.
+        """
         return self._toi_table['Duration (hours)'][0] * u.hour
 
     @property
     def duration_error(self):
+        """
+        duration_error: float
+            The uncertainty in the duration of the transit.
+        """
         return self._toi_table['Duration (hours) err'][0] * u.hour
 
     @property
     def coord(self):
+        """
+        coord: `astropy.coordinates.SkyCoord`
+            The coordinates of the target.
+        """
         return SkyCoord(ra=self._tic_info['ra'][0], dec=self._tic_info['dec'][0], unit='degree')
 
     @property
     def tic_id(self):
+        """
+        tic_id: int
+            The TIC ID of the target.
+        """
         return self._tic_info['ID'][0]
 
 @dataclass
 class TessTargetFile:
     """
-    A class to hold information about a TESS target file.
+    A data class to hold information about a TESS target file.
 
     Parameters
     ----------

--- a/stellarphot/tests/test_detection.py
+++ b/stellarphot/tests/test_detection.py
@@ -13,6 +13,16 @@ from stellarphot.photometry import photutils_stellar_photometry
 
 
 class FakeImage:
+    """
+    Creates a fake image with a set of sources using the datafile stored
+    at `data/test_sources.csv`.
+
+    Parameters
+    ----------
+
+    noise_dev : float
+        The standard deviation of the noise in the image.
+    """
     def __init__(self, noise_dev=1.0):
         self.image_shape = [400, 500]
         data_file = get_pkg_data_filename('data/test_sources.csv')
@@ -28,10 +38,16 @@ class FakeImage:
 
     @property
     def sources(self):
+        """
+        Return the table of sources used to create the fake image.
+        """
         return self._sources
 
     @property
     def image(self):
+        """
+        Return the fake image.
+        """
         return self._stars + self._noise
 
 

--- a/stellarphot/tests/test_detection.py
+++ b/stellarphot/tests/test_detection.py
@@ -20,7 +20,7 @@ class FakeImage:
     Parameters
     ----------
 
-    noise_dev : float
+    noise_dev : float, optional
         The standard deviation of the noise in the image.
     """
     def __init__(self, noise_dev=1.0):

--- a/stellarphot/visualization/aij_plots.py
+++ b/stellarphot/visualization/aij_plots.py
@@ -107,6 +107,8 @@ def seeing_plot(raw_radius, raw_counts, binned_radius, binned_counts, HWHM,
 def plot_predict_ingress_egress(ingress_time, egress_time, end_line=1,
                                 ingress_x_pos=1, egress_x_pos=1, labels_y_pos=1):
     """
+    Plot vertical lines at the ingress and egress times and label them.
+
     Parameters
     ----------
     ingress_time : float

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -368,8 +368,12 @@ class ComparisonViewer:
     Attributes
     ----------
 
-    target_mag : float
-        Magnitude of the target.
+
+    aperture_output_file : str
+        File to save aperture information to.
+
+    box : `ipywidgets.Box`
+        Box containing the widgets.
 
     bright_mag_limit : float
         Bright magnitude limit for APASS stars.
@@ -377,23 +381,20 @@ class ComparisonViewer:
     dim_mag_limit : float
         Dim magnitude limit for APASS stars.
 
-    targets_from_file : str
-        File with target information.
-
-    tess_submission : `~stellarphot.io.TessSubmission`
-        Instance of the TESS submission class.
+    iw : `ginga.util.grc.RemoteClient`
+        Ginga widget.
 
     target_coord : `astropy.coordinates.SkyCoord`
         Coordinates of the target.
 
-    box : `ipywidgets.Box`
-        Box containing the widgets.
+    targets_from_file : str
+        File with target information.
 
-    iw : `ginga.util.grc.RemoteClient`
-        Ginga widget.
+    target_mag : float
+        Magnitude of the target.
 
-    aperture_output_file : str
-        File to save aperture information to.
+    tess_submission : `~stellarphot.io.TessSubmission`
+        Instance of the TESS submission class.
     """
     def __init__(self,
                  file="",
@@ -485,14 +486,7 @@ class ComparisonViewer:
     @property
     def variables(self):
         """
-        Return a dictionary of the variables in the class.
-
-        Returns
-        -------
-
-        our_vsx : `astropy.table.Table`
-            Table of the variables in the class.
-
+        An `astropy.table.Table` of the variables in the class.
         """
         comp_table = self.generate_table()
         new_vsx_mark = comp_table['marker name'] == 'VSX'

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -394,6 +394,8 @@ class ComparisonViewer:
 
     tess_submission : `~stellarphot.io.TessSubmission`
         Instance of the TESS submission class.
+
+    variables : `astropy.table.Table`
     """
     def __init__(self,
                  file="",

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -368,7 +368,6 @@ class ComparisonViewer:
     Attributes
     ----------
 
-
     aperture_output_file : str
         File to save aperture information to.
 

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -365,6 +365,33 @@ class ComparisonViewer:
     """
     A class to store an instance of the comparison viewer.
 
+    Parameters
+    ----------
+
+    file : str, optional
+        File to open. Defaults to "".
+
+    directory : str, optional
+        Directory to open file from. Defaults to '.'.
+
+    target_mag : float, optional
+        Magnitude of the target. Defaults to 10.
+
+    bright_mag_limit : float, optional
+        Bright magnitude limit for APASS stars. Defaults to 8.
+
+    dim_mag_limit : float, optional
+        Dim magnitude limit for APASS stars.  Defaults to 17.
+
+    targets_from_file : str, optional
+        File with target information.  Defaults to None.
+
+    object_coordinate : `astropy.coordinates.SkyCoord`, optional
+        Coordinates of the target. Defaults to None.
+
+    aperture_output_file : str, optional
+        File to save aperture information to.  Defaults to None.
+
     Attributes
     ----------
 
@@ -406,36 +433,6 @@ class ComparisonViewer:
                  targets_from_file=None,
                  object_coordinate=None,
                  aperture_output_file=None):
-        """
-        Initializes an instance of the ComparisonViewer class.
-
-        Parameters
-        ----------
-
-        file : str, optional
-            File to open. Defaults to "".
-
-        directory : str, optional
-            Directory to open file from. Defaults to '.'.
-
-        target_mag : float, optional
-            Magnitude of the target. Defaults to 10.
-
-        bright_mag_limit : float, optional
-            Bright magnitude limit for APASS stars. Defaults to 8.
-
-        dim_mag_limit : float, optional
-            Dim magnitude limit for APASS stars.  Defaults to 17.
-
-        targets_from_file : str, optional
-            File with target information.  Defaults to None.
-
-        object_coordinate : `astropy.coordinates.SkyCoord`, optional
-            Coordinates of the target. Defaults to None.
-
-        aperture_output_file : str, optional
-            File to save aperture information to.  Defaults to None.
-        """
 
         self._label_name = 'labels'
         self._circle_name = 'target circle'

--- a/stellarphot/visualization/fits_opener.py
+++ b/stellarphot/visualization/fits_opener.py
@@ -13,6 +13,20 @@ __all__ = ['FitsOpener']
 class FitsOpener:
     """
     A class to open FITS files using a file chooser and display them in an `astrowidgets.ImageWidget`.
+
+    Attributes
+    ----------
+
+    ccd : `astropy.nddata.CCDData`
+
+    file_chooser : `ipyfilechooser.FileChooser`
+
+    header : `astropy.io.fits.Header`
+
+    object : str
+        The object name from the FITS header.
+
+    path : `pathlib.Path`
     """
     def __init__(self, title="Choose an image", filter_pattern=None, **kwargs):
         """

--- a/stellarphot/visualization/fits_opener.py
+++ b/stellarphot/visualization/fits_opener.py
@@ -11,26 +11,8 @@ __all__ = ['FitsOpener']
 
 
 class FitsOpener:
-    """ A class to open FITS files and display them in an `astrowidgets.ImageWidget`.
-
-    Attributes
-    ----------
-
-    ccd : `astropy.nddata.CCDData`
-        The selected FITS file as a CCDData object.
-
-    file_chooser : `ipyfilechooser.FileChooser`
-        The actual FileChooser widget.
-
-    header : dict
-        The header of the selected FITS file.
-
-    path : `pathlib.Path`
-        The path to the selected FITS file.
-
-    register_callback : function, optional
-        A function that takes one argument. This function will be called when the
-        selected file changes.
+    """
+    A class to open FITS files using a file chooser and display them in an `astrowidgets.ImageWidget`.
     """
     def __init__(self, title="Choose an image", filter_pattern=None, **kwargs):
         """
@@ -67,18 +49,24 @@ class FitsOpener:
 
     @property
     def header(self):
+        """
+        The header of the selected FITS file.
+        """
         self._set_header()
         return self._header
 
     @property
     def ccd(self):
         """
-        Return image as CCDData object
+        Return image stored in FITS file as CCDData object
         """
         return CCDData.read(self.path)
 
     @property
     def path(self):
+        """
+        The path to the selected FITS file.
+        """
         return Path(self._fc.selected)
 
     def _set_header(self):

--- a/stellarphot/visualization/fits_opener.py
+++ b/stellarphot/visualization/fits_opener.py
@@ -14,6 +14,15 @@ class FitsOpener:
     """
     A class to open FITS files using a file chooser and display them in an `astrowidgets.ImageWidget`.
 
+    Parameters
+    ----------
+
+    title : str, optional
+        The title of the FileChooser widget. The default is "Choose an image".
+
+    filter_pattern : str, optional
+        The filter pattern to use for the FileChooser widget. The default is None.
+
     Attributes
     ----------
 
@@ -29,20 +38,6 @@ class FitsOpener:
     path : `pathlib.Path`
     """
     def __init__(self, title="Choose an image", filter_pattern=None, **kwargs):
-        """
-        Initializes an instance of the FitsOpener class, which is a wrapper around
-        the `ipyfilechooser.FileChooser` widget that (if no `filter_pattern` is given)
-        defaults to showing only FITS files.
-
-        Parameters
-        ----------
-
-        title : str, optional
-            The title of the FileChooser widget. The default is "Choose an image".
-
-        filter_pattern : str, optional
-            The filter pattern to use for the FileChooser widget. The default is None,
-        """
         self._fc = FileChooser(title=title, **kwargs)
         if not filter_pattern:
             self._fc.filter_pattern = ['*.fit*', '*.fit*.[bg]z']

--- a/stellarphot/visualization/photometry_widget_functions.py
+++ b/stellarphot/visualization/photometry_widget_functions.py
@@ -11,26 +11,6 @@ __all__ = ['PhotometrySettings']
 class PhotometrySettings:
     """
     A class to hold the widgets for photometry settings.
-
-    Attributes
-    ----------
-    aperture_locations : `pathlib.Path`
-        The path to the file containing the aperture locations.
-
-    aperture_radius : int
-        The radius of the aperture.
-
-    box : `ipywidgets.VBox`
-        The box containing the widgets.
-
-    ifc : `ccdproc.ImageFileCollection`
-        The image file collection for the images.
-
-    image_folder : `pathlib.Path`
-        The path to the folder containing the images.
-
-    object_name : str
-        The name of the object.
     """
     def __init__(self):
         """
@@ -49,22 +29,42 @@ class PhotometrySettings:
 
     @property
     def box(self):
+        """
+        box : `ipywidgets.VBox`
+            The box containing the widgets.
+        """
         return self._box
 
     @property
     def image_folder(self):
+        """
+        image_folder : `pathlib.Path`
+            The path to the folder containing the images.
+        """
         return self._image_dir.selected
 
     @property
     def aperture_locations(self):
+        """
+        aperture_locations : `pathlib.Path`
+            The path to the file containing the aperture locations
+        """
         return self._aperture_file_loc.selected
 
     @property
     def aperture_radius(self):
+        """
+        aperture_radius : int
+            The radius of the aperture.
+        """
         return self._aperture_radius
 
     @property
     def object_name(self):
+        """
+        object_name : str
+            The name of the object.
+        """
         return self._object_name.value
 
     def _update_ifc(self, change):

--- a/stellarphot/visualization/photometry_widget_functions.py
+++ b/stellarphot/visualization/photometry_widget_functions.py
@@ -11,6 +11,22 @@ __all__ = ['PhotometrySettings']
 class PhotometrySettings:
     """
     A class to hold the widgets for photometry settings.
+
+    Attributes
+    ----------
+
+    aperture_locations : `pathlib.Path`
+
+    aperture_radius : int
+
+    box : `ipywidgets.VBox`
+
+    image_folder : `pathlib.Path`
+
+    ifc : `ccdproc.ImageFileCollection`
+        The ImageFileCollection for the selected folder.
+
+    object_name : str
     """
     def __init__(self):
         """
@@ -30,40 +46,35 @@ class PhotometrySettings:
     @property
     def box(self):
         """
-        box : `ipywidgets.VBox`
-            The box containing the widgets.
+        The box containing the widgets.
         """
         return self._box
 
     @property
     def image_folder(self):
         """
-        image_folder : `pathlib.Path`
-            The path to the folder containing the images.
+        The path to the folder containing the images.
         """
         return self._image_dir.selected
 
     @property
     def aperture_locations(self):
         """
-        aperture_locations : `pathlib.Path`
-            The path to the file containing the aperture locations
+        The path to the file containing the aperture locations
         """
         return self._aperture_file_loc.selected
 
     @property
     def aperture_radius(self):
         """
-        aperture_radius : int
-            The radius of the aperture.
+        The radius of the aperture.
         """
         return self._aperture_radius
 
     @property
     def object_name(self):
         """
-        object_name : str
-            The name of the object.
+        The name of the object.
         """
         return self._object_name.value
 

--- a/stellarphot/visualization/photometry_widget_functions.py
+++ b/stellarphot/visualization/photometry_widget_functions.py
@@ -29,9 +29,6 @@ class PhotometrySettings:
     object_name : str
     """
     def __init__(self):
-        """
-        Initialize an instance of the PhotometrySettings widget.
-        """
         self._image_dir = FileChooser(title="Choose folder with images", show_only_dirs=True)
         self._aperture_file_loc = FileChooser(title='Choose aperture location file')
         self._aperture_settings_loc = FileChooser(title='Choose file with aperture settings')

--- a/stellarphot/visualization/seeing_profile_functions.py
+++ b/stellarphot/visualization/seeing_profile_functions.py
@@ -261,35 +261,11 @@ class RadialProfile:
     """
     Class to hold radial profile information for a star.
 
-    Parameters
-    ----------
-
-    data : numpy array
-        Image data.
-
-    x : int
-        x position of the star.
-
-    y : int
-        y position of the star.
-
     Attributes
     ----------
 
-    cen : tuple
-        x, y position of the center of the star.
-
-    data : numpy array
-        Image data.
-
-    FWHM : float
-        Full-width half-max of the radial profile.
-
     profile_size : int
         Size of the cutout used to construct the radial profile.
-
-    radius_values : numpy array
-        Radius values for the radial profile.
 
     r_exact : numpy array
         Exact radius of center of each pixels from profile center.
@@ -300,13 +276,13 @@ class RadialProfile:
     """
     def __init__(self, data, x, y):
         """
-        Initialize the radial profile object instance.  Sets the center
+        Initialize the radial profile object instance by setting the center
         of the star and the image data.
 
         Parameters
         ----------
 
-        data : numpy array
+        _data : numpy array
             Image data.
 
         x : int
@@ -317,13 +293,15 @@ class RadialProfile:
 
 
         """
-        self.cen = find_center(data, (x, y), cutout_size=30)
-        self.data = data
+        self._cen = find_center(data, (x, y), cutout_size=30)
+        self._data = data
 
     def profile(self, profile_size):
         """
         Construct the radial profile of the star.  Sets
-        ``r_exact``, ``ravg``, and ``radialprofile`` attributes.
+        ``r_exact``, ``ravg``, and ``radialprofile`` attributes
+        as well as ``scaled_profile``, ``scaled_exact_counts``, and
+        ``HWHM``.
 
         Parameters
         ----------
@@ -347,11 +325,35 @@ class RadialProfile:
         self.HWHM = find_hwhm(self.ravg, self.scaled_profile)
 
     @property
+    def data(self):
+        """
+        data : numpy array
+            Image data.
+        """
+        return self._data
+
+    @property
+    def cen(self):
+        """
+        cen : tuple
+            x, y position of the center of the star.
+        """
+        return self._cen
+
+    @property
     def FWHM(self):
+        """
+        FWHM : float
+            Full-width half-max of the radial profile.
+        """
         return int(np.round(2 * self.HWHM))
 
     @property
     def radius_values(self):
+        """
+        radius_values : numpy array
+            Radius values for the radial profile.
+        """
         return np.arange(len(self.radialprofile))
 
 

--- a/stellarphot/visualization/seeing_profile_functions.py
+++ b/stellarphot/visualization/seeing_profile_functions.py
@@ -261,6 +261,18 @@ class RadialProfile:
     """
     Class to hold radial profile information for a star.
 
+    Parameters
+    ----------
+
+    data : numpy array
+        Image data.
+
+    x : int
+        x position of the star.
+
+    y : int
+        y position of the star.
+
     Attributes
     ----------
 
@@ -291,24 +303,6 @@ class RadialProfile:
         Radial profile scaled to have a maximum of 1.
     """
     def __init__(self, data, x, y):
-        """
-        Initialize the radial profile object instance by setting the center
-        of the star and the image data.
-
-        Parameters
-        ----------
-
-        data : numpy array
-            Image data.
-
-        x : int
-            x position of the star.
-
-        y : int
-            y position of the star.
-
-
-        """
         self._cen = find_center(data, (x, y), cutout_size=30)
         self._data = data
 
@@ -389,6 +383,14 @@ class SeeingProfileWidget:
     """
     A class for storing an instance of a widget displaying the seeing profile of stars in an image.
 
+    Parameters
+    ----------
+    imagewidget : `astrowidgets.ImageWidget`, optional
+        ImageWidget instance to use for the seeing profile.
+
+    width : int, optional
+        Width of the seeing profile widget. Default is 500 pixels.
+
     Attributes
     ----------
 
@@ -436,17 +438,6 @@ class SeeingProfileWidget:
 
     """
     def __init__(self, imagewidget=None, width=500):
-        """
-        Initizes the SeeingProfileWidget instance.
-
-        Parameters
-        ----------
-        imagewidget : `astrowidgets.ImageWidget`, optional
-            ImageWidget instance to use for the seeing profile.
-
-        width : int, optional
-            Width of the seeing profile widget. Default is 500 pixels.
-        """
         if not imagewidget:
             imagewidget = ImageWidget(image_width=width,
                                       image_height=width,

--- a/stellarphot/visualization/seeing_profile_functions.py
+++ b/stellarphot/visualization/seeing_profile_functions.py
@@ -264,15 +264,31 @@ class RadialProfile:
     Attributes
     ----------
 
+    cen : tuple
+
+    data : numpy array
+
+    FWHM : float
+
+    HWHM : float
+        Half-width half-max of the radial profile.
+
     profile_size : int
         Size of the cutout used to construct the radial profile.
 
     r_exact : numpy array
         Exact radius of center of each pixels from profile center.
 
+    radius_values : numpy array
+
     ravg : numpy array
         Average radius in pixels used in constructing profile.
 
+    scaled_exact_counts : numpy array
+        Exact counts in each pixel, scaled to have a maximum of 1.
+
+    scaled_profile : numpy array
+        Radial profile scaled to have a maximum of 1.
     """
     def __init__(self, data, x, y):
         """
@@ -282,7 +298,7 @@ class RadialProfile:
         Parameters
         ----------
 
-        _data : numpy array
+        data : numpy array
             Image data.
 
         x : int
@@ -298,10 +314,7 @@ class RadialProfile:
 
     def profile(self, profile_size):
         """
-        Construct the radial profile of the star.  Sets
-        ``r_exact``, ``ravg``, and ``radialprofile`` attributes
-        as well as ``scaled_profile``, ``scaled_exact_counts``, and
-        ``HWHM``.
+        Construct the radial profile of the star.
 
         Parameters
         ----------
@@ -327,32 +340,28 @@ class RadialProfile:
     @property
     def data(self):
         """
-        data : numpy array
-            Image data.
+        Image data.
         """
         return self._data
 
     @property
     def cen(self):
         """
-        cen : tuple
-            x, y position of the center of the star.
+        x, y position of the center of the star.
         """
         return self._cen
 
     @property
     def FWHM(self):
         """
-        FWHM : float
-            Full-width half-max of the radial profile.
+        Full-width half-max of the radial profile.
         """
         return int(np.round(2 * self.HWHM))
 
     @property
     def radius_values(self):
         """
-        radius_values : numpy array
-            Radius values for the radial profile.
+        Radius values for the radial profile.
         """
         return np.arange(len(self.radialprofile))
 
@@ -380,15 +389,64 @@ class SeeingProfileWidget:
     """
     A class for storing an instance of a widget displaying the seeing profile of stars in an image.
 
-    Parameters
+    Attributes
     ----------
-    imagewidget : `astrowidgets.ImageWidget`, optional
-        ImageWidget instance to use for the seeing profile.
 
-    width : int, optional
-        Width of the seeing profile widget.
+    ap_t : `ipywidgets.IntText`
+        Text box for the aperture radius.
+
+    box : `ipywidgets.VBox`
+        Box containing the seeing profile widget.
+
+    container : `ipywidgets.VBox`
+        Container for the seeing profile widget.
+
+    object_name : str
+        Name of the object in the FITS file.
+
+    in_t : `ipywidgets.IntText`
+        Text box for the inner annulus.
+
+    iw : `astrowidgets.ImageWidget`
+        ImageWidget instance used for the seeing profile.
+
+    object_name : str
+        Name of the object in the FITS file.
+
+    out : `ipywidgets.Output`
+        Output widget for the seeing profile.
+
+    out2 : `ipywidgets.Output`
+        Output widget for the integrated counts.
+
+    out3 : `ipywidgets.Output`
+        Output widget for the SNR.
+
+    out_t : `ipywidgets.IntText`
+        Text box for the outer annulus.
+
+    rad_prof : `RadialProfile`
+        Radial profile of the star.
+
+    save_aps : `ipywidgets.Button`
+        Button to save the aperture settings.
+
+    tess_box : `ipywidgets.VBox`
+        Box containing the TESS settings.
+
     """
     def __init__(self, imagewidget=None, width=500):
+        """
+        Initizes the SeeingProfileWidget instance.
+
+        Parameters
+        ----------
+        imagewidget : `astrowidgets.ImageWidget`, optional
+            ImageWidget instance to use for the seeing profile.
+
+        width : int, optional
+            Width of the seeing profile widget. Default is 500 pixels.
+        """
         if not imagewidget:
             imagewidget = ImageWidget(image_width=width,
                                       image_height=width,
@@ -450,6 +508,15 @@ class SeeingProfileWidget:
         self._set_observers()
 
     def load_fits(self, file):
+        """
+        Load a FITS file into the image widget.
+
+        Parameters
+        ----------
+
+        file : str
+            Filename to open.
+        """
         self.fits_file.load_in_image_widget(self.iw)
 
     def _update_file(self, change):


### PR DESCRIPTION
Given that @property gets auto-rendered in sphinx into an attributes list, I removed attributes from the Class docstrings where @property was used and moved those into the actual @property functions.  I also tweaked the docstrings for `__init__` functions to read more clearly when rendered into documentation by sphinx.

There are a few cases where I had to create @property functions to access the variables (which I changed to be initialized into hidden variables in `__init__`) in order for the documentation to be consistent without redundancy.  There are still a few cases where I left attributes listed in the main class docstring because only one or two attributes had @property functions associated with them (e.g. `analysis.TransitModelFit`).