### PR TITLE
Add ruff exceptions for some missing args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ MANIFEST
 pip-wheel-metadata
 .pytest_cache
 .tmp
+.ruff_cache
 
 # Sphinx
 docs/api

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -117,7 +117,10 @@ def wrap(imagewidget, outputwidget):
 
     """
 
-    def cb(viewer, event, data_x, data_y):
+    def cb(viewer, event, data_x, data_y):  # noqa: ARG001
+        """
+        The signature of this function must have the four arguments above.
+        """
         i = imagewidget._viewer.get_image()
 
         try:
@@ -365,7 +368,10 @@ class ComparisonViewer:
             self._tess_object_info.layout.visibility = "visible"
             self.targets_from_file = self._target_file_info.table
 
-    def _set_file(self, change):
+    def _set_file(self, change):  # noqa: ARG002
+        """
+        Widget callbacks need to accept a change argument, even if not used.
+        """
         self._set_object()
         self._init()
         self._update_tess_save_names()
@@ -386,7 +392,11 @@ class ComparisonViewer:
         self.tess_save_toggle.observe(self._save_toggle_action, "value")
         self.save_files.on_click(self.save_tess_files)
 
-    def _save_variables_to_file(self, button=None, filename=""):
+    def _save_variables_to_file(self, button=None, filename=""):  # noqa: ARG002
+        """
+        Widget button callbacks need to be able to take an argument. It is called
+        button above the the button will be passed as the first positional argument.
+        """
         if not filename:
             filename = "variables.csv"
         # Export variables as CSV (overwrite existing file if it exists)
@@ -411,7 +421,11 @@ class ComparisonViewer:
             value
         ]
 
-    def _save_aperture_to_file(self, button=None, filename=""):
+    def _save_aperture_to_file(self, button=None, filename=""):  # noqa: ARG002
+        """
+        Widget button callbacks need to be able to take an argument. It is called
+        button above the the button will be passed as the first positional argument.
+        """
         if not filename:
             filename = self.photom_apertures_file
 
@@ -563,7 +577,7 @@ class ComparisonViewer:
 
         return box, iw
 
-    def save_tess_files(self, button=None):
+    def save_tess_files(self, button=None):  # noqa: ARG002
         """
         Save the TESS files.
 

--- a/stellarphot/gui_tools/fits_opener.py
+++ b/stellarphot/gui_tools/fits_opener.py
@@ -49,7 +49,7 @@ class FitsOpener:
         self._header = {}
         self._selected_cache = self._fc.selected
         self.object = ""
-        self.register_callback(lambda x: None)
+        self.register_callback(lambda _: None)
 
     @property
     def file_chooser(self):

--- a/stellarphot/gui_tools/photometry_widget_functions.py
+++ b/stellarphot/gui_tools/photometry_widget_functions.py
@@ -80,7 +80,10 @@ class PhotometrySettings:
         self.ifc = ImageFileCollection(self.file_locations.image_folder)
         self._update_object_list(change)
 
-    def _update_object_list(self, change):
+    def _update_object_list(self, change):  # noqa: ARG002
+        """
+        Widget callbacks need to accept a single argument, even if it is not used.
+        """
         if self.ifc.summary:
             self._object_name.options = sorted(
                 set(self.ifc.summary["object"][~self.ifc.summary["object"].mask])
@@ -88,7 +91,10 @@ class PhotometrySettings:
         else:
             self._object_name.options = []
 
-    def _update_aperture_settings(self, change):
+    def _update_aperture_settings(self, change):  # noqa: ARG002
+        """
+        Widget callbacks need to accept a single argument, even if it is not used.
+        """
         self.aperture_settings = ApertureSettings.parse_file(
             self.file_locations.aperture_settings_file
         )

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -541,7 +541,10 @@ class SeeingProfileWidget:
             planet=self.setting_box.planet_num.value,
         )
 
-    def _set_seeing_profile_name(self, change):
+    def _set_seeing_profile_name(self, change):  # noqa: ARG002
+        """
+        Widget callbacks need to accept a single argument, even if it is not used.
+        """
         self._construct_tess_sub()
         self.seeing_file_name.value = self._tess_sub.seeing_profile
 
@@ -554,7 +557,10 @@ class SeeingProfileWidget:
         else:
             self.setting_box.layout.visibility = "hidden"
 
-    def _save_seeing_plot(self, button):
+    def _save_seeing_plot(self, button):  # noqa: ARG002
+        """
+        Widget button callbacks need to accept a single argument.
+        """
         self._seeing_plot_fig.savefig(self.seeing_file_name.value)
 
     def _change_aperture_save_location(self, change):
@@ -583,7 +589,10 @@ class SeeingProfileWidget:
         self.setting_box.planet_num.observe(self._set_seeing_profile_name)
         self.setting_box.telescope_code.observe(self._set_seeing_profile_name)
 
-    def _save_ap_settings(self, button):
+    def _save_ap_settings(self, button):  # noqa: ARG002
+        """
+        Widget button callbacks need to accept a single argument.
+        """
         with open("aperture_settings.txt", "w") as f:
             f.write(f"{ap_rad},{ap_rad + 10},{ap_rad + 15}")
 
@@ -619,7 +628,12 @@ class SeeingProfileWidget:
         self.aperture_settings.value = value
 
     def _make_show_event(self):
-        def show_event(viewer, event=None, datax=None, datay=None, aperture=None):
+        def show_event(
+            viewer, event=None, datax=None, datay=None, aperture=None
+        ):  # noqa: ARG001
+            """
+            ginga callbacks require the function signature above.
+            """
             profile_size = 60
             default_gap = 5  # pixels
             default_annulus_width = 15  # pixels

--- a/stellarphot/transit_fitting/gui.py
+++ b/stellarphot/transit_fitting/gui.py
@@ -74,7 +74,10 @@ class MyValid(ipw.Button):
         self._set_properties(None)
 
     @observe("value")
-    def _set_properties(self, change):
+    def _set_properties(self, change):  # noqa: ARG002
+        """
+        Widget callbacks need to accept a single argument, even if it is not used.
+        """
         if self.value:
             self.style.button_color = "green"
             self.icon = "check"
@@ -387,7 +390,10 @@ def exotic_settings_widget():
         "known": value_widget["known"][pre_reduced_file],
     }
 
-    def observe_select(change):
+    def observe_select(change):  # noqa: ARG001
+        """
+        Widget callbacks need to accept a single argument, even if it is not used.
+        """
         input_container.children = [
             lookup_link_html[select_planet_type.value],
             hb2[select_planet_type.value],


### PR DESCRIPTION
These are otherwise identified as having unused arguments. While it is the case that they are not used, it is also the case that the signature is dictated by the package doing the callback.