### PR TITLE
Change documentation build to use pyproject.toml and fix minor sphinx issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,33 @@ jobs:
     - name: Run tests
       run: |
         pytest -v stellarphot
+
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip'
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Install stellarphot
+        run: |
+          pip install .
+
+      - name: Install batman
+        run: |
+          pip install batman-package
+
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+
+      - name: Run tests
+        run: |
+          tox -e build_docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,25 +156,6 @@ latex_documents = [('index', project + '.tex', project + u' Documentation',
 man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
-
-# -- Options for the edit_on_github extension ---------------------------------
-
-if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['sphinx_astropy.ext.edit_on_github']
-
-    versionmod = import_module(setup_cfg['name'] + '.version')
-    edit_on_github_project = setup_cfg['github_project']
-    if versionmod.release:
-        edit_on_github_branch = "v" + versionmod.version
-    else:
-        edit_on_github_branch = "master"
-
-    edit_on_github_source_root = ""
-    edit_on_github_doc_root = "docs"
-
-# -- Resolving issue number to links in changelog -----------------------------
-github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
-
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
 #
 # nitpicky = True

--- a/docs/stellarphot/index.rst
+++ b/docs/stellarphot/index.rst
@@ -25,8 +25,8 @@ Reference/API
 .. automodapi:: stellarphot.differential_photometry
 .. automodapi:: stellarphot.gui_tools
 .. automodapi:: stellarphot.io
-.. automodapi:: stellarphot.photometry
-.. automodapi:: stellarphot.source_detection
+.. automodapi:: stellarphot.photometry.photometry
+.. automodapi:: stellarphot.photometry.source_detection
 .. automodapi:: stellarphot.transit_fitting
 .. automodapi:: stellarphot.transit_fitting.gui
 .. automodapi:: stellarphot.transit_fitting.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 docs = [
     "sphinx",
     "sphinx-astropy",
+    "graphviz",
 ]
 exo_fitting = [
     "batman-package",

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -656,15 +656,6 @@ class CatalogData(BaseEnhancedTable):
     dec                   u.deg
     mag                   None
     passband              None
-
-    Attributes
-    ----------
-    catalog_name: str
-        User readable name for the catalog.
-
-    catalog_source: str
-        User readable designation for the source of the catalog (could be a
-        URL or a journal reference).
     """
 
     # Define columns that must be in table and provide information about their type, and

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -166,7 +166,7 @@ def find_center(image, center_guess, cutout_size=30, max_iters=10):
 def radial_profile(data, center, size=30, return_scaled=True):
     """
     Construct a radial profile of a chunk of width ``size`` centered
-    at ``center`` from image ``data`.
+    at ``center`` from image ``data``.
 
     Parameters
     ----------


### PR DESCRIPTION
This should have been done as part #197 but we don't have a documentation build as part of the CI, so it wasn't.

Also adding a documentation build to the CI matrix...
