### PR TITLE
Added a pydantic-validated Camera class and test.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@
 New Features
 ^^^^^^^^^^^^
 + Development of new data classes for handling source list, photometry, and catalog data which include data format validation. [#125]
-+ Aperture photometry streamlined into ``single_image_photometry``  ``multi_image_photometry`` functions that use the new data classes. [#141]
-+ Photometry related notebooks updated to use new data classes. [#151]
++ Aperture photometry streamlined into ``single_image_photometry`` and ``multi_image_photometry`` functions that use the new data classes. [#141]
 + ``multi_image_photometry`` now is a wrapper for single_image_photometry instead of a completely separate function.
-+ Logging has been implemented for photmetry, so all the output can now be logged to a file. [#150]
++ Photometry related notebooks updated to use new data classes and new functions. [#151]
++ Logging has been implemented for photometry, so all the output can now be logged to a file. [#150]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -134,7 +134,7 @@ class Camera(BaseModel):
         try:
             rn_unit = Quantity(values['read_noise']).unit
         except KeyError:
-            raise ValueError("Valid keys for values are: ", values.keys())
+            raise ValueError("read_noise must be specified including units.")
 
         # Check that gain and read noise have compatible units, that is that
         # gain is read noise per adu.

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -131,6 +131,7 @@ class Camera(BaseModel):
     # When the switch to pydantic v2 happens, this root_validator will need
     # to be replaced by a model_validator decorator.
     @root_validator(skip_on_failure=True)
+    @classmethod
     def validate_gain(cls, values):
         # Get read noise units
         rn_unit = Quantity(values['read_noise']).unit

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -32,26 +32,42 @@ def test_camera_unitscheck():
     dark_current = 0.01 * u.electron / u.second
     pixel_scale = 0.563 * u.arcsec / u.pix
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         c = Camera(gain=gain.value,
                 read_noise=read_noise,
                 dark_current=dark_current,
                 pixel_scale=pixel_scale)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         c = Camera(gain=gain,
                 read_noise=read_noise.value,
                 dark_current=dark_current,
                 pixel_scale=pixel_scale)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         c = Camera(gain=gain,
                 read_noise=read_noise,
                 dark_current=dark_current.value,
                 pixel_scale=pixel_scale)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         c = Camera(gain=gain,
                 read_noise=read_noise,
                 dark_current=dark_current,
                 pixel_scale=pixel_scale.value)
+
+
+def test_camera_altunitscheck():
+    # Check to see that 'count' is allowed instead of 'electron'
+    gain = 2.0 * u.count / u.adu
+    read_noise = 10 * u.count
+    dark_current = 0.01 * u.count / u.second
+    pixel_scale = 0.563 * u.arcsec / u.pix
+    c = Camera(gain=gain,
+               read_noise=read_noise,
+               dark_current=dark_current,
+               pixel_scale=pixel_scale)
+    assert c.gain == gain
+    assert c.dark_current == dark_current
+    assert c.read_noise == read_noise
+    assert c.pixel_scale == pixel_scale
 
 
 # Create several test descriptions for use in base_enhanced_table tests.

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 from astropy.io import ascii
 from astropy.coordinates import EarthLocation
 from astropy.utils.data import get_pkg_data_filename
-
+from pydantic import ValidationError
 from stellarphot.core import (Camera, BaseEnhancedTable, PhotometryData,
                               CatalogData, SourceListData)
 
@@ -32,22 +32,22 @@ def test_camera_unitscheck():
     dark_current = 0.01 * u.electron / u.second
     pixel_scale = 0.563 * u.arcsec / u.pix
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError,  match="gain"):
         c = Camera(gain=gain.value,
                 read_noise=read_noise,
                 dark_current=dark_current,
                 pixel_scale=pixel_scale)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError,  match="read_noise"):
         c = Camera(gain=gain,
                 read_noise=read_noise.value,
                 dark_current=dark_current,
                 pixel_scale=pixel_scale)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError,  match="dark_current"):
         c = Camera(gain=gain,
                 read_noise=read_noise,
                 dark_current=dark_current.value,
                 pixel_scale=pixel_scale)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError,  match="pixel_scale"):
         c = Camera(gain=gain,
                 read_noise=read_noise,
                 dark_current=dark_current,


### PR DESCRIPTION
I have added a pydantic (v1) validated Camera class.  I also had to modify previous units checks (we now through `ValueError` instead of `TypeError`) and added a new check to see that any 'count' (e.g. count or electron or whatever) is acceptable as long as the units of read_noise, gain, and dark_current are consistent.  

I also confirmed we can json serialize the Camera object, so we can dump its value to disk and should be able to deserialize it easily enough.