### PR TITLE
Add more tests of our pydantic models prior to upgrading to pydantic 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,4 +153,6 @@ filterwarnings = [
     'ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning',
     # ipywidgets or ipyautoui generates this warning...
     'ignore:Passing unrecognized arguments to super:DeprecationWarning',
+    # pandas will require pyarrow at some point, which is good to know, I guess...
+    'ignore:[.\n]*Pyarrow will become a required dependency of pandas[.\n]*:DeprecationWarning',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,4 +151,6 @@ filterwarnings = [
     'ignore:metadata \{.+\} was set from the constructor:DeprecationWarning',
     # Generated from batman
     'ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning',
+    # ipywidgets or ipyautoui generates this warning...
+    'ignore:Passing unrecognized arguments to super:DeprecationWarning',
 ]

--- a/stellarphot/gui_tools/fits_opener.py
+++ b/stellarphot/gui_tools/fits_opener.py
@@ -128,3 +128,4 @@ class FitsOpener:
 
         self._fc.reset(directory, file)
         self._fc._apply_selection()
+        self._fc._value = self._fc.selected

--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -358,7 +358,9 @@ class SeeingProfileWidget:
                 x = int(np.floor(event.data_x))
                 y = int(np.floor(event.data_y))
 
-                rad_prof = CenterAndProfile(data, (x, y), profile_radius=profile_size)
+                rad_prof = CenterAndProfile(
+                    data, (x, y), profile_radius=profile_size, cutout_size=profile_size
+                )
 
                 try:
                     try:  # Remove previous marker
@@ -387,6 +389,7 @@ class SeeingProfileWidget:
                     radius=aperture_radius,
                     gap=default_gap,
                     annulus_width=default_annulus_width,
+                    fwhm=rad_prof.FWHM,
                 )
                 update_aperture_settings = True
             else:

--- a/stellarphot/gui_tools/tests/test_comparison_functions.py
+++ b/stellarphot/gui_tools/tests/test_comparison_functions.py
@@ -1,0 +1,83 @@
+import warnings
+
+import ipywidgets as ipw
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.nddata import CCDData
+from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyWarning
+from astropy.wcs import WCS
+from astropy.wcs.wcs import FITSFixedWarning
+
+from stellarphot.gui_tools import comparison_functions as cf
+
+CCD_SHAPE = [2048, 3073]
+
+
+def test_comparison_object_creation():
+    # This test simply makes sure we can create the object
+    comparison_widget = cf.ComparisonViewer()
+    assert isinstance(comparison_widget.box, ipw.Box)
+
+
+@pytest.mark.remote_data
+def test_comparison_properties(tmp_path):
+    # Test that we can load a file...
+    wcs_file = get_pkg_data_filename("../../tests/data/sample_wcs_ey_uma.fits")
+    with fits.open(wcs_file) as hdulist:
+        with warnings.catch_warnings():
+            # Ignore the warning about the WCS having a different number of
+            # axes than the (non-existent) image.
+            warnings.filterwarnings(
+                "ignore",
+                message="The WCS transformation has more",
+                category=FITSFixedWarning,
+            )
+            wcs = WCS(hdulist[0].header)
+    wcs.pixel_shape = list(reversed(CCD_SHAPE))
+    ccd = CCDData(data=np.zeros(CCD_SHAPE), wcs=wcs, unit="adu")
+    # Set the object name to the star in this field, EY UMa
+    ccd.header["object"] = "EY UMa"
+    file_name = "test.fits"
+    ccd.write(tmp_path / file_name, overwrite=True)
+    with warnings.catch_warnings():
+        # Ignore the warning about the WCS having non-standard keywords (the SIP
+        # distortion parameters).
+        warnings.filterwarnings(
+            "ignore",
+            message="Some non-standard WCS keywords were excluded",
+            category=AstropyWarning,
+        )
+        comparison_widget = cf.ComparisonViewer(directory=tmp_path, file=str(file_name))
+
+    # Check that we have some variables in this field of view, which contains the
+    # variable star EY UMa
+    assert len(comparison_widget.variables) > 0
+
+    # Check that we have APASS stars too
+    table = comparison_widget.generate_table()
+    assert "APASS comparison" in table["marker name"]
+
+    # Check that is we show labels then the label names we expect show up in
+    # the astrowidgets marker table.
+    comparison_widget.show_labels()
+
+    # Supress a warning about the default marker set containing no stars
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Marker set named.*is empty",
+            category=UserWarning,
+        )
+        label_markers = comparison_widget.iw.get_markers(
+            marker_name=comparison_widget._label_name
+        )
+    # There should be a label for each star, so check that the number of labels matches
+    # the length of the table of stars excluding the labels.
+    table = comparison_widget.generate_table()
+
+    # Drop table entries that are labels
+    table = table[table["marker name"] != comparison_widget._label_name]
+
+    assert len(label_markers) == len(table)

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -251,7 +251,8 @@ class PhotometryApertures(BaseModel):
     radius: conint(ge=1) = Field(autoui=CustomBoundedIntTex, default=1)
     gap: conint(ge=1) = Field(autoui=CustomBoundedIntTex, default=1)
     annulus_width: conint(ge=1) = Field(autoui=CustomBoundedIntTex, default=1)
-    fwhm: confloat(gt=0)
+    # Disable the UI element by default because it is often calculate from an image
+    fwhm: confloat(gt=0) = Field(disabled=True, default=1.0)
 
     class Config:
         validate_assignment = True


### PR DESCRIPTION
I think I know how to upgrade to pydantic 2 now, but before I do that PR I thought it was prudent to write more tests of our pydantic models and their uses in notebooks. 

If you have a chance to look at this, @JuanCab, great, but I think it is fine to self-merge since this mostly adds tests.

The tests I wrote did uncover a couple bugs -- places where we hadn't properly added handling of the new `FWHM` property on `PhotometryApertures`.