### PR TITLE
Switch to the pydata sphinx theme

### DIFF
--- a/docs/_static/astropy.css
+++ b/docs/_static/astropy.css
@@ -1,0 +1,86 @@
+/* Copied from astropy repo */
+/* Main page overview cards */
+
+.sd-card {
+  background: #fff;
+  border-radius: 0;
+  padding: 30px 10px 20px 10px;
+  margin: 10px 0px;
+}
+
+.sd-card .sd-card-header {
+  text-align: center;
+}
+
+.sd-card .sd-card-header .sd-card-text {
+  margin: 0px;
+}
+
+.sd-card .sd-card-img-top {
+  height: 52px;
+  width: 52px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.sd-card .sd-card-header {
+  border: none;
+  background-color: white;
+  color: #150458 !important;
+  font-size: var(--pst-font-size-h5);
+  font-weight: bold;
+  padding: 2.5rem 0rem 0.5rem 0rem;
+}
+
+.sd-card .sd-card-footer {
+  border: none;
+  background-color: white;
+}
+
+.sd-card .sd-card-footer .sd-card-text {
+  max-width: 220px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Dark theme tweaking */
+html[data-theme=dark] .sd-card img[src*='.svg'] {
+    filter: invert(0.82) brightness(0.8) contrast(1.2);
+}
+
+/* Main index page overview cards */
+html[data-theme=dark] .sd-card {
+  background-color:var(--pst-color-background);
+}
+
+html[data-theme=dark] .sd-shadow-sm {
+    box-shadow: 0 .1rem 1rem rgba(250, 250, 250, .6) !important
+}
+
+html[data-theme=dark] .sd-card .sd-card-header {
+  background-color:var(--pst-color-background);
+  color: #150458 !important;
+}
+
+html[data-theme=dark] .sd-card .sd-card-footer {
+  background-color:var(--pst-color-background);
+}
+
+html[data-theme=dark] h1 {
+  color: var(--pst-color-primary);
+}
+
+html[data-theme=dark] h3 {
+  color: #0a6774;
+}
+
+/* Flip the colours on graphviz graphs on dark mode */
+html[data-theme="dark"] div.graphviz > object.inheritance {
+  filter: invert(0.82) brightness(0.8) contrast(1.2);
+}
+html[data-theme="dark"] div.graphviz > object.graphviz {
+  filter: invert(0.82) brightness(0.8) contrast(1.2);
+}
+html[data-theme="dark"] ul.cooframelegend {
+  filter: invert(0.82) brightness(0.8) contrast(1.2);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,13 +29,12 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-try:
-    from sphinx_astropy.conf.v1 import *  # noqa
-except ImportError:
-    print(
-        "ERROR: the documentation requires the sphinx-astropy package to be installed"
-    )
-    sys.exit(1)
+from sphinx_astropy.conf.v2 import *  # noqa: E402, F403
+from sphinx_astropy.conf.v2 import (  # noqa: E402
+    exclude_patterns,
+    html_theme_options,
+    rst_epilog,
+)
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
@@ -88,6 +87,10 @@ version = package.__version__.split("-", 1)[0]
 # The full version, including alpha/beta/rc tags.
 release = package.__version__
 
+# Only include dev docs in dev version.
+dev = "dev" in release
+if not dev:
+    exclude_patterns += ["development/*"]
 
 # -- Options for HTML output --------------------------------------------------
 
@@ -108,13 +111,29 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 # html_theme = None
 
+html_theme_options.update(
+    {
+        "github_url": "https://github.com/feder-observatory/stellarphot",
+        "use_edit_page_button": True,
+        # "logo": {
+        #     "image_light": "_static/astropy_banner_96.png",
+        #     "image_dark": "_static/astropy_banner_96_dark.png",
+        # },
+        # https://github.com/pydata/pydata-sphinx-theme/issues/1492
+        "navigation_with_keys": False,
+    }
+)
 
-html_theme_options = {
-    "logotext1": "stellarphot",  # white,  semi-bold
-    "logotext2": "",  # orange, light
-    "logotext3": ":docs",  # white,  light
+# A dictionary of values to pass into the template engine's context for all pages.
+html_context = {
+    "default_mode": "dark",
+    "to_be_indexed": ["stable", "latest"],
+    "is_development": dev,
+    "github_user": "feder-observatory",
+    "github_repo": "stellarphot",
+    "github_version": "main",
+    "doc_path": "docs",
 }
-
 
 # Custom sidebar templates, maps document names to template names.
 # html_sidebars = {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,8 +135,7 @@ html_context = {
     "doc_path": "docs",
 }
 
-# Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+html_css_files = ["astropy.css"]
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
     "sphinx",
-    "sphinx-astropy",
+    "sphinx-astropy[confv2]",
     "graphviz",
 ]
 exo_fitting = [

--- a/stellarphot/version.py
+++ b/stellarphot/version.py
@@ -3,12 +3,12 @@ try:
     from importlib_metadata import PackageNotFoundError
     from importlib_metadata import version as _version
 
-    version = _version("my-package")
+    version = _version("stellarphot")
 except ImportError:
     from pkg_resources import DistributionNotFound, get_distribution
 
     try:
-        version = get_distribution("my-package").version
+        version = get_distribution("stellarphot").version
     except DistributionNotFound:
         pass
 except PackageNotFoundError:


### PR DESCRIPTION
This theme was recently adopted by astropy and is pretty widely used by other large projects. Seemed better to switch pre-release rather than post-release.

Marking this as a draft for now because ~~I need to copy over some CSS from astropy, I think...~~

Copied that over, still want to look at how they do the card setup here: astropy.rtfd.io