### PR TITLE
Replace photometry settings widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ New Features
 + ``multi_image_photometry`` now is a wrapper for single_image_photometry instead of a completely separate function.
 + Photometry related notebooks updated to use new data classes and new functions. [#151]
 + Logging has been implemented for photometry, so all the output can now be logged to a file. [#150]
-+ Add class to hold the file lcoations needed for the photometry notebook. [#168]
++ Add class to hold the file locations needed for the photometry notebook. [#168]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ New Features
 + ``multi_image_photometry`` now is a wrapper for single_image_photometry instead of a completely separate function.
 + Photometry related notebooks updated to use new data classes and new functions. [#151]
 + Logging has been implemented for photometry, so all the output can now be logged to a file. [#150]
++ Add class to hold the file lcoations needed for the photometry notebook. [#168]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/stellarphot/notebooks/photometry/03-photometry-template.ipynb
+++ b/stellarphot/notebooks/photometry/03-photometry-template.ipynb
@@ -10,8 +10,6 @@
     "\n",
     "import numpy as np\n",
     "\n",
-    "from ipyfilechooser import FileChooser\n",
-    "\n",
     "import astropy.units as u\n",
     "from astropy.nddata import CCDData\n",
     "from astropy.coordinates import SkyCoord, EarthLocation\n",
@@ -99,15 +97,6 @@
     "\n",
     "# Retrieve the object name here\n",
     "object_name = ps.object_name"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "aperture_settings.inner_annulus"
    ]
   },
   {
@@ -207,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -1,12 +1,16 @@
 # Objects that contains the user settings for the program.
 
 from enum import Enum
+from pathlib import Path
 
 from pydantic import BaseModel, Field, conint, root_validator
 
 from .autowidgets import CustomBoundedIntTex
 
-__all__ = ['ApertureSettings']
+__all__ = [
+    'ApertureSettings',
+    'PhotometryFileSettings'
+]
 
 
 class ApertureSettings(BaseModel):
@@ -63,3 +67,13 @@ class ApertureSettings(BaseModel):
         Radius of the outer annulus in pixels.
         """
         return self.inner_annulus + self.annulus_width
+
+
+class PhotometryFileSettings(BaseModel):
+    """
+    An evolutionary step on the way to having a monolithic set of photometry settings.
+    """
+    image_folder : Path = Field(show_only_dirs=True, default='',
+                                description="Folder containing the calibrated images")
+    aperture_settings_file : Path = Field(filter_pattern='*.json', default='')
+    aperture_locations_file : Path = Field(filter_pattern=['*.ecsv', '*.csv'], default='')


### PR DESCRIPTION
This switches the widget used in the photometry notebook to primarily use a pydantic model/ipyautoui widget generator for the settings. The settings in this case are really just locations of files.

Closes #166 