### PR TITLE
Rewrite seeing profile radial profile calculation

### DIFF
--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 from stellarphot.io import TessSubmission
 from stellarphot.gui_tools.fits_opener import FitsOpener
 from stellarphot.photometry import CenterAndProfile
+from stellarphot.photometry.photometry import EXPOSURE_KEYWORDS
 from stellarphot.plotting import seeing_plot
 from stellarphot.settings import ApertureSettings, ui_generator
 
@@ -238,7 +239,16 @@ class SeeingProfileWidget:
         """
         self.fits_file.load_in_image_widget(self.iw)
         self.object_name = self.fits_file.object
-        self.exposure = self.fits_file.header["EXPOSURE"]
+        for key in EXPOSURE_KEYWORDS:
+            if key in self.fits_file.header:
+                self.exposure = self.fits_file.header[key]
+                break
+        else:
+            warnings.warn(
+                "No exposure time keyword found in FITS header. "
+                "Setting exposure to NaN"
+            )
+            self.exposure = np.nan
 
     def _update_file(self, change):
         self.load_fits(change.selected)

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -2,16 +2,10 @@ from pathlib import Path
 import warnings
 
 import numpy as np
-from photutils.centroids import centroid_com, centroid_quadratic, centroid_2dg
-from photutils.profiles import RadialProfile, CurveOfGrowth
 import ipywidgets as ipw
 
 from astropy.io import fits
-from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
-from astropy.nddata import Cutout2D
-from astropy.nddata.utils import NoOverlapError
-from astropy.utils import lazyproperty
 
 try:
     from astrowidgets import ImageWidget
@@ -22,15 +16,12 @@ import matplotlib.pyplot as plt
 
 from stellarphot.io import TessSubmission
 from stellarphot.gui_tools.fits_opener import FitsOpener
-from stellarphot.photometry import calculate_noise
+from stellarphot.photometry import CenterAndProfile
 from stellarphot.plotting import seeing_plot
 from stellarphot.settings import ApertureSettings, ui_generator
 
 __all__ = [
     "set_keybindings",
-    "find_center",
-    "CenterAndProfile",
-    "box",
     "SeeingProfileWidget",
 ]
 
@@ -95,277 +86,6 @@ def set_keybindings(image_widget, scroll_zoom=False):
     bind_map.map_event(None, (), "kp_right", "pan_left")
     bind_map.map_event(None, (), "kp_up", "pan_down")
     bind_map.map_event(None, (), "kp_down", "pan_up")
-
-
-# TODO: Can this be replaced by a properly masked call to centroid_com?
-def find_center(image, center_guess, cutout_size=30, max_iters=10, match_limit=3):
-    """
-    Find the centroid of a star from an initial guess of its position. Originally
-    written to find star from a mouse click.
-
-    Parameters
-    ----------
-
-    image : `astropy.nddata.CCDData` or numpy array
-        Image containing the star.
-
-    center_guess : array or tuple
-        The position, in pixels, of the initial guess for the position of
-        the star. The coordinates should be horizontal first, then vertical,
-        i.e. opposite the usual Python convention for a numpy array.
-
-    cutout_size : int, optional
-        The default width of the cutout to use for finding the star.
-
-    max_iters : int, optional
-        Maximum number of iterations to go through in finding the center.
-
-    match_limit : int, optional
-        Maximum number of pixels to allow the COM centroid and Gaussian center to
-        differ.
-
-    Returns
-    -------
-
-    cen : array
-        The position of the star, in pixels, as found by the centroiding
-        algorithm.
-    """
-    pad = cutout_size // 2
-    x, y = center_guess
-
-    # Keep track of iterations
-    cnt = 0
-
-    # Grab the cutout...
-    sub_data = Cutout2D(image, center_guess, (cutout_size, cutout_size), mode="trim")
-    # ...do stats on it...
-    _, sub_med, _ = sigma_clipped_stats(sub_data.data)
-    # ...and centroid.
-    mask = (sub_data.data - sub_med) < 0
-    x_cm, y_cm = centroid_com(sub_data.data - sub_med, mask=mask)
-
-    # Translate centroid back to original image (maybe use Cutout2D instead)
-    cen = np.array(sub_data.to_original_position((x_cm, y_cm)))
-    print(f"{cen=} {x_cm=} {y_cm=}")
-    # ceno is the "original" center guess, set it to something nonsensical here
-    ceno = np.array([-100, -100])
-
-    while cnt <= max_iters and (
-        np.abs(np.array([x_cm, y_cm]) - pad).max() > 3 or np.abs(cen - ceno).max() > 0.1
-    ):
-        try:
-            sub_data = Cutout2D(image, cen, (cutout_size, cutout_size), mode="trim")
-        except NoOverlapError:
-            raise RuntimeError(
-                f"Centroid finding failed, previous was {ceno}, current is {cen}"
-            )
-        _, sub_med, _ = sigma_clipped_stats(sub_data.data)
-
-        mask = (sub_data.data - sub_med) < 0
-        x_cm, y_cm = centroid_com(sub_data.data - sub_med, mask=mask)
-        ceno = cen
-        cen = np.array(sub_data.to_original_position((x_cm, y_cm)))
-        if not np.all(~np.isnan(cen)):
-            raise RuntimeError(
-                f"Centroid finding failed, previous was {ceno}, current is {cen}"
-            )
-        cnt += 1
-
-    # Is we hit the max number of iterations, raise an error
-    if max_iters > 1 and cnt > max_iters:
-        raise RuntimeError(f"Centroid finding did not converge")
-
-    # Get the final centroid position by fitting a gaussian
-    # We may not have converged on a star, so capture any warning about a
-    # bad fit.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        ceng = centroid_2dg(sub_data.data - sub_med)
-    ceng = np.array(sub_data.to_original_position(ceng))
-
-    # Confirm that we actually found a star by comparing the two centroiding
-    # methods
-    if np.linalg.norm(cen - ceng) > match_limit:
-        raise RuntimeError(
-            "Centroid did not converge on a star. "
-            f"Got {cen} from centroid_com and {ceng} from centroid_2dg."
-        )
-
-    return ceng
-
-
-class CenterAndProfile:
-    """
-    Class to dentermine center of and hold radial profile information for a star.
-
-    Parameters
-    ----------
-    data : `astropy.nddata.CCDData` or numpy array
-        Image data
-
-    center_approx : list-like
-        x, y position of the center in pixel coordinates, i.e. horizontal
-        coordinate then vertical.
-
-    cutout_size : int, optional
-        Width of the rectangular image cutout to use in looking for a star.
-
-    profile_radius : int, optional
-        Maximum radius to use in constructing the profile.
-    """
-
-    def __init__(self, data, center_approx, cutout_size=30, profile_radius=None):
-        self._cen = find_center(data, center_approx, cutout_size=cutout_size)
-        self._data = data
-        self._cutout = Cutout2D(data, self._cen, (cutout_size, cutout_size))
-        if profile_radius is None:
-            profile_radius = cutout_size // 2
-
-        radii = np.linspace(0, profile_radius, profile_radius + 1)
-        # Get a rough profile without background subtraction
-        self._radial_profile = RadialProfile(self._data, self._cen, radii)
-
-        self._sky_area = None
-
-        # Do proper background subtraction for the final radial profile
-        self._radial_profile = RadialProfile(
-            data - self.sky_pixel_value, self._cen, radii
-        )
-
-    @property
-    def center(self):
-        """
-        x, y position of the center of the star.
-        """
-        return self._cen
-
-    @property
-    def FWHM(self):
-        """
-        Full-width half-max of the radial profile.
-        """
-        return self.radial_profile.gaussian_fwhm
-
-    @property
-    def HWHM(self):
-        """
-        Half-width half-max of the radial profile.
-        """
-        return self.FWHM / 2
-
-    @property
-    def cutout(self):
-        """
-        Cutout image around the star.
-        """
-        return self._cutout
-
-    @property
-    def radial_profile(self):
-        """
-        Radial profile of the star.
-        """
-        return self._radial_profile
-
-    @lazyproperty
-    def normalized_profile(self):
-        """
-        Radial profile scaled to have a maximum of 1.
-        """
-        # This seems to be what photutils does under the hood
-        return self.radial_profile.profile / self.radial_profile.profile.max()
-
-    @lazyproperty
-    def pixel_values_in_profile(self):
-        """
-        Pixel values in the radial profile.
-        """
-        radii = []
-        pixel_values = []
-        for rad, ap in zip(self.radial_profile.radius, self.radial_profile.apertures):
-            ap_mask = ap.to_mask(method="center")
-            ap_data = ap_mask.multiply(self._data)
-            good_data = ap_data != 0
-            pixel_values.extend(ap_data[good_data].flatten())
-            radii.extend([rad] * good_data.sum())
-        radii = np.array(radii)
-        pixel_values = np.array(pixel_values)
-        return radii, pixel_values
-
-    @lazyproperty
-    def curve_of_growth(self):
-        """
-        Curve of growth for the star.
-        """
-        self._cog = CurveOfGrowth(
-            self._data - self.sky_pixel_value,
-            self.center,
-            self.radial_profile.radii + 1,
-        )
-        return self._cog
-
-    @lazyproperty
-    def sky_pixel_value(self):
-        """
-        Pixel values for the sky, i.e. outside the star.
-        """
-        grid_x, grid_y = np.mgrid[: self.cutout.shape[0], : self.cutout.shape[1]]
-        x_s, y_s = self.cutout.to_cutout_position(self.center)
-        dist_from_star = np.sqrt((grid_x - x_s) ** 2 + (grid_y - y_s) ** 2)
-        mask = dist_from_star > self.FWHM * 3
-        self._sky_area = mask.sum()
-        _, median, _ = sigma_clipped_stats(self.cutout.data[mask])
-        return median
-
-    @lazyproperty
-    def sky_area(self):
-        """
-        Area of the sky annulus.
-        """
-        if self._sky_area is None:
-            # sky area is set as a side effect of this....
-            _ = self.sky_pixel_value
-
-        return self._sky_area
-
-    def noise(self, camera, exposure):
-        """
-        Noise in the star.
-        """
-        return calculate_noise(
-            camera,
-            counts=self.curve_of_growth.profile,
-            sky_per_pix=self.sky_pixel_value,
-            aperture_area=self.curve_of_growth.area,
-            annulus_area=0,
-            exposure=exposure,
-        )
-
-    def snr(self, camera, exposure):
-        """
-        Signal to noise ratio of the star.
-        """
-        return camera.gain * self.curve_of_growth.profile / self.noise(camera, exposure)
-
-
-def box(imagewidget):
-    """
-    Compatibility layer for older versions of the photometry notebooks.
-
-    Parameters
-    ----------
-
-    imagewidget : `astrowidgets.ImageWidget`
-        ImageWidget instance to use for the seeing profile.
-
-    Returns
-    -------
-
-    box : `ipywidgets.VBox`
-        Box containing the seeing profile widget.
-    """
-    return SeeingProfileWidget(imagewidget=imagewidget).box
 
 
 class SeeingProfileWidget:
@@ -685,7 +405,6 @@ class SeeingProfileWidget:
         self.seeing_profile_plot.clear_output(wait=True)
         ap_settings = ApertureSettings(**self.aperture_settings.value)
         with self.seeing_profile_plot:
-            # sub_med += med
             r_exact, individual_counts = rad_prof.pixel_values_in_profile
             scaled_exact_counts = (
                 individual_counts / rad_prof.radial_profile.profile.max()
@@ -718,7 +437,7 @@ class SeeingProfileWidget:
             plt.title("Net counts in aperture")
 
             plt.xlabel("Aperture radius (pixels)")
-            plt.ylabel("Net counts")
+            plt.ylabel(f"Net counts ({self.camera.data_unit})")
             plt.show()
 
         # CALCULATE And DISPLAY SNR AS A FUNCTION OF RADIUS
@@ -726,6 +445,7 @@ class SeeingProfileWidget:
         with self.snr_plot:
             plt.figure(figsize=fig_size)
             snr = rad_prof.snr(self.camera, self.exposure)
+
             plt.plot(rad_prof.curve_of_growth.radius, snr)
 
             plt.title(

--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -1,27 +1,7 @@
-import numpy as np
-
-import pytest
-
-from photutils.datasets import make_gaussian_sources_image, make_noise_image
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyUserWarning
 from astrowidgets import ImageWidget
 
 from stellarphot.gui_tools import seeing_profile_functions as spf
-
-# Make a few round stars
-STARS = Table(
-    dict(
-        amplitude=[1000, 200, 300],
-        x_mean=[30, 100, 150],
-        y_mean=[40, 110, 160],
-        x_stddev=[4, 4, 4],
-        y_stddev=[4, 4, 4],
-        theta=[0, 0, 0],
-    )
-)
-SHAPE = (300, 300)
-RANDOM_SEED = 1230971
 
 
 def test_keybindings():
@@ -52,66 +32,3 @@ def test_keybindings():
     assert "Nonekp_+" in bound_keys
     # Yes, the line below is correct...
     assert new_bindings[bound_keys["Nonekp_left"]]["name"] == "pan_right"
-
-
-def test_find_center_no_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    # Good initial guess, no noise, should converge in one try
-    cen1 = spf.find_center(image, (31, 41), max_iters=1)
-    np.testing.assert_allclose(cen1, [30, 40])
-
-
-def test_find_center_noise_bad_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
-    )
-    cen2 = spf.find_center(image + noise, [40, 50], max_iters=1)
-    # Bad initial guess, noise, should take more than one try...
-    with pytest.raises(AssertionError):
-        np.testing.assert_allclose(cen2, [30, 40])
-
-
-def test_find_center_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
-    )
-    # Trying again with several iterations should work
-    cen3 = spf.find_center(image + noise, [31, 41], max_iters=20)
-    # Tolerance chosen based on some trial and error
-    np.testing.assert_allclose(cen3, [30, 40], atol=0.02)
-
-
-def test_find_center_no_noise_star_at_edge():
-    # Trying to put the star at the edge of the initial guess
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    cen = spf.find_center(image, [45, 65], max_iters=20)
-
-    np.testing.assert_allclose(cen, [30, 40], atol=0.02)
-
-
-def test_find_center_no_star():
-    # No star anywhere near the original guess
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    # Offset the mean from zero to avoid nan center
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=1000, stddev=5, seed=RANDOM_SEED
-    )
-
-    with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
-        cen = spf.find_center(image + noise, [50, 200], max_iters=10)
-
-
-def test_radial_profile():
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    for row in STARS:
-        cen = spf.find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
-        print(row)
-        r_ex, r_a, radprof = spf.radial_profile(image, cen)
-        r_exs, r_as, radprofs = spf.radial_profile(image, cen, return_scaled=False)
-
-        # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
-        expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
-        print(expected_integral, radprofs.sum())
-        np.testing.assert_allclose(radprofs.sum(), expected_integral, atol=50)

--- a/stellarphot/photometry/__init__.py
+++ b/stellarphot/photometry/__init__.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from .photometry import *
+from .profiles import *
 from .source_detection import *

--- a/stellarphot/photometry/profiles.py
+++ b/stellarphot/photometry/profiles.py
@@ -113,7 +113,7 @@ def find_center(image, center_guess, cutout_size=30, max_iters=10, match_limit=3
 
 class CenterAndProfile:
     """
-    Class to dentermine center of and hold radial profile information for a star.
+    Class to determine center of and hold radial profile information for a star.
 
     Parameters
     ----------

--- a/stellarphot/photometry/profiles.py
+++ b/stellarphot/photometry/profiles.py
@@ -1,0 +1,305 @@
+import warnings
+
+import numpy as np
+from astropy.stats import sigma_clipped_stats
+from astropy.nddata import Cutout2D
+from astropy.nddata.utils import NoOverlapError
+from astropy.utils import lazyproperty
+
+from photutils.profiles import RadialProfile, CurveOfGrowth
+from photutils.centroids import centroid_com, centroid_2dg
+
+from stellarphot.photometry import calculate_noise
+
+__all__ = ["find_center", "CenterAndProfile"]
+
+
+def find_center(image, center_guess, cutout_size=30, max_iters=10, match_limit=3):
+    """
+    Find the centroid of a star from an initial guess of its position. Originally
+    written to find star from a mouse click.
+
+    Parameters
+    ----------
+
+    image : `astropy.nddata.CCDData` or numpy array
+        Image containing the star.
+
+    center_guess : array or tuple
+        The position, in pixels, of the initial guess for the position of
+        the star. The coordinates should be horizontal first, then vertical,
+        i.e. opposite the usual Python convention for a numpy array.
+
+    cutout_size : int, optional
+        The default width of the cutout to use for finding the star.
+
+    max_iters : int, optional
+        Maximum number of iterations to go through in finding the center.
+
+    match_limit : int, optional
+        Maximum number of pixels to allow the COM centroid and Gaussian center to
+        differ.
+
+    Returns
+    -------
+
+    cen : array
+        The position of the star, in pixels, as found by the centroiding
+        algorithm.
+    """
+    pad = cutout_size // 2
+    x, y = center_guess
+
+    # Keep track of iterations
+    cnt = 0
+
+    # Grab the cutout...
+    sub_data = Cutout2D(image, center_guess, (cutout_size, cutout_size), mode="trim")
+    # ...do stats on it...
+    _, sub_med, _ = sigma_clipped_stats(sub_data.data)
+    # ...and centroid.
+    mask = (sub_data.data - sub_med) < 0
+    x_cm, y_cm = centroid_com(sub_data.data - sub_med, mask=mask)
+
+    # Translate centroid back to original image (maybe use Cutout2D instead)
+    cen = np.array(sub_data.to_original_position((x_cm, y_cm)))
+    print(f"{cen=} {x_cm=} {y_cm=}")
+    # ceno is the "original" center guess, set it to something nonsensical here
+    ceno = np.array([-100, -100])
+
+    while cnt <= max_iters and (
+        np.abs(np.array([x_cm, y_cm]) - pad).max() > 3 or np.abs(cen - ceno).max() > 0.1
+    ):
+        try:
+            sub_data = Cutout2D(image, cen, (cutout_size, cutout_size), mode="trim")
+        except NoOverlapError:
+            raise RuntimeError(
+                f"Centroid finding failed, previous was {ceno}, current is {cen}"
+            )
+        _, sub_med, _ = sigma_clipped_stats(sub_data.data)
+
+        mask = (sub_data.data - sub_med) < 0
+        x_cm, y_cm = centroid_com(sub_data.data - sub_med, mask=mask)
+        ceno = cen
+        cen = np.array(sub_data.to_original_position((x_cm, y_cm)))
+        if not np.all(~np.isnan(cen)):
+            raise RuntimeError(
+                f"Centroid finding failed, previous was {ceno}, current is {cen}"
+            )
+        cnt += 1
+
+    # Is we hit the max number of iterations, raise an error
+    if max_iters > 1 and cnt > max_iters:
+        raise RuntimeError(f"Centroid finding did not converge")
+
+    # Get the final centroid position by fitting a gaussian
+    # We may not have converged on a star, so capture any warning about a
+    # bad fit.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ceng = centroid_2dg(sub_data.data - sub_med)
+    ceng = np.array(sub_data.to_original_position(ceng))
+
+    # Confirm that we actually found a star by comparing two centroiding
+    # methods
+    if np.linalg.norm(cen - ceng) > match_limit:
+        raise RuntimeError(
+            "Centroid did not converge on a star. "
+            f"Got {cen} from centroid_com and {ceng} from centroid_2dg."
+        )
+
+    return ceng
+
+
+class CenterAndProfile:
+    """
+    Class to dentermine center of and hold radial profile information for a star.
+
+    Parameters
+    ----------
+    data : `astropy.nddata.CCDData` or numpy array
+        Image data
+
+    center_approx : list-like
+        x, y position of the center in pixel coordinates, i.e. horizontal
+        coordinate then vertical.
+
+    cutout_size : int, optional
+        Width of the rectangular image cutout to use in looking for a star.
+
+    profile_radius : int, optional
+        Maximum radius to use in constructing the profile.
+
+    max_iters : int, optional
+        Maximum number of iterations to go through in finding the center.
+    """
+
+    def __init__(
+        self, data, center_approx, cutout_size=30, profile_radius=None, max_iters=10
+    ):
+        self._cen = find_center(data, center_approx, cutout_size=cutout_size)
+        self._data = data
+        self._cutout = Cutout2D(data, self._cen, (cutout_size, cutout_size))
+        self._max_iters = max_iters
+        if profile_radius is None:
+            profile_radius = cutout_size // 2
+
+        radii = np.linspace(0, profile_radius, profile_radius + 1)
+        # Get a rough profile without background subtraction
+        self._radial_profile = RadialProfile(self._data, self._cen, radii)
+
+        self._sky_area = None
+
+        # Do proper background subtraction for the final radial profile
+        self._radial_profile = RadialProfile(
+            data - self.sky_pixel_value, self._cen, radii
+        )
+
+    @property
+    def center(self):
+        """
+        x, y position of the center of the star.
+        """
+        return self._cen
+
+    @property
+    def FWHM(self):
+        """
+        Full-width half-max of the radial profile.
+        """
+        return self.radial_profile.gaussian_fwhm
+
+    @property
+    def HWHM(self):
+        """
+        Half-width half-max of the radial profile.
+        """
+        return self.FWHM / 2
+
+    @property
+    def cutout(self):
+        """
+        Cutout image around the star.
+        """
+        return self._cutout
+
+    @property
+    def radial_profile(self):
+        """
+        Radial profile of the star.
+        """
+        return self._radial_profile
+
+    @property
+    def max_iters(self):
+        """
+        Maximum number of iterations to go through in finding the center.
+        """
+        return self._max_iters
+
+    @lazyproperty
+    def normalized_profile(self):
+        """
+        Radial profile scaled to have a maximum of 1.
+        """
+        # This seems to be what photutils does under the hood
+        return self.radial_profile.profile / self.radial_profile.profile.max()
+
+    @lazyproperty
+    def pixel_values_in_profile(self):
+        """
+        Pixel values in the radial profile.
+        """
+        radii = []
+        pixel_values = []
+        for rad, ap in zip(self.radial_profile.radius, self.radial_profile.apertures):
+            ap_mask = ap.to_mask(method="center")
+            ap_data = ap_mask.multiply(self._data)
+            good_data = ap_data != 0
+            pixel_values.extend(ap_data[good_data].flatten())
+            radii.extend([rad] * good_data.sum())
+        radii = np.array(radii)
+        pixel_values = np.array(pixel_values)
+        return radii, pixel_values
+
+    @lazyproperty
+    def curve_of_growth(self):
+        """
+        Curve of growth for the star.
+        """
+        self._cog = CurveOfGrowth(
+            self._data - self.sky_pixel_value,
+            self.center,
+            self.radial_profile.radii + 1,
+        )
+        return self._cog
+
+    @lazyproperty
+    def sky_pixel_value(self):
+        """
+        Pixel values for the sky, i.e. outside the star.
+        """
+        grid_x, grid_y = np.mgrid[: self.cutout.shape[0], : self.cutout.shape[1]]
+        x_s, y_s = self.cutout.to_cutout_position(self.center)
+        dist_from_star = np.sqrt((grid_x - x_s) ** 2 + (grid_y - y_s) ** 2)
+        mask = dist_from_star > self.FWHM * 3
+        self._sky_area = mask.sum()
+        _, median, _ = sigma_clipped_stats(self.cutout.data[mask])
+        return median
+
+    @lazyproperty
+    def sky_area(self):
+        """
+        Area of the sky annulus.
+        """
+        if self._sky_area is None:
+            # sky area is set as a side effect of this....
+            _ = self.sky_pixel_value
+
+        return self._sky_area
+
+    def noise(self, camera, exposure):
+        """
+        Noise in the star.
+
+        Parameters
+        ----------
+
+        camera : `stellarphot.settings.Camera`
+            Camera settings.
+
+        exposure : float
+            Exposure time in seconds.
+
+        Returns
+        -------
+        noise : `numpy.ndarray` of float
+            Noise calculated using the CCD equation.
+        """
+        return calculate_noise(
+            camera,
+            counts=self.curve_of_growth.profile,
+            sky_per_pix=self.sky_pixel_value,
+            aperture_area=self.curve_of_growth.area,
+            annulus_area=0,
+            exposure=exposure,
+        )
+
+    def snr(self, camera, exposure):
+        """
+        Signal to noise ratio of the star.
+
+        Parameters
+        ----------
+        camera : `stellarphot.settings.Camera`
+            Camera settings.
+
+        exposure : float
+            Exposure time in seconds.
+
+        Returns
+        -------
+        snr : `numpy.ndarray` of float
+            Signal to noise ratio.
+        """
+        return camera.gain * self.curve_of_growth.profile / self.noise(camera, exposure)

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -1,0 +1,91 @@
+import numpy as np
+
+import pytest
+
+from astropy.table import Table
+from astropy.utils.exceptions import AstropyUserWarning
+
+from photutils.datasets import make_gaussian_sources_image, make_noise_image
+
+from stellarphot.photometry import find_center, CenterAndProfile
+
+# Make a few round stars
+STARS = Table(
+    dict(
+        amplitude=[1000, 200, 300],
+        x_mean=[30, 100, 150],
+        y_mean=[40, 110, 160],
+        x_stddev=[4, 4, 4],
+        y_stddev=[4, 4, 4],
+        theta=[0, 0, 0],
+    )
+)
+SHAPE = (300, 300)
+RANDOM_SEED = 1230971
+
+
+def test_find_center_no_noise_good_guess():
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    # Good initial guess, no noise, should converge in one try
+    cen1 = find_center(image, (31, 41), max_iters=1)
+    np.testing.assert_allclose(cen1, [30, 40])
+
+
+def test_find_center_noise_bad_guess():
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    noise = make_noise_image(
+        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
+    )
+    cen2 = find_center(image + noise, [40, 50], max_iters=1)
+    # Bad initial guess, noise, should take more than one try...
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(cen2, [30, 40])
+
+
+def test_find_center_noise_good_guess():
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    noise = make_noise_image(
+        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
+    )
+    # Trying again with several iterations should work
+    cen3 = find_center(image + noise, [31, 41], max_iters=20)
+    # Tolerance chosen based on some trial and error
+    np.testing.assert_allclose(cen3, [30, 40], atol=0.02)
+
+
+def test_find_center_no_noise_star_at_edge():
+    # Trying to put the star at the edge of the initial guess
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    cen = find_center(image, [45, 65], max_iters=20)
+
+    np.testing.assert_allclose(cen, [30, 40], atol=0.02)
+
+
+def test_find_center_no_star():
+    # No star anywhere near the original guess
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    # Offset the mean from zero to avoid nan center
+    noise = make_noise_image(
+        SHAPE, distribution="gaussian", mean=1000, stddev=5, seed=RANDOM_SEED
+    )
+
+    with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
+        cen = find_center(image + noise, [50, 200], max_iters=10)
+
+
+def test_radial_profile():
+    image = make_gaussian_sources_image(SHAPE, STARS)
+    for row in STARS:
+        cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
+
+        # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
+        # stars fairly big -- the bare minimum would be a radius of 3 FWHM, which is a
+        # cutout size around 60.
+        rad_prof = CenterAndProfile(image, cen, cutout_size=60, profile_radius=30)
+
+        # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
+        expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
+
+        np.testing.assert_allclose(
+            rad_prof.curve_of_growth.profile[-1], expected_integral, atol=50
+        )

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -24,6 +24,16 @@ from stellarphot.core import (
 )
 
 
+TEST_CAMERA_VALUES = dict(
+    data_unit=u.adu,
+    gain=2.0 * u.electron / u.adu,
+    read_noise=10 * u.electron,
+    dark_current=0.01 * u.electron / u.second,
+    pixel_scale=0.563 * u.arcsec / u.pix,
+    max_data_value=50000 * u.adu,
+)
+
+
 def test_camera_attributes():
     # Check that the attributes are set properly
     data_unit = u.adu


### PR DESCRIPTION
This rewrites the radial profile calculation from seeing_profile_functions into a class that makes use of relatively new functionality in photutils for finding radial profiles.

The radial profiling class was added to the `photometry` sub-package but could go somewhere else I suppose.

One subsequent change to the `SeeingProfileWidget` will be to move the plotting functionality into the `plotting` subpackage.