### PR TITLE
Fix TessTargetFile on windows 

### DIFF
--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -441,7 +441,9 @@ class TessTargetFile:
     def __post_init__(self):
         self.aperture_server = GAIA_APERTURE_SERVER
         if not self.file:
-            self.file = NamedTemporaryFile()
+            # Be sure not to delete the file -- otherwise, one windows,
+            # the file is deleted immediately as far as I can tell.
+            self.file = NamedTemporaryFile(delete=False)
         self._path = Path(self.file.name)
         self.target_file = self._retrieve_target_file()
         self.target_table = self._build_table()

--- a/stellarphot/io/tests/test_tess_submission.py
+++ b/stellarphot/io/tests/test_tess_submission.py
@@ -2,7 +2,8 @@ import re
 
 import pytest
 
-from stellarphot.io.tess import TessSubmission
+from astropy.coordinates import SkyCoord
+from stellarphot.io.tess import TessSubmission, TessTargetFile
 
 GOOD_HEADER = {
     "date-obs": "2022-06-04T05:44:28.010",
@@ -69,3 +70,18 @@ def test_valid_method():
     # Set invalid TIC number
     tsub.tic_id = 10_000_000_000
     assert not tsub._valid()
+
+
+def test_target_file():
+    # Getting the target information failed on windows, so the
+    # first point of this test is to simply succeed in creating the
+    # object
+
+    tic_742648307 = SkyCoord(ra=104.733225, dec=49.968739, unit='degree')
+    tess_target = TessTargetFile(tic_742648307, magnitude=12, depth=10)
+
+    # Check that the first thing in the list is the tick object
+    check_coords = SkyCoord(ra=tess_target.table['RA'][0],
+                            dec=tess_target.table['Dec'][0],
+                            unit=('hour', 'degree'))
+    assert tic_742648307.separation(check_coords).arcsecond < 1


### PR DESCRIPTION
One of the comparison notebook fails on Windows because temporary files are handled somewhat differently there. This PR adds a test to (hopefully) reproduce the problem. Once I'm sure the test is checking what I want I'll push the fix.