### PR TITLE
Add isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@ c47587cbfa829b03be1dc2e5a79dc96af6ea712f
 855f1d409a0eaf407e55d0d39a7ee195c19612a3
 # Ignore whitespace changes in comments/docstrings
 1b7139d4e9db54c818293832e89aaca30b662a32
+# Ignore initial isort
+479a2cdb25baa7f40cc73b1f5999e0b61c4d69ed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,8 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
-import sys
 import datetime
+import sys
 from importlib import import_module
 from pathlib import Path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ select = [
     "UP",
     # check for numpy deprecations
     "NPY",
+    "I",    # isort checks
 ]
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` and `F403` (import violations) in all `__init__.py` files.

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -1,19 +1,16 @@
 import re
 
+import numpy as np
+import pandas as pd
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader
 from astropy.table import Column, QTable, Table, TableAttribute
 from astropy.time import Time
-from astropy.units import Quantity, Unit, IrreducibleUnit
+from astropy.units import IrreducibleUnit, Quantity, Unit
 from astropy.wcs import WCS
-
 from astroquery.vizier import Vizier
-
-import pandas as pd
-from pydantic import BaseModel, root_validator, Field, validator
-
-import numpy as np
+from pydantic import BaseModel, Field, root_validator, validator
 
 __all__ = [
     "Camera",

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -1,8 +1,7 @@
+import astropy.units as u
 import numpy as np
-
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-import astropy.units as u
 
 __all__ = ["add_in_quadrature", "calc_aij_relative_flux"]
 

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -1,11 +1,9 @@
+import astropy.units as u
 import numpy as np
-
 import pytest
-
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-import astropy.units as u
 
 from stellarphot import PhotometryData
 from stellarphot.differential_photometry.aij_rel_fluxes import calc_aij_relative_flux

--- a/stellarphot/differential_photometry/tests/test_vsx_mags.py
+++ b/stellarphot/differential_photometry/tests/test_vsx_mags.py
@@ -1,7 +1,8 @@
-from astropy.table import Table, vstack
-from astropy.coordinates import SkyCoord
-from astropy.utils.data import get_pkg_data_filename
 import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.table import Table, vstack
+from astropy.utils.data import get_pkg_data_filename
+
 from .. import calc_multi_vmag, calc_vmag
 
 

--- a/stellarphot/differential_photometry/vsx_mags.py
+++ b/stellarphot/differential_photometry/vsx_mags.py
@@ -1,8 +1,7 @@
 import numpy as np
-
-from astropy.table import Table
-from astropy.coordinates import SkyCoord
 from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
 
 __all__ = ["calc_multi_vmag", "calc_vmag"]
 

--- a/stellarphot/gui_tools/__init__.py
+++ b/stellarphot/gui_tools/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .fits_opener import *
 from .comparison_functions import *
+from .fits_opener import *
 from .photometry_widget_functions import *
 from .seeing_profile_functions import *

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -2,14 +2,11 @@ import functools
 from pathlib import Path
 
 import ipywidgets as ipw
-
 import numpy as np
-
-from astropy.table import Table
-from astropy.coordinates import SkyCoord
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.coordinates.name_resolve import NameResolveError
-
+from astropy.table import Table
 
 try:
     from astrowidgets import ImageWidget
@@ -17,16 +14,15 @@ except ImportError:
     from astrowidgets.ginga import ImageWidget
 
 from stellarphot import SourceListData
-from stellarphot.gui_tools.seeing_profile_functions import set_keybindings
 from stellarphot.gui_tools.fits_opener import FitsOpener
-from stellarphot.io import TessSubmission, TOI, TessTargetFile
+from stellarphot.gui_tools.seeing_profile_functions import set_keybindings
+from stellarphot.io import TOI, TessSubmission, TessTargetFile
 from stellarphot.utils.comparison_utils import (
-    set_up,
     crossmatch_APASS2VSX,
-    mag_scale,
     in_field,
+    mag_scale,
+    set_up,
 )
-
 
 __all__ = ["make_markers", "wrap", "ComparisonViewer"]
 

--- a/stellarphot/gui_tools/fits_opener.py
+++ b/stellarphot/gui_tools/fits_opener.py
@@ -1,11 +1,9 @@
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 from astropy.io import fits
 from astropy.nddata import CCDData
-
 from ipyfilechooser import FileChooser
-
 
 __all__ = ["FitsOpener"]
 

--- a/stellarphot/gui_tools/photometry_widget_functions.py
+++ b/stellarphot/gui_tools/photometry_widget_functions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from ccdproc import ImageFileCollection
 import ipywidgets as ipw
+from ccdproc import ImageFileCollection
 
 from stellarphot.settings import ApertureSettings, PhotometryFileSettings, ui_generator
 

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -1,9 +1,8 @@
-from pathlib import Path
 import warnings
+from pathlib import Path
 
-import numpy as np
 import ipywidgets as ipw
-
+import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 
@@ -14,8 +13,8 @@ except ImportError:
 
 import matplotlib.pyplot as plt
 
-from stellarphot.io import TessSubmission
 from stellarphot.gui_tools.fits_opener import FitsOpener
+from stellarphot.io import TessSubmission
 from stellarphot.photometry import CenterAndProfile
 from stellarphot.photometry.photometry import EXPOSURE_KEYWORDS
 from stellarphot.plotting import seeing_plot

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -1,11 +1,10 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 import astropy.units as u
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-
-import numpy as np
 
 __all__ = [
     "ApertureAIJ",

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -1,15 +1,14 @@
+import re
 from dataclasses import dataclass
 from pathlib import Path
-import re
 from tempfile import NamedTemporaryFile
 
+import requests
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-from astropy import units as u
 from astropy.utils.data import download_file
-
-import requests
 
 from stellarphot.transit_fitting.io import get_tic_info
 

--- a/stellarphot/io/tests/test_aij_io.py
+++ b/stellarphot/io/tests/test_aij_io.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename

--- a/stellarphot/io/tests/test_tess_submission.py
+++ b/stellarphot/io/tests/test_tess_submission.py
@@ -2,8 +2,8 @@ import re
 import warnings
 
 import pytest
-
 from astropy.coordinates import SkyCoord
+
 from stellarphot.io.tess import TessSubmission, TessTargetFile
 
 GOOD_HEADER = {

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -1,10 +1,9 @@
-import warnings
 import logging
+import warnings
+from pathlib import Path
 
 import bottleneck as bn
 import numpy as np
-from pathlib import Path
-
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.nddata import CCDData, NoOverlapError
@@ -15,7 +14,6 @@ from astropy.wcs import FITSFixedWarning
 from ccdproc import ImageFileCollection
 from photutils.aperture import CircularAnnulus, CircularAperture, aperture_photometry
 from photutils.centroids import centroid_sources
-
 from scipy.spatial.distance import cdist
 
 from stellarphot import Camera, PhotometryData, SourceListData

--- a/stellarphot/photometry/profiles.py
+++ b/stellarphot/photometry/profiles.py
@@ -1,13 +1,12 @@
 import warnings
 
 import numpy as np
-from astropy.stats import sigma_clipped_stats
 from astropy.nddata import Cutout2D
 from astropy.nddata.utils import NoOverlapError
+from astropy.stats import sigma_clipped_stats
 from astropy.utils import lazyproperty
-
-from photutils.profiles import RadialProfile, CurveOfGrowth
-from photutils.centroids import centroid_com, centroid_2dg
+from photutils.centroids import centroid_2dg, centroid_com
+from photutils.profiles import CurveOfGrowth, RadialProfile
 
 from stellarphot.photometry import calculate_noise
 

--- a/stellarphot/photometry/tests/test_detection.py
+++ b/stellarphot/photometry/tests/test_detection.py
@@ -2,15 +2,13 @@ import warnings
 
 import numpy as np
 import pytest
-
-from astropy.table import QTable
-from astropy.stats import gaussian_sigma_to_fwhm
 from astropy import units as u
+from astropy.stats import gaussian_sigma_to_fwhm
+from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
-
-from stellarphot.photometry import source_detection, compute_fwhm
-
 from fake_image import FakeImage
+
+from stellarphot.photometry import compute_fwhm, source_detection
 
 # Make sure the tests are deterministic by using a random seed
 SEED = 5432985

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -1,6 +1,6 @@
 import tempfile
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -9,7 +9,6 @@ from astropy.coordinates import EarthLocation
 from astropy.io import ascii
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.metadata.exceptions import MergeConflictWarning
-
 from fake_image import FakeCCDImage, shift_FakeCCDImage
 
 from stellarphot.core import Camera, SourceListData

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -1,13 +1,10 @@
 import numpy as np
-
 import pytest
-
 from astropy.table import Table
-
 from photutils.datasets import make_gaussian_sources_image, make_noise_image
 
 from stellarphot import Camera
-from stellarphot.photometry import find_center, CenterAndProfile
+from stellarphot.photometry import CenterAndProfile, find_center
 from stellarphot.tests.test_core import TEST_CAMERA_VALUES
 
 # Make a few round stars

--- a/stellarphot/plotting/__init__.py
+++ b/stellarphot/plotting/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .multi_night_plots import *
 from .aij_plots import *
+from .multi_night_plots import *
 from .transit_plots import *

--- a/stellarphot/plotting/multi_night_plots.py
+++ b/stellarphot/plotting/multi_night_plots.py
@@ -1,12 +1,9 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
-
 from astropy.stats import mad_std
 from astropy.time import Time
-
 from astropy.timeseries import LombScargle
-
 
 __all__ = ["plot_magnitudes", "multi_night"]
 

--- a/stellarphot/plotting/transit_plots.py
+++ b/stellarphot/plotting/transit_plots.py
@@ -1,9 +1,6 @@
-from matplotlib import pyplot as plt
-
 import numpy as np
-
 from astropy import units as u
-
+from matplotlib import pyplot as plt
 
 __all__ = ["plot_many_factors", "bin_data", "scale_and_shift"]
 

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -2,17 +2,14 @@
 
 from pathlib import Path
 
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from astropy.units import Quantity
 from pydantic import BaseModel, Field, conint, validator
 
-from .autowidgets import CustomBoundedIntTex
-
-from astropy.time import Time
-from astropy.coordinates import SkyCoord
-from astropy.units import Quantity
-import astropy.units as u
-
 from ..core import QuantityType
-
+from .autowidgets import CustomBoundedIntTex
 
 __all__ = ["ApertureSettings", "PhotometryFileSettings", "Exoplanet"]
 

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -1,11 +1,10 @@
+import astropy.units as u
+import pytest
+from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from pydantic import ValidationError
-import pytest
 
 from stellarphot.settings.models import ApertureSettings, Exoplanet
-
-from astropy.coordinates import SkyCoord
-import astropy.units as u
 
 DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15)
 

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -1,28 +1,27 @@
 import warnings
 
-import pytest
 import numpy as np
+import pytest
 from astropy import units as u
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.io import ascii, fits
+from astropy.nddata import CCDData
 from astropy.table import Table
 from astropy.time import Time
-from astropy.io import ascii, fits
-from astropy.coordinates import EarthLocation, SkyCoord
-from astropy.nddata import CCDData
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from astropy.wcs.wcs import FITSFixedWarning
-
 from pydantic import ValidationError
+
 from stellarphot.core import (
-    Camera,
     BaseEnhancedTable,
-    PhotometryData,
+    Camera,
     CatalogData,
+    PhotometryData,
+    SourceListData,
     apass_dr9,
     vsx_vizier,
-    SourceListData,
 )
-
 
 TEST_CAMERA_VALUES = dict(
     data_unit=u.adu,

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -1,9 +1,8 @@
 import warnings
 
 import numpy as np
-
-from astropy.modeling.models import custom_model
 from astropy.modeling.fitting import LevMarLSQFitter, _validate_model
+from astropy.modeling.models import custom_model
 
 # Functions below changed from private to public in astropy 5
 try:
@@ -14,6 +13,8 @@ try:
 except ImportError:
     from astropy.modeling.fitting import (
         _fitter_to_model_params as fitter_to_model_params,
+    )
+    from astropy.modeling.fitting import (
         _model_to_fit_params as model_to_fit_params,
     )
 

--- a/stellarphot/transit_fitting/gui.py
+++ b/stellarphot/transit_fitting/gui.py
@@ -1,12 +1,11 @@
+import json
 import re
 from pathlib import Path
-import json
 
-import numpy as np
 import ipywidgets as ipw
-from traitlets import observe, Bool
-
+import numpy as np
 from astropy.utils.data import get_pkg_data_filename
+from traitlets import Bool, observe
 
 from stellarphot.transit_fitting.io import get_tic_info
 

--- a/stellarphot/transit_fitting/io.py
+++ b/stellarphot/transit_fitting/io.py
@@ -1,6 +1,5 @@
 from astroquery.mast import Catalogs
 
-
 __all__ = ["get_tic_info"]
 
 

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -1,7 +1,7 @@
 import sys
 
-import pytest
 import numpy as np
+import pytest
 
 from stellarphot.transit_fitting import TransitModelFit
 

--- a/stellarphot/utils/comparison_utils.py
+++ b/stellarphot/utils/comparison_utils.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 
 import pandas as pd
-
-from astropy.table import Table
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.nddata import CCDData
-from astropy import units as u
+from astropy.table import Table
 
 from stellarphot import apass_dr9, vsx_vizier
-
 
 __all__ = ["read_file", "set_up", "crossmatch_APASS2VSX", "mag_scale", "in_field"]
 

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -1,16 +1,14 @@
 from collections import namedtuple
 
 import numpy as np
-from scipy.optimize import curve_fit
-
-from astropy.modeling import models, fitting
+from astropy import units as u
+from astropy.coordinates import SkyCoord, match_coordinates_sky
+from astropy.modeling import fitting, models
 from astropy.stats import sigma_clip
 from astropy.table import MaskedColumn
-from astropy.coordinates import SkyCoord, match_coordinates_sky
-from astropy import units as u
+from scipy.optimize import curve_fit
 
 from ..core import apass_dr9
-
 
 __all__ = [
     "f",

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1,20 +1,18 @@
 import warnings
 
 import numpy as np
+import pytest
+from astropy import units as u
+from astropy.modeling import models
+from astropy.table import Column, Table
+from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 
 from ..magnitude_transforms import (
-    filter_transform,
     calculate_transform_coefficients,
+    filter_transform,
     transform_magnitudes,
 )
-
-import pytest
-
-from astropy.modeling import models
-from astropy.table import Table, Column
-from astropy.utils.data import get_pkg_data_filename
-from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
 
 
 def generate_input_mags(n_stars):

--- a/stellarphot/version.py
+++ b/stellarphot/version.py
@@ -1,10 +1,11 @@
 version = "unknown.dev"
 try:
-    from importlib_metadata import version as _version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _version
 
     version = _version("my-package")
 except ImportError:
-    from pkg_resources import get_distribution, DistributionNotFound
+    from pkg_resources import DistributionNotFound, get_distribution
 
     try:
         version = get_distribution("my-package").version


### PR DESCRIPTION
This PR sorts the import statements at the top of each file in a particular order.

Big picture, imports from Python standard library are in the first group, imports from other packages are in the second group, and imports from stellarphot are in the third group.

Within each group, lines that start `import` committee first, then lines that start `from ... import ...`. Within each of those groupings imports are arranged alphabetically.

A check of isort has been turned on in ruff.

**What this means in practice:** You will need to pull in the latest main branch from feder-observatory to your local git clone before opening any new PRs. To do that, navigate in a terminal to your git clone and

```
git checkout main
git pull --set-upstream --ff-only upstream main 
```

@JuanCab @Tanner728 @AbigaleMoen @WatsonEmily11 @MDeRung2021 