### PR TITLE
Add an Observatory class

### DIFF
--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -278,7 +278,7 @@ class ComparisonViewer:
 
     def _init(self):
         """
-        Handles aspects of initialization that need to be defered until
+        Handles aspects of initialization that need to be deferred until
         a file is chosen.
         """
         if self.tess_submission is not None:
@@ -365,10 +365,10 @@ class ComparisonViewer:
                 planet=1,
             )
         except ValueError:
-            # Guess not, time to turn on the coordinates box
-            # self._turn_on_coordinates()
+            # Not a TESS object, so turn off the TESS interface
             _settings_for_no_tess()
         else:
+            # This is a TESS object, so set up the TESS interface
             self.tess_save_toggle.disabled = False
             self.tess_save_toggle.layout.visibility = "visible"
             self.toi_info = TOI(self.tess_submission.tic_id)

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -195,6 +195,13 @@ class ComparisonViewer:
     overwrite_outputs: bool, optional
         Whether to overwrite existing output files. Defaults to True.
 
+    observatory : `stellarphot.settings.Observatory`, optional
+        Observatory information. If this is set and the observatory has
+        a `stellarphot.settings.Observatory.TESS_telescope_code` attribute,
+        then the TESS submission information will be extracted from the header
+        and a button will appear to save images of the field for a TESS
+        submission.
+
     Attributes
     ----------
 
@@ -242,6 +249,7 @@ class ComparisonViewer:
         object_coordinate=None,
         photom_apertures_file=None,
         overwrite_outputs=True,
+        observatory=None,
     ):
         self._label_name = "labels"
         self._circle_name = "target circle"
@@ -255,6 +263,7 @@ class ComparisonViewer:
         self.tess_submission = None
         self._tess_object_info = None
         self.target_coord = object_coordinate
+        self.observatory = observatory
 
         self.box, self.iw = self._viewer()
 
@@ -332,12 +341,7 @@ class ComparisonViewer:
         except NameResolveError:
             pass
 
-        # Maybe this is a tess object?
-        try:
-            self.tess_submission = TessSubmission.from_header(
-                self._file_chooser.header, telescope_code="Paul-P-Feder-0.4m", planet=1
-            )
-        except ValueError:
+        def _settings_for_no_tess():
             # Guess not, time to turn on the coordinates box
             # self._turn_on_coordinates()
             self.tess_submission = None
@@ -346,8 +350,27 @@ class ComparisonViewer:
             self._tess_object_info.layout.visibility = "hidden"
             self.tess_save_toggle.value = False
             self.tess_save_toggle.disabled = True
+            self.tess_save_toggle.layout.visibility = "hidden"
+
+        # Maybe this is a tess object?
+
+        if self.observatory is None or self.observatory.TESS_telescope_code is None:
+            _settings_for_no_tess()
+            return
+
+        try:
+            self.tess_submission = TessSubmission.from_header(
+                self._file_chooser.header,
+                telescope_code=self.observatory.TESS_telescope_code,
+                planet=1,
+            )
+        except ValueError:
+            # Guess not, time to turn on the coordinates box
+            # self._turn_on_coordinates()
+            _settings_for_no_tess()
         else:
             self.tess_save_toggle.disabled = False
+            self.tess_save_toggle.layout.visibility = "visible"
             self.toi_info = TOI(self.tess_submission.tic_id)
 
             self._target_file_info = TessTargetFile(
@@ -484,11 +507,14 @@ class ComparisonViewer:
         self.tess_save_toggle = ipw.ToggleButton(
             description="TESS files...", disabled=True
         )
+        self.tess_save_toggle.layout.visibility = "hidden"
         self._tess_save_box = ipw.VBox()
         self._tess_save_box.layout.visibility = "hidden"
 
+        tess_scope = self.observatory.TESS_telescope_code if self.observatory else None
+        tess_scope = "" if tess_scope is None else tess_scope
         scope_name = ipw.Text(
-            description="Telescope code", value="Paul-P-Feder-0.4m", style=DESC_STYLE
+            description="Telescope code", value=tess_scope, style=DESC_STYLE
         )
 
         planet_num = ipw.IntText(description="Planet", value=1)

--- a/stellarphot/gui_tools/tests/test_comparison_functions.py
+++ b/stellarphot/gui_tools/tests/test_comparison_functions.py
@@ -81,3 +81,10 @@ def test_comparison_properties(tmp_path):
     table = table[table["marker name"] != comparison_widget._label_name]
 
     assert len(label_markers) == len(table)
+
+
+def test_no_tess_buttons_at_init():
+    # Make sure TESS controls are not displayed initially
+    comparison_widget = cf.ComparisonViewer()
+    assert comparison_widget.tess_save_toggle.layout.visibility == "hidden"
+    assert comparison_widget._tess_object_info.layout.visibility == "hidden"

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Annotated
 
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader
 from astropy.time import Time
 from astropy.units import Quantity, Unit
@@ -22,9 +22,16 @@ from .astropy_pydantic import (
     QuantityType,
     UnitType,
     WithPhysicalType,
+    _UnitQuantTypePydanticAnnotation,
 )
 
-__all__ = ["Camera", "PhotometryApertures", "PhotometryFileSettings", "Exoplanet"]
+__all__ = [
+    "Camera",
+    "PhotometryApertures",
+    "PhotometryFileSettings",
+    "Exoplanet",
+    "Observatory",
+]
 
 # Most models should use the default configuration, but it can be customized if needed.
 MODEL_DEFAULT_CONFIGURATION = ConfigDict(
@@ -37,7 +44,61 @@ MODEL_DEFAULT_CONFIGURATION = ConfigDict(
 )
 
 
-class Camera(BaseModel):
+def add_degree_to_float(value, _handler):
+    """
+    Translate a value that can be a number to a string with "degree" appended.
+    """
+    try:
+        as_number = float(value)
+    except (ValueError, TypeError):
+        # A value error will happen if the value is not a number.
+        # A type error will happen at least in the case where the value is
+        # an astropy Quantity.
+        return value
+    else:
+        return f"{as_number} degree"
+
+
+class BaseModelWithTableRep(BaseModel):
+    """
+    Class to add to a pydantic model YAML serialization to an Astropy table.
+    """
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, **kwargs)
+        self.generate_table_representers()
+
+    def generate_table_representers(self):
+        """
+        Call this method during initialization of a class to add the YAML
+        Table representation for the class.
+        """
+        class_string = f"!{self.__class__.__name__}"
+
+        # Add YAML round-tripping for the model
+        def _representer(dumper, model):
+            # THIS SHOULD TAP INTO ASTROPY'S YAML DUMPER SOMEHOW
+            # This is a little hacky at the moment. It seems like YAML
+            # has trouble reading in a dictionary, so though model.model_dump()
+            # works fine for writing, we can't construct from the dump.
+            #
+            # Instead of figuring out the right way to do that, this just dumps
+            # the json representation as a string.
+            return dumper.represent_mapping(
+                class_string, {"model_json_string": model.model_dump_json()}
+            )
+
+        def _constructor(loader, node):
+            # This loads the simple dictionary we dumped in _representer,
+            # then initializes the model with the json string.
+            mapping = loader.construct_mapping(node)
+            return self.__class__.model_validate_json(mapping["model_json_string"])
+
+        AstropyDumper.add_representer(self.__class__, _representer)
+        AstropyLoader.add_constructor(class_string, _constructor)
+
+
+class Camera(BaseModelWithTableRep):
     """
     A class to represent a CCD-based camera.
 
@@ -202,20 +263,7 @@ class Camera(BaseModel):
         return self
 
 
-# Add YAML round-tripping for Camera
-def _camera_representer(dumper, cam):
-    return dumper.represent_mapping("!Camera", cam.model_dump())
-
-
-def _camera_constructor(loader, node):
-    return Camera(**loader.construct_mapping(node))
-
-
-AstropyDumper.add_representer(Camera, _camera_representer)
-AstropyLoader.add_constructor("!Camera", _camera_constructor)
-
-
-class PhotometryApertures(BaseModel):
+class PhotometryApertures(BaseModelWithTableRep):
     """
     Settings for aperture photometry.
 
@@ -290,7 +338,7 @@ class PhotometryApertures(BaseModel):
         return self.inner_annulus + self.annulus_width
 
 
-class PhotometryFileSettings(BaseModel):
+class PhotometryFileSettings(BaseModelWithTableRep):
     """
     An evolutionary step on the way to having a monolithic set of photometry settings.
     """
@@ -308,7 +356,59 @@ class PhotometryFileSettings(BaseModel):
     )
 
 
-class Exoplanet(BaseModel):
+class Observatory(BaseModelWithTableRep):
+    """
+    Class to represent an observatory.
+
+    Parameters
+    ----------
+    name : str
+        Name of the observatory.
+
+    latitude : `astropy.coordinates.Latitude` or other valid latitude representation
+        Latitude of the observatory. Use a positive number for north and negative
+        for south.
+
+    longitude : `astropy.coordinates.Longitude` or other valid longitude representation
+        Longitude of the observatory. Use a positive number for east and negative
+        for west.
+
+    elevation : `astropy.units.Quantity`
+        Elevation of the observatory.
+
+    AAVSO_code : str, optional
+        AAVSO observer code.
+
+    TESS_telescope_code : str, optional
+        TESS telescope code.
+    """
+
+    model_config = MODEL_DEFAULT_CONFIGURATION
+
+    name: str
+    latitude: Annotated[
+        Latitude, _UnitQuantTypePydanticAnnotation, BeforeValidator(add_degree_to_float)
+    ]
+    longitude: Annotated[
+        Longitude,
+        _UnitQuantTypePydanticAnnotation,
+        BeforeValidator(add_degree_to_float),
+    ]
+    elevation: Annotated[QuantityType, WithPhysicalType("length")]
+    AAVSO_code: str | None = None
+    TESS_telescope_code: str | None = None
+
+    @lazyproperty
+    def earth_location(self):
+        """
+        Return an `astropy.coordinates.EarthLocation` object for the observatory.
+        """
+        return EarthLocation(
+            lat=self.latitude, lon=self.longitude, height=self.elevation
+        )
+
+
+class Exoplanet(BaseModelWithTableRep):
     """
     Create an object representing an Exoplanet.
 

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -7,8 +7,10 @@ from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader
 from astropy.time import Time
 from astropy.units import Quantity, Unit
+from astropy.utils import lazyproperty
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     PositiveFloat,


### PR DESCRIPTION
This pull request 

- adds an Observatory class
- Moves the functionality needed to serialize models to an astropy table into a base class on which others build
- Consolidates a bunch of tests into a test class that is parameterized with the models defined in the code
- Uses the `Observatory` class in a couple of cases to replace Feder-specific code

A couple comments about the motivation for adding the Observatory class, and at least one alternative I looked at:

+ Right now we represent an observatory with an `EarthLocation`. There is some additional information, like AAVSO observer code and TESS designation that it makes sense to me to include in an observatory definition.
+ I started with an `EarthLocation` as one of the properties of `Observatory` but had trouble getting that to work with auto-generation of a widgets UI to enter it, so I went with taking lat, long and altitude as input and providing a property with the `EarthLocation`.
+ I looked at the [`Observer` class](https://astroplan.readthedocs.io/en/stable/api/astroplan.Observer.html#astroplan.Observer) from astroplan. That has much more than we need, some of which might be useful, but would mean adding a new dependency and I wasn't sure how it would work with pydantic. One thought is to offer it as a property with astroplan as an optional dependency. Or we just punt the whole issue down the road.

@JuanCab -- if it is possible to do this oen this week that would be great, but if not let me know. 

Fixes #98 