### PR TITLE
Add flake8-bugbear linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,18 +103,14 @@ include = '\.pyi?$'
 
 [tool.ruff.lint]
 select = [
-    # E and W are the checks done by pycodestyle
-    "E",
+    "E",    # E and W are the checks done by pycodestyle
     "W",
-    # pyflakes checks
-    "F",
-    # flake8-unused-arguments
-    "ARG",
-    # language updates
-    "UP",
-    # check for numpy deprecations
-    "NPY",
+    "F",    # pyflakes checks
+    "ARG",  # flake8-unused-arguments
+    "UP",   # language updates
+    "NPY",  # check for numpy deprecations
     "I",    # isort checks
+    "B",    # flake8-bugbear
 ]
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` and `F403` (import violations) in all `__init__.py` files.

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -1015,7 +1015,7 @@ class CatalogData(BaseEnhancedTable):
         # create a single list of all the matches
         matches = [
             m_match if m_match else c_match
-            for m_match, c_match in zip(mag_match, color_match)
+            for m_match, c_match in zip(mag_match, color_match, strict=True)
         ]
 
         # The passband should be the first group match.
@@ -1037,7 +1037,7 @@ class CatalogData(BaseEnhancedTable):
         mag_col_prepend = "magstphot"
         mag_col_map = {
             orig_col: f"{mag_col_prepend}_{passband}"
-            for orig_col, passband in zip(orig_cols, passbands)
+            for orig_col, passband in zip(orig_cols, passbands, strict=True)
         }
 
         # Dictionary to update the magnitude error column names. The
@@ -1046,7 +1046,7 @@ class CatalogData(BaseEnhancedTable):
         mag_err_col_prepend = "errorstphot"
         mag_err_col_map = {
             orig_col: f"{mag_err_col_prepend}_{passband}"
-            for orig_col, passband in zip(mag_err_cols, passbands)
+            for orig_col, passband in zip(mag_err_cols, passbands, strict=True)
         }
 
         # All columns except those we have renamed should be preserved, so make

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -68,8 +68,8 @@ class QuantityType(Quantity):
     def validate(cls, v):
         try:
             v = Quantity(v)
-        except TypeError:
-            raise ValueError(f"Invalid value for Quantity: {v}")
+        except TypeError as err:
+            raise ValueError(f"Invalid value for Quantity: {v}") from err
         else:
             if not v.unit.bases:
                 raise ValueError("Must provided a unit")
@@ -105,8 +105,8 @@ class PixelScaleType(Quantity):
     def validate(cls, v):
         try:
             v = Quantity(v)
-        except TypeError:
-            raise ValueError(f"Invalid value for Quantity: {v}")
+        except TypeError as err:
+            raise ValueError(f"Invalid value for Quantity: {v}") from err
         if (
             len(v.unit.bases) != 2
             or v.unit.bases[0].physical_type != "angle"
@@ -360,11 +360,11 @@ class BaseEnhancedTable(QTable):
             # and values)
             try:
                 self._table_description = {k: v for k, v in table_description.items()}
-            except AttributeError:
+            except AttributeError as err:
                 raise TypeError(
                     "You must provide a dict as table_description (input "
                     f"table_description is type {type(table_description)})."
-                )
+                ) from err
 
             # Check data before copying to avoid recusive loop and non-QTable
             # data input.
@@ -385,12 +385,12 @@ class BaseEnhancedTable(QTable):
                 # Confirm a proper colname_map is passed
                 try:
                     self._colname_map = {k: v for k, v in colname_map.items()}
-                except AttributeError:
+                except AttributeError as err:
                     raise TypeError(
                         "You must provide a dict as table_description "
                         "(input table_description is type "
                         f"{type(self._table_description)})."
-                    )
+                    ) from err
 
                 self._update_colnames(self._colname_map, data)
 
@@ -424,17 +424,17 @@ class BaseEnhancedTable(QTable):
                             f"(should be {this_unit} but reported "
                             f"as {data[this_col].unit})."
                         )
-                except KeyError:
+                except KeyError as err:
                     raise ValueError(
                         f"data['{this_col}'] is missing from input " "data."
-                    )
+                    ) from err
             else:  # Check that columns with no units but are required exist!
                 try:
                     _ = data[this_col]
-                except KeyError:
+                except KeyError as err:
                     raise ValueError(
                         f"data['{this_col}'] is missing from input " "data."
-                    )
+                    ) from err
 
     def _update_colnames(self, colname_map, data):
         # Change column names as desired, done before validating the columns,
@@ -442,11 +442,11 @@ class BaseEnhancedTable(QTable):
         for orig_name, new_name in colname_map.items():
             try:
                 data.rename_column(orig_name, new_name)
-            except KeyError:
+            except KeyError as err:
                 raise ValueError(
                     f"data['{orig_name}'] is missing from input "
                     "data but listed in colname_map!"
-                )
+                ) from err
 
     def _update_passbands(self):
         # Converts filter names in filter column to AAVSO standard names
@@ -697,12 +697,12 @@ class PhotometryData(BaseEnhancedTable):
                         "have scale='utc', "
                         f"not '{input_data['date-obs'][0].scale}'."
                     )
-            except AttributeError:
+            except AttributeError as err:
                 # Happens if first item doesn't have a "scale"
                 raise ValueError(
                     "input_data['date-obs'] isn't column of "
                     "astropy.time.Time entries."
-                )
+                ) from err
 
             # Convert input data to QTable (while also checking for required columns)
             super().__init__(
@@ -1419,11 +1419,11 @@ class SourceListData(BaseEnhancedTable):
                 # Confirm a proper colname_map is passed
                 try:
                     self._colname_map = {k: v for k, v in colname_map.items()}
-                except AttributeError:
+                except AttributeError as err:
                     raise TypeError(
                         "You must provide a dict as table_description (it "
                         f"is type {type(self._colname_map)})."
-                    )
+                    ) from err
                 self._update_colnames(self._colname_map, data)
 
                 # No need to repeat this

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -153,7 +153,7 @@ def calc_aij_relative_flux(
 
     # This seems a little hacky; there must be a better way
     for date_obs, comp_total, comp_error in zip(
-        comp_fluxes.groups.keys, comp_totals, comp_errors
+        comp_fluxes.groups.keys, comp_totals, comp_errors, strict=True
     ):
         this_time = star_data["date-obs"] == date_obs[0]
         comp_total_vector[this_time] *= comp_total

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -394,11 +394,11 @@ class ComparisonViewer:
         # Export variables as CSV (overwrite existing file if it exists)
         try:
             self.variables.write(filename, overwrite=self.overwrite_outputs)
-        except OSError:
+        except OSError as err:
             raise OSError(
                 f"Existing file ({filename}) can not be overwritten. "
                 "Set overwrite_outputs=True to address this."
-            )
+            ) from err
 
     def _show_label_button_handler(self, change):
         value = change["new"]
@@ -439,11 +439,11 @@ class ComparisonViewer:
         # Export aperture file as CSV (overwrite existing file if it exists)
         try:
             sources.write(filename, overwrite=self.overwrite_outputs)
-        except OSError:
+        except OSError as err:
             raise OSError(
                 f"Existing file ({filename}) can not be overwritten."
                 "Set overwrite_outputs=True to address this."
-            )
+            ) from err
 
     def _make_control_bar(self):
         self._show_labels_button = ipw.ToggleButton(description="Click to show labels")
@@ -592,11 +592,11 @@ class ComparisonViewer:
                 Path(self._field_name.value).unlink()
             try:
                 self.iw.save(self._field_name.value)
-            except OSError:
+            except OSError as err:
                 raise OSError(
                     f"Existing file ({self._field_name.value}) can not be overwritten. "
                     "Set overwrite_outputs=True to address this."
-                )
+                ) from err
 
         if self._zoom_name.value:
             self.tess_field_zoom_view()
@@ -605,11 +605,11 @@ class ComparisonViewer:
                 Path(self._zoom_name.value).unlink()
             try:
                 self.iw.save(self._zoom_name.value)
-            except OSError:
+            except OSError as err:
                 raise OSError(
                     f"Existing file ({self._zoom_name.value}) can not be overwritten. "
                     "Set overwrite_outputs=True to address this."
-                )
+                ) from err
 
     def generate_table(self):
         """

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -237,9 +237,12 @@ class SeeingProfileWidget:
                 self.exposure = self.fits_file.header[key]
                 break
         else:
+            # apparently setting a higher stacklevel is better, see
+            # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
             warnings.warn(
                 "No exposure time keyword found in FITS header. "
-                "Setting exposure to NaN"
+                "Setting exposure to NaN",
+                stacklevel=2,
             )
             self.exposure = np.nan
 

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -439,7 +439,7 @@ def generate_aij_table(table_name, comparison_table):
     }
     by_star = table_name.group_by("star_id")
     base_table = by_star.groups[0][list(info_columns.keys())]
-    for star_id, sub_table in zip(by_star.groups.keys, by_star.groups):
+    for star_id, sub_table in zip(by_star.groups.keys, by_star.groups, strict=True):
         star_co = SkyCoord(
             ra=sub_table["RA"][0], dec=sub_table["Dec"][0], unit="degree"
         )
@@ -520,7 +520,7 @@ def parse_aij_table(table_name):
         specifc_column_names = ["_".join([g, source]) for g in generic_source_columns]
         all_names = common_columns + specifc_column_names
         my_table = raw[all_names]
-        for spec, gen in zip(specifc_column_names, generic_source_columns):
+        for spec, gen in zip(specifc_column_names, generic_source_columns, strict=True):
             my_table.rename_column(spec, gen)
         stars.append(Star(my_table, idx + 1))
 

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -304,11 +304,11 @@ def single_image_photometry(
         too_close = find_too_close(
             sourcelist, aperture_settings.radius, pixel_scale=camera.pixel_scale.value
         )
-    except Exception as e:
+    except Exception as err:
         # Any failure here is BAD, so raise an error
         raise RuntimeError(
-            f"Call to find_too_close() returned {type(e).__name__}: {str(e)}"
-        )
+            f"Call to find_too_close() returned {type(err).__name__}: {str(err)}"
+        ) from err
     too_close_cnt = np.sum(too_close)
     non_overlap = ~too_close
     msg = (

--- a/stellarphot/photometry/profiles.py
+++ b/stellarphot/photometry/profiles.py
@@ -105,10 +105,10 @@ def find_center(image, center_guess, cutout_size=30, max_iters=10, match_limit=3
     ):
         try:
             sub_data = Cutout2D(image, cen, (cutout_size, cutout_size), mode="trim")
-        except NoOverlapError:
+        except NoOverlapError as err:
             raise RuntimeError(
                 f"Centroid finding failed, previous was {ceno}, current is {cen}"
-            )
+            ) from err
         _, sub_med, _ = sigma_clipped_stats(sub_data.data)
 
         mask = (sub_data.data - sub_med) < 0

--- a/stellarphot/photometry/profiles.py
+++ b/stellarphot/photometry/profiles.py
@@ -245,7 +245,9 @@ class CenterAndProfile:
         """
         radii = []
         pixel_values = []
-        for rad, ap in zip(self.radial_profile.radius, self.radial_profile.apertures):
+        for rad, ap in zip(
+            self.radial_profile.radius, self.radial_profile.apertures, strict=True
+        ):
             ap_mask = ap.to_mask(method="center")
             ap_data = ap_mask.multiply(self._data)
             good_data = ap_data != 0

--- a/stellarphot/photometry/tests/test_detection.py
+++ b/stellarphot/photometry/tests/test_detection.py
@@ -92,7 +92,7 @@ def test_detect_source_number_location():
     # Do we have the right number of sources?
     assert len(sources) == len(found_sources)
 
-    for inp, out in zip(sources, found_sources):
+    for inp, out in zip(sources, found_sources, strict=True):
         # Do the positions match?
         np.testing.assert_allclose(out["xcenter"], inp["x_mean"], rtol=1e-5, atol=0.05)
         np.testing.assert_allclose(out["ycenter"], inp["y_mean"], rtol=1e-5, atol=0.05)

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -308,7 +308,7 @@ def test_aperture_photometry_no_outlier_rejection(int_data):
     phot.sort("aperture_sum")
     sources.sort("amplitude")
 
-    for inp, out in zip(sources, phot):
+    for inp, out in zip(sources, phot, strict=True):
         stdev = inp["x_stddev"]
         expected_flux = (
             inp["amplitude"]
@@ -390,7 +390,7 @@ def test_aperture_photometry_with_outlier_rejection(reject):
     phot.sort("aperture_sum")
     sources.sort("amplitude")
 
-    for inp, out in zip(sources, phot):
+    for inp, out in zip(sources, phot, strict=True):
         stdev = inp["x_stddev"]
         expected_flux = (
             inp["amplitude"]
@@ -514,7 +514,7 @@ def test_photometry_on_directory():
     # Get noise level from the first image
     noise_dev = fake_images[0].noise_dev
 
-    for fnd, inp in zip(found_sources, sources):
+    for fnd, inp in zip(found_sources, sources, strict=True):
         star_id_chk = fnd["star_id"]
         # Select the rows in phot_data that correspond to the current star
         # and compute the average of the aperture sums.

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -100,10 +100,13 @@ class VariableArgsFitter(LevMarLSQFitter):
         self.fit_info["message"] = mess
         self.fit_info["ierr"] = ierr
         if ierr not in [1, 2, 3, 4]:
+            # apparently setting a higher stacklevel is better, see
+            # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
             warnings.warn(
                 "The fit may be unsuccessful; check "
                 "fit_info['message'] for more information.",
                 AstropyUserWarning,
+                stacklevel=2,
             )
 
         # now try to compute the true covariance matrix

--- a/stellarphot/transit_fitting/gui.py
+++ b/stellarphot/transit_fitting/gui.py
@@ -428,9 +428,9 @@ def set_values_from_json_file(widget, json_file):
         input_values = json.load(f)
 
     planet_type = widget.planet_type.value
-    for k, widget in widget.value_widget[planet_type].items():
+    for k, a_widget in widget.value_widget[planet_type].items():
         k1, k2 = k.split(join_char)
-        widget.value = input_values[k1][k2]
+        a_widget.value = input_values[k1][k2]
 
 
 def get_values_from_widget(exotic_widget, key=None):

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -63,7 +63,7 @@ def opts_to_str(opts):
     """
     opt_names = ["a", "b", "c", "d", "z"]
     names = []
-    for name, value in zip(opt_names, opts):
+    for name, value in zip(opt_names, opts, strict=True):
         names.append(f"{name}={value:.4f}")
     return ", ".join(names)
 
@@ -594,7 +594,7 @@ def transform_to_catalog(
     cat_coords = None
 
     for file, one_image_inp in zip(
-        observed_mags_grouped.groups.keys, observed_mags_grouped.groups
+        observed_mags_grouped.groups.keys, observed_mags_grouped.groups, strict=True
     ):
         one_image = one_image_inp[one_image_inp["passband"] == obs_filter]
         our_coords = SkyCoord(one_image["RA"], one_image["Dec"], unit="degree")
@@ -653,7 +653,7 @@ def transform_to_catalog(
         )
 
         # Accumulate the parameters
-        for param, value in zip(all_params, popt):
+        for param, value in zip(all_params, popt, strict=True):
             param.extend([value] * len(one_image))
 
         # Calculate and accumulate residual
@@ -688,7 +688,7 @@ def transform_to_catalog(
         ]
     opt_names = ["a", "b", "c", "d", "z"]
 
-    for name, values in zip(opt_names, all_params):
+    for name, values in zip(opt_names, all_params, strict=True):
         result[name] = values
 
     result["mag_cat"] = cat_mags


### PR DESCRIPTION
This identified a few cases where some code changes were recommended:

+ When raising an exception inside the `except` of a `try/except` block the best practice is apparently to raise the exception `from` the original error. This adds more detail to the traceback and makes it easier to identify cases where the exception is triggered by an error in the `except` block.
+ Apparently there is a `strict` argument to `zip` which generates an error if the items in the zip are not the same length. The default (which I sort of knew) behavior is to truncate the items to the length of the shortest one, which iis not what we are usually looking for.