### PR TITLE
Remove redundant function get_cat

### DIFF
--- a/stellarphot/notebooks/photometry/04-transform-pared-back.ipynb
+++ b/stellarphot/notebooks/photometry/04-transform-pared-back.ipynb
@@ -18,7 +18,7 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from stellarphot.utils.magnitude_transforms import get_cat, f, opts_to_str, calc_residual, transform_to_catalog"
+    "from stellarphot.utils.magnitude_transforms import f, opts_to_str, calc_residual, transform_to_catalog"
    ]
   },
   {
@@ -72,7 +72,7 @@
     "our_filters = ['SI']\n",
     "\n",
     "aavso_band_names = dict(\n",
-    "    B='B', \n",
+    "    B='B',\n",
     "    V='V',\n",
     "    gp='SG',\n",
     "    rp='SR',\n",
@@ -90,7 +90,7 @@
     ")\n",
     "\n",
     "cat_filter = dict(\n",
-    "    B='Bmag', \n",
+    "    B='Bmag',\n",
     "    V='Vmag',\n",
     "    gp='g_mag',\n",
     "    rp='r_mag',\n",
@@ -154,16 +154,16 @@
    },
    "outputs": [],
    "source": [
-    "output_table = [] \n",
+    "output_table = []\n",
     "\n",
     "for k, group in zip(our_filters, filter_groups.groups):\n",
     "    print(f'Transforming band {k}')\n",
     "    by_bjd = group.group_by('bjd')\n",
-    "    \n",
-    "    transform_to_catalog(by_bjd, f'mag_inst', aavso_band_names[k], \n",
-    "                     obs_error_column='mag_error', \n",
+    "\n",
+    "    transform_to_catalog(by_bjd, f'mag_inst', aavso_band_names[k],\n",
+    "                     obs_error_column='mag_error',\n",
     "                     zero_point_range=[12, 25],\n",
-    "                     c_delta=0.5, # b_delta=0.1, \n",
+    "                     c_delta=0.5, # b_delta=0.1,\n",
     "                     cat_filter=cat_filter[k], cat_color=cat_color_colums[k],\n",
     "                     in_place=True);\n",
     "    output_table.append(by_bjd.copy())\n",


### PR DESCRIPTION
Closes #96 by replacing `get_cat` with a call to `apass_dr9`.