### PR TITLE
Format required columns as RST tables for type in core

### DIFF
--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -307,7 +307,8 @@ class PhotometryData(BaseEnhancedTable):
     simply means it can be any unit, but it must be the same for all the columns with
     'consistent count units'.
 
-    name                  unit
+    =================     =======
+    Column name           Unit
     -----------------     -------
     star_id               None
     RA                    u.deg
@@ -338,6 +339,7 @@ class PhotometryData(BaseEnhancedTable):
     airmass               None
     passband              None
     file                  None
+    =================     =======
 
     In addition to these required columns, the following columns are created based
     on the input data during creation.
@@ -624,13 +626,15 @@ class CatalogData(BaseEnhancedTable):
 
     input_data MUST contain the following columns with the following units:
 
-    name                  unit
+    =================     =======
+    Column Name           Unit
     -----------------     -------
     id                    None
     ra                    u.deg
     dec                   u.deg
     mag                   None
     passband              None
+    =================     =======
     """
 
     # Define columns that must be in table and provide information about their type, and
@@ -1102,23 +1106,29 @@ class SourceListData(BaseEnhancedTable):
 
     input_data MUST contain the following columns in the following column:
 
-    name                  unit
+    =================     =======
+    Column Name           Unit
     -----------------     -------
     star_id               None
+    =================     =======
 
     In addition to the star_id columns you must have EITHER
 
-    name                  unit
+    =================     =======
+    Column Name           Unit
     -----------------     -------
     ra                    u.deg
     dec                   u.deg
+    =================     =======
 
     and/or
 
-    name                  unit
+    =================     =======
+    Column Name           Unit
     -----------------     -------
     xcenter               u.pix
     ycenter               u.pix
+    =================     =======
 
     to define the locations of the sources.  If one locaton pair is provided but not
     the other, the missing columns will be added but assigned NaN values.  It is ok


### PR DESCRIPTION
Currently, the docstrings of `PhotometryData`, `CatalogData`, and `SourceList` each contain a list of required columns. These render in the documentation quite badly. The list is in the yellow box below:

<img width="858" alt="PhotometryData_—_stellarphot_v0_1_dev233_g383d1c1_d20240205" src="https://github.com/feder-observatory/stellarphot/assets/1147167/8504bcab-8acb-4cad-8119-b615135a40f9">

This pull request formats these as rst tables by adding a few equal signs here and there. After this, the same section of the documentation will look like this:

<img width="599" alt="PhotometryData_—_stellarphot_v1_3_10_dev590_g383d1c1_d20240206" src="https://github.com/feder-observatory/stellarphot/assets/1147167/510e8135-a91c-46d9-854f-4e129b092584">

@JuanCab, I'll self-merge this unless you object....