### PR TITLE
Fix all warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,4 +139,12 @@ log_cli_level = "info"
 xfail_strict = true
 filterwarnings = [
     "error",
+    # Apparently bqplot is using deprecated traitlets APIs
+    'ignore:\s+Sentinel is not a public part of the traitlets API:DeprecationWarning',
+    # ginga is using something from asdf that has been deprecated
+    'ignore:AsdfInFits has been deprecated:DeprecationWarning',
+    # ipyautoui generates this warning...
+    'ignore:metadata \{.+\} was set from the constructor:DeprecationWarning',
+    # Generated from batman
+    'ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,6 @@ addopts = [
 ]
 log_cli_level = "info"
 xfail_strict = true
+filterwarnings = [
+    "error",
+]

--- a/stellarphot/__init__.py
+++ b/stellarphot/__init__.py
@@ -6,26 +6,4 @@
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 
-# Enforce Python version check during package import.
-# This is the same check as the one at the top of setup.py
-import sys
-from distutils.version import LooseVersion
-
-__minimum_python_version__ = "3.10"
-
-__all__ = []
-
-
-class UnsupportedPythonError(Exception):
-    """
-    Wraps an exception to raise if a user tries to use stellarphot
-    with an unsupported version of Python.
-    """
-    pass
-
-
-if LooseVersion(sys.version) < LooseVersion(__minimum_python_version__):
-    raise UnsupportedPythonError("stellarphot does not support Python < {}"
-                                 .format(__minimum_python_version__))
-
 from .core import *

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -108,9 +108,10 @@ def test_bad_comp_star(bad_thing):
 
     if bad_thing == 'RA':
         # "Jiggle" one of the stars by moving it by a few arcsec in one image.
-        coord_inp = SkyCoord(ra=last_one['ra'], dec=last_one['dec'],
+        coord_inp = SkyCoord(ra=last_one['ra'][0], dec=last_one['dec'][0],
                              unit=u.degree)
         coord_bad_ra = coord_inp.ra + 3 * u.arcsecond
+        print(len(last_one), coord_inp)
         input_table['ra'][-1] = coord_bad_ra.degree
     elif bad_thing == 'NaN':
         input_table['aperture_net_cnts'][-1] = np.nan

--- a/stellarphot/differential_photometry/tests/test_vsx_mags.py
+++ b/stellarphot/differential_photometry/tests/test_vsx_mags.py
@@ -30,7 +30,9 @@ def test_multi_vmag():
 
     vmag, error = calc_vmag(var_stars, star_data, comp_stars, band='Rc', star_data_mag_column='mag_inst_R')
     del var_stars['coords']
-    v_data = vstack([var_stars, var_stars])
+
+    # We really don't care about the metadata here, so silently accept one
+    v_data = vstack([var_stars, var_stars], metadata_conflicts='silent')
     v_data['coords'] = SkyCoord(ra=v_data['RAJ2000'],
                                 dec=v_data['DEJ2000'], unit='degree')
     v_table = calc_multi_vmag(v_data, star_data, comp_stars, band='Rc', star_data_mag_column='mag_inst_R')

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -609,7 +609,7 @@ def multi_image_photometry(directory_with_images,
     reject_unmatched : bool, optional (Default: True)
         If ``True``, any sources that are not detected on all the images are
         rejected.  If you are interested in a source that can intermittently
-        fall below your detection limits, we suggest setting this to ``False`` 
+        fall below your detection limits, we suggest setting this to ``False``
         so that all sources detected on each image are reported.
 
     include_dig_noise : bool, optional (Default: True)
@@ -973,7 +973,7 @@ def calculate_noise(camera=None, counts=0.0, sky_per_pix=0.0,
 
         \\sigma = \\sqrt{G \\cdot N_C + A \\cdot \\left(1 + \\frac{A}{B}\\right)\\cdot \\left[ G\\cdot S + D \\cdot t + R^2 + (0.289 G)^2\\right]}
 
-    where :math:`\sigma` is the noise, :math:`G` is the gain,
+    where :math:`\\sigma` is the noise, :math:`G` is the gain,
     :math:`N_C` is the source counts (which is photon/electron counts divided by gain),
     :math:`A` is the aperture area in pixels,
     :math:`B` is the annulus area in pixels,
@@ -1053,4 +1053,3 @@ def calculate_noise(camera=None, counts=0.0, sky_per_pix=0.0,
         digitization = area_ratio * (gain * 0.289) ** 2
 
     return np.sqrt(poisson_source + sky + dark + rn_error + digitization)
-

--- a/stellarphot/photometry/tests/test_detection.py
+++ b/stellarphot/photometry/tests/test_detection.py
@@ -46,7 +46,7 @@ def test_compute_fwhm_with_NaNs():
 
     # Add a NaN to the image at the location of the first source. Note the
     # usual row/column swap when going to x/y coordinates.
-    print(x, y)
+    image[y, x] = np.nan
 
     # We expect a warning about NaNs in the image, so catch it
     with warnings.catch_warnings():

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -16,6 +16,9 @@ from stellarphot.photometry import (calculate_noise, find_too_close,
 from stellarphot.settings import ApertureSettings
 
 GAINS = [1.0, 1.5, 2.0]
+# Make sure the tests are deterministic by using a random seed
+SEED = 5432985
+
 
 def test_calc_noise_defaults():
     # If we put in nothing we should get an error about is missing camera
@@ -224,7 +227,7 @@ coords2use='pixel'
 # The True case below is a regression test for #157
 @pytest.mark.parametrize('int_data', [True, False])
 def test_aperture_photometry_no_outlier_rejection(int_data):
-    fake_CCDimage = FakeCCDImage()
+    fake_CCDimage = FakeCCDImage(seed=SEED)
 
     sources = fake_CCDimage.sources
     aperture = sources['aperture'][0]
@@ -293,7 +296,7 @@ def test_aperture_photometry_with_outlier_rejection(reject):
     the photometry is correct when outliers are rejected and is
     incorrect when outliers are not rejected.
     """
-    fake_CCDimage = FakeCCDImage()
+    fake_CCDimage = FakeCCDImage(seed=SEED)
     sources = fake_CCDimage.sources
     aperture = sources['aperture'][0]
     inner_annulus = 2 * aperture
@@ -305,6 +308,8 @@ def test_aperture_photometry_with_outlier_rejection(reject):
 
     image = fake_CCDimage.data
 
+    print(f'{fake_CCDimage=}')
+    print(f"{sources['x_stddev'].mean()}")
     found_sources = source_detection(fake_CCDimage,
                                     fwhm=sources['x_stddev'].mean(),
                                     threshold=10)
@@ -363,7 +368,7 @@ def test_aperture_photometry_with_outlier_rejection(reject):
 
 def list_of_fakes(num_files):
     # Generate fake CCDData objects for use in photometry_on_directory tests
-    fake_images = [FakeCCDImage()]
+    fake_images = [FakeCCDImage(seed=SEED)]
 
     # Create additional images, each in a different position.
     for i in range(num_files-1):

--- a/stellarphot/utils/tests/test_catalog_search.py
+++ b/stellarphot/utils/tests/test_catalog_search.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -7,6 +9,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.nddata import CCDData
+from astropy.wcs.wcs import FITSFixedWarning
 
 from ..catalog_search import catalog_clean, in_frame, \
                              catalog_search, find_known_variables, \
@@ -136,7 +139,14 @@ def test_catalog_search(clip, data_file):
     data = get_pkg_data_filename(data_file)
     expected = Table.read(data)
     wcs_file = get_pkg_data_filename('data/sample_wcs_ey_uma.fits')
-    wcs = WCS(fits.open(wcs_file)[0].header)
+    with fits.open(wcs_file) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings("ignore",
+                                    message="The WCS transformation has more",
+                                    category=FITSFixedWarning)
+            wcs = WCS(hdulist[0].header)
     wcs.pixel_shape = list(reversed(CCD_SHAPE))
     actual = catalog_search(wcs, CCD_SHAPE, 'B/vsx/vsx',
                             clip_by_frame=clip)
@@ -150,7 +160,14 @@ def test_find_known_variables():
     data = get_pkg_data_filename(data_file)
     expected = Table.read(data)
     wcs_file = get_pkg_data_filename('data/sample_wcs_ey_uma.fits')
-    wcs = WCS(fits.open(wcs_file)[0].header)
+    with fits.open(wcs_file) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings("ignore",
+                                    message="The WCS transformation has more",
+                                    category=FITSFixedWarning)
+            wcs = WCS(hdulist[0].header)
     wcs.pixel_shape = list(reversed(CCD_SHAPE))
     ccd = CCDData(data=np.zeros(CCD_SHAPE), wcs=wcs, unit='adu')
     vsx = find_known_variables(ccd)
@@ -161,7 +178,14 @@ def test_find_known_variables():
 def test_catalog_search_from_wcs_or_coord():
     data_file = 'data/sample_wcs_ey_uma.fits'
     data = get_pkg_data_filename(data_file)
-    wcs = WCS(fits.open(data)[0].header)
+    with fits.open(data) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings("ignore",
+                                    message="The WCS transformation has more",
+                                    category=FITSFixedWarning)
+            wcs = WCS(hdulist[0].header)
     wcs.pixel_shape = (4096, 4096)
     # Try the search using the WCS alone
     vsx_vars = catalog_search(wcs, [4096, 4096], 'B/vsx/vsx',
@@ -182,7 +206,14 @@ def test_catalog_search_with_coord_and_frame_clip_fails():
     # error.
     data_file = 'data/sample_wcs_ey_uma.fits'
     data = get_pkg_data_filename(data_file)
-    wcs = WCS(fits.open(data)[0].header)
+    with fits.open(data) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings("ignore",
+                                    message="The WCS transformation has more",
+                                    category=FITSFixedWarning)
+            wcs = WCS(hdulist[0].header)
     cen_coord = wcs.pixel_to_world(4096 / 2, 4096 / 2)
     with pytest.raises(ValueError) as e:
         _ = catalog_search(cen_coord, [4096, 4096], 'B/vsx/vsx',
@@ -196,7 +227,14 @@ def test_find_apass():
     expected_all = Table.read(get_pkg_data_filename('data/all_apass_ey_uma_sorted_ra_first_20.fits'))
     expected_low_error = Table.read(get_pkg_data_filename('data/low_error_apass_ey_uma_sorted_ra_first_20.fits'))
     wcs_file = get_pkg_data_filename('data/sample_wcs_ey_uma.fits')
-    wcs = WCS(fits.open(wcs_file)[0].header)
+    with fits.open(wcs_file) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings("ignore",
+                                    message="The WCS transformation has more",
+                                    category=FITSFixedWarning)
+            wcs = WCS(hdulist[0].header)
     wcs.pixel_shape = list(reversed(CCD_SHAPE))
     ccd = CCDData(data=np.zeros(CCD_SHAPE), wcs=wcs, unit='adu')
     all_apass, apass_low_error = find_apass_stars(ccd)


### PR DESCRIPTION
This PR:

+ Promotes all warnings in the tests to errors.
+ Fixes a bunch of warnings. In many cases this boils down to catching warnings that we expect to happen.
+ Warnings that are generated by code we don't control are simply filtered out in the `pytest` settings in `pyproject.toml`

