### PR TITLE
Check camera json encoding

### DIFF
--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -4,7 +4,7 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Column, QTable, Table
 from astropy.time import Time
-from astropy.units import Quantity, Unit
+from astropy.units import Quantity, Unit, IrreducibleUnit
 from astropy.wcs import WCS
 
 from astroquery.vizier import Vizier
@@ -240,7 +240,8 @@ class Camera(BaseModel):
         json_encoders = {
             Quantity: lambda v: f"{v.value} {v.unit}",
             QuantityType: lambda v: f"{v.value} {v.unit}",
-            UnitType: lambda v: f"{v}",
+            Unit: lambda v: f"{v}",
+            IrreducibleUnit: lambda v: f"{v}",
             PixelScaleType: lambda v: f"{v.value} {v.unit}",
         }
 

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -193,6 +193,28 @@ def test_camera_schema():
     assert len(schema["properties"]) == 6
 
 
+def test_camera_json_round_trip():
+    # Check that a camera can be converted to json and back
+    data_unit = u.adu
+    gain = 2.0 * u.electron / u.adu
+    read_noise = 10 * u.electron
+    dark_current = 0.01 * u.electron / u.second
+    pixel_scale = 0.563 * u.arcsec / u.pix
+    max_val = 50000 * u.adu
+
+    c = Camera(
+        data_unit=data_unit,
+        gain=gain,
+        read_noise=read_noise,
+        dark_current=dark_current,
+        pixel_scale=pixel_scale,
+        max_data_value=max_val,
+    )
+
+    c2 = Camera.parse_raw(c.json())
+    assert c2 == c
+
+
 # Create several test descriptions for use in base_enhanced_table tests.
 test_descript = {
     "id": None,


### PR DESCRIPTION
This fixes an oversight from #231 in which I forgot to add a json encoder for units.