### PR TITLE
Fix formatting of columns in AAVSO tables

### DIFF
--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -237,6 +237,18 @@ class AAVSOExtendedFileFormat:
                 value = getattr(self, key.lower())
             table.meta['comments'].append(f"{key}={value}")
 
+        # Specify formats for the columns that have formats
+        for k, v in table_structure['data'].items():
+            length_limit = v.get('limit', None)
+            if length_limit:
+                if v['type'] == 'float':
+                    table[k].info.format = f"{length_limit}f"
+                elif v['type'] == 'str':
+                    if k == 'STARID':
+                        print(table[k])
+                    table[k].info.format = f".{length_limit}s"
+                else:
+                    raise ValueError(f"Unknown type {v['type']}")
         return table
 
     def write(self, filename, overwrite=False):

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -242,8 +242,25 @@ class AAVSOExtendedFileFormat:
             length_limit = v.get('limit', None)
             if length_limit:
                 if v['type'] == 'float':
-                    table[k].info.format = f"{length_limit}f"
+                    # For float, the width in the format specifier is the _minimum_
+                    # width of the field, not the maximum. Since, most of the time,
+                    # any width issues will arise because some rounding is needed,
+                    # use the width to calculate the place to which to round the
+                    # number, EXCEPT in the case of time. There, use all the digits and
+                    # hope for the best.
+                    if k != 'DATE':
+                        max_precision = length_limit - 3
+                        precision = min(max_precision, 6)
+                    else:
+                        precision = 8
+
+                    # Check whether table column is all "na" -- if that is the case, don't
+                    # set a format.
+                    if not all(table[k] == "na"):
+                        table[k].info.format = f"{length_limit}.{precision}f"
                 elif v['type'] == 'str':
+                    # For a string, the "precision" in the format is the maximum
+                    # size of the field.
                     if k == 'STARID':
                         print(table[k])
                     table[k].info.format = f".{length_limit}s"

--- a/stellarphot/io/aavso_submission_schema.yml
+++ b/stellarphot/io/aavso_submission_schema.yml
@@ -13,7 +13,7 @@ comments:
       Name and version of software used to create the format. If it is
       private software, put some type of description here.
       For example: "#SOFTWARE=AIP4Win Version 2.2".
-      Limit: 255 characters.
+    limit: 255
   DELIM:
     summary: |
       The delimiter used to separate fields in the report. Any ASCII character
@@ -54,19 +54,21 @@ data:
     summary: |
       The star's identifier. It can be the AAVSO Designation, the AAVSO Name, or
       the AAVSO Unique Identifier, but NOT more than one of these.
-      Limit: 30 characters.
+    limit: 30
   DATE:
     summary: |
       The date of the observation, in the format specified in the DATE parameter.
-      Limit: 16 characters.
+    limit: 16
   MAGNITUDE:
     summary: |
       The magnitude of the observation. Prepend with < if a fainter-than.
-      A dot is required (e.g. "9.0" rather than "9"). Limit: 8 characters.
+      A dot is required (e.g. "9.0" rather than "9"). 
+    limit: 8
   MAGERR:
     summary: |
       Photometric uncertainty associated with the variable star magnitude.
-      If not available put "na". Limit: 6 characters.
+      If not available put "na".
+    limit: 6
   FILTER:
     summary: |
       The filter used for the observation.
@@ -177,28 +179,31 @@ data:
       Comparison star name or label such as the AUID (much preferred)
       or the chart label for the comparison star used.
       Use "ENSEMBLE" for ensemble photometry.
-      If not present, use "na". Limit: 20 characters.
+      If not present, use "na". 
+    limit: 20
   CMAG:
     summary: |
       Instrumental magnitude of the comparison star.
       If "ensemble" see example below. If not present,
-      use "na". Limit: 8 characters.
+      use "na".
+    limit: 8
   KNAME:
     summary: |
       Check star name or label such as the AUID (much preferred)
       or the chart label for the check star. If not present,
       use "na".
-      Limit: 20 characters.
+    limit: 20
   KMAG:
     summary: |
       Instrumental magnitude of the check star, unless doing "ensemble" photometry
       in which case the calibrated magnitude should be reported.
       If "ensemble" see example below. If not present, use "na".
-      Limit: 8 characters.
+    limit: 8
   AIRMASS:
     summary: |
       Airmass of observation Limit 7 characters - entry will be truncated
-      if longer than that. If not present, use "na".
+      if longer than that. If not present, use "na".\
+    limit: 7
   GROUP:
     summary: |
       Grouping identifier (maximum 5 characters). It is used
@@ -210,7 +215,8 @@ data:
       for multiple stars, etc., just set GROUP to "na." For cases where you
       want to group observations, GROUP should be an integer, identical for
       all observations in a group, and unique for a given observer for a
-      given star on a given Julian Date. Limit: 5 characters.
+      given star on a given Julian Date. 
+    limit: 5
   CHART:
     summary: |
       Please use the sequence ID you will find written in Bold print
@@ -221,7 +227,8 @@ data:
       do not give a chart ID, even if you plotted the chart using VSP.
       Use the comment code K (non-AAVSO chart) and give a proper
       chart name like "APASS DR10". Then add information on the comp
-      stars in the notes. Limit: 20 characters.
+      stars in the notes. 
+    limit: 20
   NOTES:
     summary: |
       Comments or notes about the observation. If no comments, use "na".

--- a/stellarphot/io/aavso_submission_schema.yml
+++ b/stellarphot/io/aavso_submission_schema.yml
@@ -55,20 +55,24 @@ data:
       The star's identifier. It can be the AAVSO Designation, the AAVSO Name, or
       the AAVSO Unique Identifier, but NOT more than one of these.
     limit: 30
+    type: str
   DATE:
     summary: |
       The date of the observation, in the format specified in the DATE parameter.
     limit: 16
+    type: float
   MAGNITUDE:
     summary: |
       The magnitude of the observation. Prepend with < if a fainter-than.
-      A dot is required (e.g. "9.0" rather than "9"). 
+      A dot is required (e.g. "9.0" rather than "9").
     limit: 8
+    type: float
   MAGERR:
     summary: |
       Photometric uncertainty associated with the variable star magnitude.
       If not available put "na".
     limit: 6
+    type: float
   FILTER:
     summary: |
       The filter used for the observation.
@@ -179,31 +183,36 @@ data:
       Comparison star name or label such as the AUID (much preferred)
       or the chart label for the comparison star used.
       Use "ENSEMBLE" for ensemble photometry.
-      If not present, use "na". 
+      If not present, use "na".
     limit: 20
+    type: str
   CMAG:
     summary: |
       Instrumental magnitude of the comparison star.
       If "ensemble" see example below. If not present,
       use "na".
     limit: 8
+    type: float
   KNAME:
     summary: |
       Check star name or label such as the AUID (much preferred)
       or the chart label for the check star. If not present,
       use "na".
     limit: 20
+    type: str
   KMAG:
     summary: |
       Instrumental magnitude of the check star, unless doing "ensemble" photometry
       in which case the calibrated magnitude should be reported.
       If "ensemble" see example below. If not present, use "na".
     limit: 8
+    type: float
   AIRMASS:
     summary: |
       Airmass of observation Limit 7 characters - entry will be truncated
       if longer than that. If not present, use "na".\
     limit: 7
+    type: float
   GROUP:
     summary: |
       Grouping identifier (maximum 5 characters). It is used
@@ -215,8 +224,9 @@ data:
       for multiple stars, etc., just set GROUP to "na." For cases where you
       want to group observations, GROUP should be an integer, identical for
       all observations in a group, and unique for a given observer for a
-      given star on a given Julian Date. 
+      given star on a given Julian Date.
     limit: 5
+    type: str
   CHART:
     summary: |
       Please use the sequence ID you will find written in Bold print
@@ -227,8 +237,9 @@ data:
       do not give a chart ID, even if you plotted the chart using VSP.
       Use the comment code K (non-AAVSO chart) and give a proper
       chart name like "APASS DR10". Then add information on the comp
-      stars in the notes. 
+      stars in the notes.
     limit: 20
+    type: str
   NOTES:
     summary: |
       Comments or notes about the observation. If no comments, use "na".

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -86,8 +86,10 @@ def test_making_table_ensemble():
                               star_id=26)
 
 
-def test_table_column_formats(tmp_path):
+@pytest.mark.parametrize("ensemble", [True, False])
+def test_table_column_formats(tmp_path, ensemble):
     aef, input_data = set_up_aef()
+    aef.ensemble = ensemble
     aef_table = aef.to_table()
     aef_table.write(tmp_path / "test.csv")
     with open(tmp_path / "test.csv") as f:

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -23,7 +23,7 @@ def test_default_values():
 
 def test_setting_type_raises_error():
     aef = AAVSOExtendedFileFormat(DEFAULT_OBSCODE)
-    with pytest.raises(AttributeError, match="no setter"):
+    with pytest.raises(AttributeError, match="(no setter)|(can't set attribute)"):
         aef.type = 'STD'
 
 


### PR DESCRIPTION
The AAVSO Extended File Format has limits on the number of characters in some columns that effectively require rounding floating point values. This PR tries to ensure that the CSV file generated respects those limits.