### PR TITLE
Fixing non-NaNable ccd images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Other Changes and Additions
 + Major reorganizaiton of code including moving functions to new modules. [#130, #133]
 + Now requires python 3.10 or later. [#147]
 + Use pydantic for aperture settings. [#154]
++ Stomped bug in handling of ``NaN``s in ``single_image_photometry``. [#157]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ New Features
 ^^^^^^^^^^^^
 + Development of new data classes for handling source list, photometry, and catalog data which include data format validation. [#125]
 + Aperture photometry streamlined into ``single_image_photometry``  ``multi_image_photometry`` functions that use the new data classes. [#141]
++ Photometry related notebooks updated to use new data classes. [#151]
 + ``multi_image_photometry`` now is a wrapper for single_image_photometry instead of a completely separate function.
++ Logging has been implemented for photmetry, so all the output can now be logged to a file. [#150]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -250,9 +250,7 @@ def single_image_photometry(ccd_image, sourcelist, camera, observatory_location,
         return None, None
 
     # Set high pixels to NaN (make sure ccd_image.data is a float array first)
-    if ccd_image.data.dtype != float:
-        ccd_image.data = ccd_image.data.astype(float)
-    ccd_image.data[ccd_image.data > max_adu] = np.nan
+    ccd_image.data[ccd_image.data.astype(float) > max_adu] = np.nan
 
     # Extract necessary values from sourcelist structure
     star_ids = sourcelist['star_id'].value

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -250,7 +250,8 @@ def single_image_photometry(ccd_image, sourcelist, camera, observatory_location,
         return None, None
 
     # Set high pixels to NaN (make sure ccd_image.data is a float array first)
-    ccd_image.data[ccd_image.data.astype(float) > max_adu] = np.nan
+    ccd_image.data = ccd_image.data.astype(float)
+    ccd_image.data[ccd_image.data > max_adu] = np.nan
 
     # Extract necessary values from sourcelist structure
     star_ids = sourcelist['star_id'].value

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -250,8 +250,8 @@ def single_image_photometry(ccd_image, sourcelist, camera, observatory_location,
         return None, None
 
     # Set high pixels to NaN (make sure ccd_image.data is a float array first)
-    if ccd_image.data.dtype != np.float:
-        ccd_image.data = ccd_image.data.astype(np.float)
+    if ccd_image.data.dtype != float:
+        ccd_image.data = ccd_image.data.astype(float)
     ccd_image.data[ccd_image.data > max_adu] = np.nan
 
     # Extract necessary values from sourcelist structure

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -249,7 +249,9 @@ def single_image_photometry(ccd_image, sourcelist, camera, observatory_location,
                "SKIPPING THIS IMAGE!")
         return None, None
 
-    # Set high pixels to NaN
+    # Set high pixels to NaN (make sure ccd_image.data is a float array first)
+    if ccd_image.data.dtype != np.float:
+        ccd_image.data = ccd_image.data.astype(np.float)
     ccd_image.data[ccd_image.data > max_adu] = np.nan
 
     # Extract necessary values from sourcelist structure


### PR DESCRIPTION
I implemented a fix for the ccddata not being NaN-able by converting it to float if needed.  Can you check that your image will now process.

I also updated the CHANGES.rst file to cover recent changes.

Fixes #157