### PR TITLE
Ruff add pyflakes stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,21 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip'
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Lint with ruff
+        run: |
+          tox -e lint
+
 
   documentation:
     runs-on: ubuntu-latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
-import os
 import sys
 import datetime
 from importlib import import_module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,12 +105,26 @@ include = '\.pyi?$'
 select = [
     # E and W are the checks done by pycodestyle
     "E",
-    "W"
+    "W",
+    # pyflakes checks
+    "F",
+    # flake8-unused-arguments
+    "ARG",
 ]
-
-# Ignore `E402` and `F403` (import violations) in all `__init__.py` files.
 [tool.ruff.lint.per-file-ignores]
+# Ignore `E402` and `F403` (import violations) in all `__init__.py` files.
 "__init__.py" = ["E402", "F403"]
+# Ignore F405 (variable may be from star imports) in docs/conf.py
+"docs/conf.py" = ["F405"]
+
+# Ignore pyflakes and ARGS issues in each subpackage until they are fixed
+"stellarphot/differential_photometry/*" = ["F"]
+"stellarphot/gui_tools/*" = ["F", "ARG"]
+"stellarphot/photometry/*" = ["F"]
+"stellarphot/plotting/*" = ["ARG"]
+"stellarphot/tests/*" = ["F"]
+"stellarphot/transit_fitting/*" = ["ARG"]
+"stellarphot/utils/*" = ["F", "ARG"]
 
 [tool.pytest.ini_options]
 minversion = 7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,10 @@ select = [
     "W"
 ]
 
+# Ignore `E402` and `F403` (import violations) in all `__init__.py` files.
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402", "F403"]
+
 [tool.pytest.ini_options]
 minversion = 7.0
 testpaths = [

--- a/stellarphot/conftest.py
+++ b/stellarphot/conftest.py
@@ -20,7 +20,7 @@ def pytest_configure(config):
     TESTED_VERSIONS[packagename] = version
 
 
-def pytest_unconfigure(config):
+def pytest_unconfigure():
     from astropy.utils.iers import conf as iers_conf
 
     # Undo IERS auto download setting for testing

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -325,7 +325,7 @@ class BaseEnhancedTable(QTable):
                     )
             else:  # Check that columns with no units but are required exist!
                 try:
-                    tempvar = data[this_col]
+                    _ = data[this_col]
                 except KeyError:
                     raise ValueError(
                         f"data['{this_col}'] is missing from input " "data."

--- a/stellarphot/differential_photometry/tests/test_vsx_mags.py
+++ b/stellarphot/differential_photometry/tests/test_vsx_mags.py
@@ -1,6 +1,5 @@
 from astropy.table import Table, vstack
 from astropy.coordinates import SkyCoord
-from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 import numpy as np
 from .. import calc_multi_vmag, calc_vmag

--- a/stellarphot/gui_tools/photometry_widget_functions.py
+++ b/stellarphot/gui_tools/photometry_widget_functions.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from ccdproc import ImageFileCollection
 import ipywidgets as ipw
-from ipyfilechooser import FileChooser
 
 from stellarphot.settings import ApertureSettings, PhotometryFileSettings, ui_generator
 

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import warnings
 
 import numpy as np
 from photutils.centroids import centroid_com

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -1,4 +1,3 @@
-from astropy import units as un
 from pydantic import ValidationError
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     coverage
     build_docs
     pycodestyle
+    lint
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -20,21 +21,25 @@ passenv =
     CFLAGS
 changedir =
     test: .tmp/{envname}
+    lint: .tmp/{envname}
     build_docs: docs
 description =
     test: run tests with pytest
     build_docs: invoke sphinx-build to build the HTML docs
     dev: run tests with astropy dev version
     coverage: run tests with coverage report
+    lint: run lint tests with ruff
 deps =
     numpy200: numpy==2.0.*
     batman: batman-package
 extras =
     test: test
     build_docs: docs
+    lint: test
 commands =
     test: pytest --pyargs {[tox]package_name} {toxinidir}/docs {posargs}
     build_docs: sphinx-build -W -b html . _build/html {posargs}
+    lint: ruff {toxinidir}
 
 
 [testenv:coverage]
@@ -46,9 +51,3 @@ extras =
 commands =
     coverage: pytest --cov={[tox]package_name} --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \
     {posargs}
-
-[testenv:pycodestyle]
-skip_install = true
-description = invoke pycodestyle on package code
-deps = pycodestyle
-commands = pycodestyle {[tox]package_name}

--- a/tox.ini
+++ b/tox.ini
@@ -21,26 +21,21 @@ passenv =
     CFLAGS
 changedir =
     test: .tmp/{envname}
-    lint: .tmp/{envname}
     build_docs: docs
 description =
     test: run tests with pytest
     build_docs: invoke sphinx-build to build the HTML docs
     dev: run tests with astropy dev version
     coverage: run tests with coverage report
-    lint: run lint tests with ruff
 deps =
     numpy200: numpy==2.0.*
     batman: batman-package
 extras =
     test: test
     build_docs: docs
-    lint: test
 commands =
     test: pytest --pyargs {[tox]package_name} {toxinidir}/docs {posargs}
     build_docs: sphinx-build -W -b html . _build/html {posargs}
-    lint: ruff {toxinidir}
-
 
 [testenv:coverage]
 passenv = {[testenv]passenv}
@@ -51,3 +46,9 @@ extras =
 commands =
     coverage: pytest --cov={[tox]package_name} --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \
     {posargs}
+
+[testenv:lint]
+skip_install = true
+description = Run lint checks with ruff
+deps = ruff
+commands = ruff {toxinidir}


### PR DESCRIPTION
This adds pyflakes checks and a flake8 check for unused function/method argument names. The subpackages where this fails are currently excluded, with the intent that they will be fixed one subpackage at a time.

It seems better to do this before release than after release...