### PR TITLE
Fixed documentation for calculate_noise and fixed bad terminology

### DIFF
--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -16,7 +16,7 @@ def add_in_quadrature(array):
 def calc_aij_relative_flux(star_data, comp_stars,
                            in_place=True, coord_column=None,
                            star_id_column='star_id',
-                           flux_column_name='aperture_net_flux'):
+                           counts_column_name='aperture_net_counts'):
     """
     Calculate AstroImageJ-style flux ratios.
 
@@ -45,9 +45,9 @@ def calc_aij_relative_flux(star_data, comp_stars,
         If provided, use this column to match comparison stars to coordinates.
         If not provided, the coordinates are generated with SkyCoord.
 
-    flux_column_name : str,  optional
-        If provided, use this column to find flux.
-        If not provided, the column 'aperture_net_flux' is used.
+    counts_column_name : str,  optional
+        If provided, use this column to find counts.
+        If not provided, the column 'aperture_net_counts' is used.
 
     star_id_column : str,  optional
         Name of the column that provides a unique identifier for each
@@ -103,7 +103,7 @@ def calc_aij_relative_flux(star_data, comp_stars,
     # Check whether any of the comp stars have NaN values and,
     # if they do, exclude them from the comp set.
     check_for_nan = Table(data=[star_data[star_id_column].data,
-                                star_data[flux_column_name].data],
+                                star_data[counts_column_name].data],
                           names=['star_id', 'net_counts'])
     check_for_nan = check_for_nan.group_by('star_id')
     check_for_nan['good'] = ~np.isnan(check_for_nan['net_counts'])
@@ -121,7 +121,7 @@ def calc_aij_relative_flux(star_data, comp_stars,
     # Make a small table with just counts, errors and time for all of the comparison
     # stars.
 
-    comp_fluxes = star_data['date-obs', flux_column_name, error_column_name][good]
+    comp_fluxes = star_data['date-obs', counts_column_name, error_column_name][good]
     # print(np.isnan(comp_fluxes[flux_column_name]).sum(),
     #       np.isnan(comp_fluxes[error_column_name]).sum())
     # print(star_data[good][flux_column_name][np.isnan(comp_fluxes[flux_column_name])])
@@ -130,12 +130,12 @@ def calc_aij_relative_flux(star_data, comp_stars,
     # and convert to regular column...eventually
 
     comp_fluxes = comp_fluxes.group_by('date-obs')
-    comp_totals = comp_fluxes.groups.aggregate(np.sum)[flux_column_name]
-    comp_num_stars = comp_fluxes.groups.aggregate(np.count_nonzero)[flux_column_name]
+    comp_totals = comp_fluxes.groups.aggregate(np.sum)[counts_column_name]
+    comp_num_stars = comp_fluxes.groups.aggregate(np.count_nonzero)[counts_column_name]
     comp_errors = comp_fluxes.groups.aggregate(add_in_quadrature)[error_column_name]
 
-    comp_total_vector = np.ones_like(star_data[flux_column_name])
-    comp_error_vector = np.ones_like(star_data[flux_column_name])
+    comp_total_vector = np.ones_like(star_data[counts_column_name])
+    comp_error_vector = np.ones_like(star_data[counts_column_name])
 
     if len(set(comp_num_stars)) > 1:
         raise RuntimeError('Different number of stars in comparison sets')
@@ -144,9 +144,9 @@ def calc_aij_relative_flux(star_data, comp_stars,
 
     # Have to remove the flux of the star if the star is a comparison
     # star.
-    is_comp = np.zeros_like(star_data[flux_column_name])
+    is_comp = np.zeros_like(star_data[counts_column_name])
     is_comp[good] = 1
-    flux_offset = -star_data[flux_column_name] * is_comp
+    flux_offset = -star_data[counts_column_name] * is_comp
 
     # This seems a little hacky; there must be a better way
     for date_obs, comp_total, comp_error in zip(comp_fluxes.groups.keys,
@@ -155,11 +155,11 @@ def calc_aij_relative_flux(star_data, comp_stars,
         comp_total_vector[this_time] *= comp_total
         comp_error_vector[this_time] = comp_error
 
-    relative_flux = star_data[flux_column_name] / (comp_total_vector + flux_offset)
+    relative_flux = star_data[counts_column_name] / (comp_total_vector + flux_offset)
     relative_flux = relative_flux.flatten()
 
-    rel_flux_error = (star_data[flux_column_name] / comp_total_vector *
-                      np.sqrt((star_data[error_column_name] / star_data[flux_column_name])**2 +
+    rel_flux_error = (star_data[counts_column_name] / comp_total_vector *
+                      np.sqrt((star_data[error_column_name] / star_data[counts_column_name])**2 +
                               (comp_error_vector / comp_total_vector)**2
                               )
                      )

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -51,7 +51,7 @@ def _raw_photometry_table():
                             _repeat(star_dec, n_times), _repeat(fluxes, n_times),
                             _repeat(errors, n_times),
                             _repeat(star_ids, n_times)],
-                      names=['date-obs', 'RA', 'Dec', 'aperture_net_flux',
+                      names=['date-obs', 'RA', 'Dec', 'aperture_net_counts',
                              'noise-aij', 'star_id'])
 
     return expected_flux_ratios, expected_flux_error, raw_table, raw_table[1:4]
@@ -111,22 +111,22 @@ def test_bad_comp_star(bad_thing):
         coord_bad_ra = coord_inp.ra + 3 * u.arcsecond
         input_table['RA'][-1] = coord_bad_ra.degree
     elif bad_thing == 'NaN':
-        input_table['aperture_net_flux'][-1] = np.nan
+        input_table['aperture_net_counts'][-1] = np.nan
 
     output_table = calc_aij_relative_flux(input_table, comp_star,
                                           in_place=False)
 
-    old_total_flux = comp_star['aperture_net_flux'].sum()
-    new_flux = old_total_flux - last_one['aperture_net_flux']
+    old_total_flux = comp_star['aperture_net_counts'].sum()
+    new_flux = old_total_flux - last_one['aperture_net_counts']
     # This works for target stars, i.e. those never in comparison set
     new_expected_flux = old_total_flux / new_flux * expected_flux
 
     # Oh wow, this is terrible....
     # Need to manually calculate for the only two that are still in comparison
-    new_expected_flux[1] = (comp_star['aperture_net_flux'][0] /
-                            comp_star['aperture_net_flux'][1])
-    new_expected_flux[2] = (comp_star['aperture_net_flux'][1] /
-                            comp_star['aperture_net_flux'][0])
+    new_expected_flux[1] = (comp_star['aperture_net_counts'][0] /
+                            comp_star['aperture_net_counts'][1])
+    new_expected_flux[2] = (comp_star['aperture_net_counts'][1] /
+                            comp_star['aperture_net_counts'][0])
 
     new_expected_flux[3] = expected_flux[3]
     if bad_thing == 'NaN':

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -392,7 +392,7 @@ def generate_aij_table(table_name, comparison_table):
     by_source_columns = {
         'xcenter': 'X(IJ)',
         'ycenter': 'Y(IJ)',
-        'aperture_net_flux': 'Source-Sky',
+        'aperture_net_counts': 'Source-Sky',
         'aperture_area': 'N_Src_Pixels',
         'noise-aij': 'Source_Error',
         'snr': 'Source_SNR',

--- a/stellarphot/photometry.py
+++ b/stellarphot/photometry.py
@@ -624,7 +624,7 @@ def calculate_noise(gain=1.0, read_noise=0.0, dark_current_per_sec=0.0,
     ----------
 
     gain : float, optional
-        Gain of the CCD. In units of electrons per DN.
+        Gain of the CCD. In units of electrons per count.
 
     read_noise : float, optional
         Read noise of the CCD in electrons.
@@ -636,7 +636,7 @@ def calculate_noise(gain=1.0, read_noise=0.0, dark_current_per_sec=0.0,
         Counts of the source.
 
     sky_per_pix : float, optional
-        Sky per pixel in counts.
+        Sky per pixel in counts per pixel.
 
     aperture_area : int, optional
         Area of the aperture in pixels.

--- a/stellarphot/tests/test_photometry.py
+++ b/stellarphot/tests/test_photometry.py
@@ -21,7 +21,7 @@ def test_calc_noise_source_only(gain, aperture_area):
     expected = np.sqrt(gain * counts)
 
     np.testing.assert_allclose(calculate_noise(gain=gain,
-                                               flux=counts,
+                                               counts=counts,
                                                aperture_area=aperture_area),
                                expected)
 
@@ -103,7 +103,7 @@ def test_calc_noise_messy_case(digit, expected):
     read_noise = 12
 
     np.testing.assert_allclose(
-        calculate_noise(flux=counts,
+        calculate_noise(counts=counts,
                         gain=gain,
                         dark_current_per_sec=dark_current,
                         read_noise=read_noise,


### PR DESCRIPTION
I fixed the documentation to make it clear `calculate_noise` is producing noise in electrons and updated variables with references to flux that were really counts with new names.