### PR TITLE
Fixes to ComparisonViewer for release version of ImageWidget

### DIFF
--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -20,6 +20,7 @@ __all__ = ["TessSubmission", "TOI", "TessTargetFile"]
 # Makes me want to vomit, but....
 DEFAULT_TABLE_LOCATION = "who.the.heck.knows"
 TOI_TABLE_URL = "https://exofop.ipac.caltech.edu/tess/download_toi.php?output=csv"
+GAIA_APERTURE_SERVER = "https://www.astro.louisville.edu/"
 TIC_regex = re.compile(r"[tT][iI][cC][^\d]?(?P<star>\d+)(?P<planet>\.\d\d)?")
 
 
@@ -406,9 +407,6 @@ class TessTargetFile:
         within 2.5 arcminutes the TESS target. If not provided, a temporary
         file will be created.
 
-    aperture_server : str, optional
-        The URL of the aperture server. default: https://www.astro.louisville.edu/
-
     Attributes
     ----------
 
@@ -442,9 +440,9 @@ class TessTargetFile:
     magnitude : float
     depth : float
     file : str = ""
-    aperture_server : str = "https://www.astro.louisville.edu/"
 
     def __post_init__(self):
+        self.aperture_server = GAIA_APERTURE_SERVER
         if not self.file:
             self.file = NamedTemporaryFile()
         self._path = Path(self.file.name)

--- a/stellarphot/source_detection.py
+++ b/stellarphot/source_detection.py
@@ -146,7 +146,7 @@ def source_detection(ccd, fwhm=8, sigma=3.0, iters=5,
                      sky_per_pix_avg=None):
     """
     Returns an astropy table containing the position of sources
-    within the image.
+    within the image identified using `photutils.DAOStarFinder` algorithm.
 
     Parameters
     ----------

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -575,8 +575,7 @@ class ComparisonViewer:
         try:
             self.variables.write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
-
+            raise OSError(f"Existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
     def _show_label_button_handler(self, change):
         value = change['new']
@@ -596,7 +595,7 @@ class ComparisonViewer:
         try:
             self.generate_table().write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save apertures to file, likely because existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
+            raise OSError(f"Existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')
@@ -728,7 +727,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._field_name.value)
             except OSError:
-                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
+                raise OSError(f"Existing file ({self._field_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
         if self._zoom_name.value:
             self.tess_field_zoom_view()
@@ -738,7 +737,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._zoom_name.value)
             except OSError:
-                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
+                raise OSError(f"Existing file ({self._zoom_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
     def generate_table(self):
         """

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -596,7 +596,7 @@ class ComparisonViewer:
         try:
             self.generate_table().write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save aperatures to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
+            print(f"ERROR: Can't save apertures to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
-from astropy import units as u
 from astropy.nddata import CCDData
 from astropy import units as u
 from astropy.coordinates.name_resolve import NameResolveError
@@ -188,12 +187,12 @@ def mag_scale(cmag, apass, v_angle, RD_angle,
     """
     high_mag = apass['r_mag'] < cmag + dimmer_dmag
     low_mag = apass['r_mag'] > cmag - brighter_dmag
-    if v_angle:
+    if len(v_angle)>0:
         good_v_angle = v_angle > 1.0 * u.arcsec
     else:
         good_v_angle = True
 
-    if RD_angle:
+    if len(RD_angle)>0:
         good_RD_angle = RD_angle > 1.0 * u.arcsec
     else:
         good_RD_angle = True

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -575,7 +575,7 @@ class ComparisonViewer:
         try:
             self.variables.write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
+            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
 
     def _show_label_button_handler(self, change):
@@ -596,7 +596,7 @@ class ComparisonViewer:
         try:
             self.generate_table().write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save apertures to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
+            print(f"ERROR: Can't save apertures to file, likely because existing file ({filename}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')
@@ -728,7 +728,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._field_name.value)
             except OSError:
-                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten, set overwrite_outputs=True to address this.")
+                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
         if self._zoom_name.value:
             self.tess_field_zoom_view()
@@ -738,7 +738,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._zoom_name.value)
             except OSError:
-                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten, set overwrite_outputs=True to address this.")
+                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten. Set overwrite_outputs=True to address this.")
 
     def generate_table(self):
         """

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -572,7 +572,11 @@ class ComparisonViewer:
         if not filename:
             filename = 'variables.csv'
         # Export variables as CSV (overwrite existing file if it exists)
-        self.variables.write(filename, overwrite=self.overwrite_outputs)
+        try:
+            self.variables.write(filename, overwrite=self.overwrite_outputs)
+        except OSError:
+            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten.")
+
 
     def _show_label_button_handler(self, change):
         value = change['new']
@@ -589,7 +593,10 @@ class ComparisonViewer:
         if not filename:
             filename = self.aperture_output_file
         # Export aperture file as CSV (overwrite existing file if it exists)
-        self.generate_table().write(filename, overwrite=self.overwrite_outputs)
+        try:
+            self.generate_table().write(filename, overwrite=self.overwrite_outputs)
+        except OSError:
+            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')
@@ -720,8 +727,8 @@ class ComparisonViewer:
                 Path(self._field_name.value).unlink()
             try:
                 self.iw.save(self._field_name.value)
-            except:
-                print("Error saving full field image.")
+            except OSError:
+                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten.")
 
         if self._zoom_name.value:
             self.tess_field_zoom_view()
@@ -730,8 +737,8 @@ class ComparisonViewer:
                 Path(self._zoom_name.value).unlink()
             try:
                 self.iw.save(self._zoom_name.value)
-            except:
-                print("Error saving zoomed in full field image.")
+            except OSError:
+                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten.")
 
     def generate_table(self):
         """

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -35,7 +35,7 @@ DESC_STYLE = {"description_width": "initial"}
 
 def read_file(radec_file):
     """
-    Read an AIJ radec file with target and/or comp positions
+    Read an AIJ radec file with target and/or comparison positions
 
     Parameters
     ----------

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -575,7 +575,7 @@ class ComparisonViewer:
         try:
             self.variables.write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten.")
+            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
 
 
     def _show_label_button_handler(self, change):
@@ -596,7 +596,7 @@ class ComparisonViewer:
         try:
             self.generate_table().write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten.")
+            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')
@@ -728,7 +728,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._field_name.value)
             except OSError:
-                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten.")
+                print(f"ERROR: Can't save full field image, likely because existing file ({self._field_name.value}) can not be overwritten, set overwrite_outputs=True to address this.")
 
         if self._zoom_name.value:
             self.tess_field_zoom_view()
@@ -738,7 +738,7 @@ class ComparisonViewer:
             try:
                 self.iw.save(self._zoom_name.value)
             except OSError:
-                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten.")
+                print(f"ERROR: Can't save zoomed image, likely because existing file ({self._zoom_name.value}) can not be overwritten, set overwrite_outputs=True to address this.")
 
     def generate_table(self):
         """

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -7,8 +7,6 @@ import ipywidgets as ipw
 
 import numpy as np
 
-import os
-
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.nddata import CCDData
@@ -718,8 +716,8 @@ class ComparisonViewer:
         if self._field_name.value:
             self.tess_field_view()
             # Remove output file if it exists
-            if os.path.exists(self._field_name.value) and self.overwrite_outputs:
-                os.remove(self._field_name.value)
+            if Path(self._field_name.value).exists() and self.overwrite_outputs:
+                Path(self._field_name.value).unlink()
             try:
                 self.iw.save(self._field_name.value)
             except:
@@ -728,8 +726,8 @@ class ComparisonViewer:
         if self._zoom_name.value:
             self.tess_field_zoom_view()
             # Remove output file if it exists
-            if os.path.exists(self._zoom_name.value) and self.overwrite_outputs:
-                os.remove(self._zoom_name.value)
+            if Path(self._zoom_name.value).exists() and self.overwrite_outputs:
+                Path(self._zoom_name.value).unlink()
             try:
                 self.iw.save(self._zoom_name.value)
             except:

--- a/stellarphot/visualization/comparison_functions.py
+++ b/stellarphot/visualization/comparison_functions.py
@@ -596,7 +596,7 @@ class ComparisonViewer:
         try:
             self.generate_table().write(filename, overwrite=self.overwrite_outputs)
         except OSError:
-            print(f"ERROR: Can't save variables to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
+            print(f"ERROR: Can't save aperatures to file, likely because existing file ({filename}) can not be overwritten, set overwrite_outputs=True to address this.")
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description='Click to show labels')


### PR DESCRIPTION
Apparently the release version of astrowidgets does NOT support overwrite as an option to saving an ImageWidget, I implemented the same functionality via the os package.  I also implemented an implementation-wide parameter to allow overwriting on all output files.

Also fixed an issue where `if v_angle:` was triggering an exception as `ambiguous` (I suspect this was a new behavior added in a recent version of astropy), instead of having v_angle evaluate as true is not empty.  I replaced it with a check of `if len(v_angle):` which evaluates the desired way.

I also went into the code for retrieving GAIA stars and made the server a constant instead of a parameter to be passed in (it is still a public attribute and can be seen).