### PR TITLE
Use FileChooser from ipyautoui

### DIFF
--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -380,7 +380,7 @@ class ComparisonViewer:
         self._show_labels_button.observe(self._show_label_button_handler, names="value")
         self._save_var_info.on_click(self._save_variables_to_file)
         self._save_aperture_file.on_click(self._save_aperture_to_file)
-        self._file_chooser.register_callback(self._set_file)
+        self._file_chooser.file_chooser.observe(self._set_file, names="_value")
         self.tess_save_toggle.observe(self._save_toggle_action, "value")
         self.save_files.on_click(self.save_tess_files)
 

--- a/stellarphot/gui_tools/fits_opener.py
+++ b/stellarphot/gui_tools/fits_opener.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from astropy.io import fits
 from astropy.nddata import CCDData
-from ipyfilechooser import FileChooser
+from ipyautoui.custom import FileChooser
 
 __all__ = ["FitsOpener"]
 
@@ -27,7 +27,7 @@ class FitsOpener:
 
     ccd : `astropy.nddata.CCDData`
 
-    file_chooser : `ipyfilechooser.FileChooser`
+    file_chooser : `ipyautoui.FileChooser`
 
     header : `astropy.io.fits.Header`
 
@@ -47,7 +47,7 @@ class FitsOpener:
         self._header = {}
         self._selected_cache = self._fc.selected
         self.object = ""
-        self.register_callback(lambda _: None)
+        self._fc.observe(self._set_header, names="_value")
 
     @property
     def file_chooser(self):
@@ -78,7 +78,7 @@ class FitsOpener:
         """
         return Path(self._fc.selected)
 
-    def _set_header(self):
+    def _set_header(self, _=None):
         if not self._header or self._fc.selected != self._selected_cache:
             self._selected_cache = self._fc.selected
             try:
@@ -90,27 +90,6 @@ class FitsOpener:
             self.object = self._header["object"]
         except KeyError:
             pass
-
-    def register_callback(self, callable):
-        """
-        Register a callback that is called when the value changes. This is
-        the alternative to observing a value, which is not implemented for
-        some reason. Only one callback function is allowed.
-
-        This wraps the user-supplied callable to also update the header.
-
-        Parameters
-        ----------
-
-        callable : function
-            A function that takes one argument.
-        """
-
-        def wrap_call(change):
-            self._set_header()
-            callable(change)
-
-        self._fc.register_callback(wrap_call)
 
     def load_in_image_widget(self, image_widget):
         """

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -299,7 +299,7 @@ class SeeingProfileWidget:
         self.aperture_settings_file_name.observe(
             self._change_aperture_save_location, names="value"
         )
-        self.fits_file.register_callback(self._update_file)
+        self.fits_file.file_chooser.observe(self._update_file, names="_value")
         self.save_toggle.observe(self._save_toggle_action, names="value")
         self.save_seeing.on_click(self._save_seeing_plot)
         self.setting_box.planet_num.observe(self._set_seeing_profile_name)

--- a/stellarphot/notebooks/photometry/06-transit-fit-template.ipynb
+++ b/stellarphot/notebooks/photometry/06-transit-fit-template.ipynb
@@ -53,7 +53,7 @@
     "    passband.disabled = False\n",
     "    passband.value = passband.options[0]\n",
     "\n",
-    "fo.register_callback(update_filter_list)\n",
+    "fo.file_chooser.observe(update_filter_list, names=\"_value\")\n",
     "box.children = [fo.file_chooser, fo2.file_chooser, passband]\n",
     "box\n"
    ]


### PR DESCRIPTION
Fixes #247. The `FileChooser` from `ipyautoui` is a little closer to a standard widget in terms of how it handles adding observers to changes in its value.