### PR TITLE
Tidy up Camera-related tests and add a name property

### DIFF
--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -29,9 +29,12 @@ SEED = 5432985
 
 SHIFT_TOLERANCE = 6
 FWHM_ESTIMATE = 5
+
+# A camera with not unreasonable settings
 FAKE_CAMERA = Camera(
     data_unit=u.adu,
     gain=1.0 * u.electron / u.adu,
+    name="test camera",
     read_noise=0 * u.electron,
     dark_current=0.1 * u.electron / u.second,
     pixel_scale=1 * u.arcsec / u.pixel,
@@ -42,6 +45,7 @@ FAKE_CAMERA = Camera(
 ZERO_CAMERA = Camera(
     data_unit=u.adu,
     gain=1.0 * u.electron / u.adu,
+    name="test camera",
     read_noise=0 * u.electron,
     dark_current=0.0 * u.electron / u.second,
     pixel_scale=1 * u.arcsec / u.pixel,

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -29,6 +29,10 @@ class Camera(BaseModel):
         The gain of the camera in units such the product of `gain`
         times the image data has units equal to that of the `read_noise`.
 
+    name : str
+        The name of the camera; can be anything that helps the user identify
+        the camera.
+
     read_noise : `astropy.units.Quantity`
         The read noise of the camera with units.
 
@@ -52,6 +56,10 @@ class Camera(BaseModel):
     gain : `astropy.units.Quantity`
         The gain of the camera in units such the product of `gain`
         times the image data has units equal to that of the `read_noise`.
+
+    name : str
+        The name of the camera; can be anything that helps the user identify
+        the camera.
 
     read_noise : `astropy.units.Quantity`
         The read noise of the camera with units.
@@ -78,6 +86,7 @@ class Camera(BaseModel):
     >>> from stellarphot.settings import Camera
     >>> camera = Camera(data_unit="adu",
     ...                 gain=1.0 * u.electron / u.adu,
+    ...                 name="test camera",
     ...                 read_noise=1.0 * u.electron,
     ...                 dark_current=0.01 * u.electron / u.second,
     ...                 pixel_scale=0.563 * u.arcsec / u.pixel,
@@ -86,6 +95,8 @@ class Camera(BaseModel):
     Unit("adu")
     >>> camera.gain
     <Quantity 1. electron / adu>
+    >>> camera.name
+    'test camera'
     >>> camera.read_noise
     <Quantity 1. electron>
     >>> camera.dark_current
@@ -103,6 +114,7 @@ class Camera(BaseModel):
         description="unit should be consistent with data and read noise",
         examples=["1.0 electron / adu"],
     )
+    name: str
     read_noise: QuantityType = Field(
         description="unit should be consistent with dark current",
         examples=["10.0 electron"],

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -11,6 +11,7 @@ DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15)
 TEST_CAMERA_VALUES = dict(
     data_unit=u.adu,
     gain=2.0 * u.electron / u.adu,
+    name="test camera",
     read_noise=10 * u.electron,
     dark_current=0.01 * u.electron / u.second,
     pixel_scale=0.563 * u.arcsec / u.pix,
@@ -96,6 +97,7 @@ def test_camera_altunitscheck():
     camera_for_test = dict(
         data_unit=u.adu,
         gain=2.0 * u.count / u.adu,
+        name="test camera",
         read_noise=10 * u.count,
         dark_current=0.01 * u.count / u.second,
         pixel_scale=0.563 * u.arcsec / u.pix,

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -20,128 +20,72 @@ TEST_CAMERA_VALUES = dict(
 
 def test_camera_attributes():
     # Check that the attributes are set properly
-    data_unit = u.adu
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = 50000 * u.adu
-
     c = Camera(
-        data_unit=data_unit,
-        gain=gain,
-        read_noise=read_noise,
-        dark_current=dark_current,
-        pixel_scale=pixel_scale,
-        max_data_value=max_val,
+        **TEST_CAMERA_VALUES,
     )
-    assert c.data_unit == data_unit
-    assert c.gain == gain
-    assert c.dark_current == dark_current
-    assert c.read_noise == read_noise
-    assert c.pixel_scale == pixel_scale
-    assert c.max_data_value == max_val
+    assert c.dict() == TEST_CAMERA_VALUES
 
 
 def test_camera_unitscheck():
     # Check that the units are checked properly
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_adu = 50000 * u.adu
 
+    # Remove units from all of the Quantity types
+    camera_dict_no_units = {
+        k: v.value if hasattr(v, "value") else v for k, v in TEST_CAMERA_VALUES.items()
+    }
     # All 5 of the attributes after data_unit will be checked for units
     # and noted in the ValidationError message. Rather than checking
     # separately for all 5, we just check for the presence of the
     # right number of errors
     with pytest.raises(ValidationError, match="5 validation errors"):
         Camera(
-            data_unit=u.adu,
-            gain=gain.value,
-            read_noise=read_noise.value,
-            dark_current=dark_current.value,
-            pixel_scale=pixel_scale.value,
-            max_data_value=max_adu.value,
+            **camera_dict_no_units,
         )
 
 
 def test_camera_negative_max_adu():
-    # Check that the units are checked properly
-    data_unit = u.adu
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = -50000 * u.adu
+    # Check that a negative maximum data value raises an error
+    camera_for_test = TEST_CAMERA_VALUES.copy()
+    camera_for_test["max_data_value"] = -1 * camera_for_test["max_data_value"]
 
     # Make sure that a negative max_adu raises an error
     with pytest.raises(ValidationError, match="must be positive"):
         Camera(
-            data_unit=data_unit,
-            gain=gain,
-            read_noise=read_noise,
-            dark_current=dark_current,
-            pixel_scale=pixel_scale,
-            max_data_value=max_val,
+            **camera_for_test,
         )
 
 
 def test_camera_incompatible_gain_units():
-    data_unit = u.adu
-    gain = 2.0 * u.count / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = 50000 * u.adu
+    camera_for_test = TEST_CAMERA_VALUES.copy()
+    # Gain unit is incompatible with noise unit (electrons vs. counts)
+    camera_for_test["gain"] = 2.0 * u.count / u.adu
 
     # Make sure that an incompatible gain raises an error
     with pytest.raises(ValidationError, match="Gain units.*not compatible"):
         Camera(
-            data_unit=data_unit,
-            gain=gain,
-            read_noise=read_noise,
-            dark_current=dark_current,
-            pixel_scale=pixel_scale,
-            max_data_value=max_val,
+            **camera_for_test,
         )
 
 
 def test_camera_incompatible_max_val_units():
-    data_unit = u.adu
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = 50000 * u.count
+    camera_for_test = TEST_CAMERA_VALUES.copy()
+    # data unit is adu, not count
+    camera_for_test["max_data_value"] = 50000 * u.count
 
     # Make sure that an incompatible gain raises an error
     with pytest.raises(
         ValidationError, match="Maximum data value units.*not consistent"
     ):
         Camera(
-            data_unit=data_unit,
-            gain=gain,
-            read_noise=read_noise,
-            dark_current=dark_current,
-            pixel_scale=pixel_scale,
-            max_data_value=max_val,
+            **camera_for_test,
         )
 
 
 def test_camera_copy():
     # Make sure copy actually copies everything
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
+
     c = Camera(
-        data_unit=u.adu,
-        gain=gain,
-        read_noise=read_noise,
-        dark_current=dark_current,
-        pixel_scale=pixel_scale,
-        max_data_value=65535 * u.adu,
+        **TEST_CAMERA_VALUES,
     )
     c2 = c.copy()
     assert c2 == c
@@ -149,61 +93,33 @@ def test_camera_copy():
 
 def test_camera_altunitscheck():
     # Check to see that 'count' is allowed instead of 'electron'
-    data_unit = u.adu
-    gain = 2.0 * u.count / u.adu
-    read_noise = 10 * u.count
-    dark_current = 0.01 * u.count / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = 50000 * u.adu
+    camera_for_test = dict(
+        data_unit=u.adu,
+        gain=2.0 * u.count / u.adu,
+        read_noise=10 * u.count,
+        dark_current=0.01 * u.count / u.second,
+        pixel_scale=0.563 * u.arcsec / u.pix,
+        max_data_value=50000 * u.adu,
+    )
 
     c = Camera(
-        data_unit=data_unit,
-        gain=gain,
-        read_noise=read_noise,
-        dark_current=dark_current,
-        pixel_scale=pixel_scale,
-        max_data_value=max_val,
+        **camera_for_test,
     )
-    assert c.data_unit == data_unit
-    assert c.gain == gain
-    assert c.dark_current == dark_current
-    assert c.read_noise == read_noise
-    assert c.pixel_scale == pixel_scale
-    assert c.max_data_value == max_val
+    assert c.dict() == camera_for_test
 
 
 def test_camera_schema():
     # Check that we can generate a schema for a Camera and that it
     # has the right number of attributes
-    c = Camera(
-        data_unit=u.adu,
-        gain=5 * u.electron / u.adu,
-        read_noise=1 * u.electron,
-        dark_current=0.1 * u.electron / u.second,
-        pixel_scale=0.6 * u.arcsec / u.pix,
-        max_data_value=65535 * u.adu,
-    )
+    c = Camera(**TEST_CAMERA_VALUES)
     schema = c.schema()
-    assert len(schema["properties"]) == 6
+    assert len(schema["properties"]) == len(TEST_CAMERA_VALUES)
 
 
 def test_camera_json_round_trip():
     # Check that a camera can be converted to json and back
-    data_unit = u.adu
-    gain = 2.0 * u.electron / u.adu
-    read_noise = 10 * u.electron
-    dark_current = 0.01 * u.electron / u.second
-    pixel_scale = 0.563 * u.arcsec / u.pix
-    max_val = 50000 * u.adu
 
-    c = Camera(
-        data_unit=data_unit,
-        gain=gain,
-        read_noise=read_noise,
-        dark_current=dark_current,
-        pixel_scale=pixel_scale,
-        max_data_value=max_val,
-    )
+    c = Camera(**TEST_CAMERA_VALUES)
 
     c2 = Camera.parse_raw(c.json())
     assert c2 == c

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -80,6 +80,7 @@ testdata = Table(data, names=colnames, dtype=coltypes, units=colunits)
 feder_cg_16m = Camera(
     data_unit=u.adu,
     gain=1.5 * u.electron / u.adu,
+    name="Andor Aspen CG16M",
     read_noise=10.0 * u.electron,
     dark_current=0.01 * u.electron / u.second,
     pixel_scale=0.563 * u.arcsec / u.pix,


### PR DESCRIPTION
My original intent here was to just a dd a name property; that allows storing at least a little information that is human-readable to identify the camera if looking at the settings much later.

Since that would have meant many, many changes to the tests I first rewrote the tests a bit so that `Camera` only needed to be changed for the new property in one or two places.

I think that ended up making the tests a little bit clearer because it is now more explicit what property of the camera is being changed/modified in a particular ttest.