### PR TITLE
Properly set title in FitsOpener

### DIFF
--- a/stellarphot/gui_tools/fits_opener.py
+++ b/stellarphot/gui_tools/fits_opener.py
@@ -38,7 +38,10 @@ class FitsOpener:
     """
 
     def __init__(self, title="Choose an image", filter_pattern=None, **kwargs):
-        self._fc = FileChooser(title=title, **kwargs)
+        # ipyautoui.FileChooser doesn't have a title attribute, so we have to
+        # add it after creating the widget
+        self._fc = FileChooser(**kwargs)
+        self._fc.title = title
         if not filter_pattern:
             self._fc.filter_pattern = ["*.fit*", "*.fit*.[bg]z"]
         else:

--- a/stellarphot/gui_tools/tests/test_fits_opener.py
+++ b/stellarphot/gui_tools/tests/test_fits_opener.py
@@ -1,0 +1,6 @@
+from stellarphot.gui_tools import FitsOpener
+
+
+def test_fits_opener_title():
+    opener = FitsOpener(title="Choose an image")
+    assert opener.file_chooser.title == "Choose an image"


### PR DESCRIPTION
Turns out #255 introduced a bug, because the ipyautoui FileChooser discards the title argument in its initializer.