### PR TITLE
Rearrange photometry settings and add object for photometry options

### DIFF
--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -589,7 +589,7 @@ def multi_image_photometry(
     sourcelist,
     camera,
     observatory_location,
-    photometry_settings,
+    photometry_apertures,
     shift_tolerance,
     include_dig_noise=True,
     reject_too_close=True,
@@ -631,7 +631,7 @@ def multi_image_photometry(
         Location of the observatory where the images were taken.  Used for calculating
         the BJD.
 
-    photometry_settings : `stellarphot.settings.PhotometryApertures`
+    photometry_apertures : `stellarphot.settings.PhotometryApertures`
         Radius, inner and outer annulus radii settings and FWHM.
 
     shift_tolerance : float
@@ -772,7 +772,7 @@ def multi_image_photometry(
             sourcelist,
             camera,
             observatory_location,
-            photometry_settings,
+            photometry_apertures,
             shift_tolerance,
             use_coordinates="sky",
             include_dig_noise=include_dig_noise,

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -83,7 +83,8 @@ def single_image_photometry(
         Radius, inner and outer annulus radii settings and FWHM.
 
     photometry_options : `stellarphot.settings.PhotometryOptions`
-        Several options for the details of performing the photometry.
+        Several options for the details of performing the photometry. See the
+        documentation for `~stellarphot.settings.PhotometryOptions` for details.
 
     passband_map: dict, optional (Default: None)
         A dictionary containing instrumental passband names as keys and
@@ -581,7 +582,8 @@ def multi_image_photometry(
         Radius, inner and outer annulus radii settings and FWHM.
 
     photometry_options : `stellarphot.settings.PhotometryOptions`
-        Several options for the details of performing the photometry.
+        Several options for the details of performing the photometry. See the
+        documentation for `~stellarphot.settings.PhotometryOptions` for details.
 
     passband_map: dict, optional (Default: None)
         A dictionary containing instrumental passband names as keys and

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -45,12 +45,12 @@ def single_image_photometry(
     include_dig_noise=True,
     reject_too_close=True,
     reject_background_outliers=True,
-    passband_map=None,
     fwhm_by_fit=True,
-    fname=None,
-    logline="single_image_photometry:",
     logfile=None,
     console_log=True,
+    passband_map=None,
+    fname=None,
+    logline="single_image_photometry:",
 ):
     """
     Perform aperture photometry on a single image, with an options for estimating
@@ -99,35 +99,23 @@ def single_image_photometry(
         positions in the sourcelist and the WCS of the `ccd_image` to
         compute the x/y positions on the image.
 
-    reject_background_outliers : bool, optional (Default: True)
-        If ``True``, sigma clip the pixels in the annulus to reject outlying
-        pixels (e.g. like stars in the annulus)
-
-    reject_too_close : bool, optional (Default: True)
-        If ``True``, any sources that are closer than twice the aperture radius
-        are rejected.  If ``False``, all sources in field are used.
-
     include_dig_noise : bool, optional (Default: True)
         If ``True``, include the digitization noise in the calculation of the
         noise for each observation.  If ``False``, only the Poisson noise from
         the source and the sky will be included.
 
-    passband_map: dict, optional (Default: None)
-        A dictionary containing instrumental passband names as keys and
-        AAVSO passband names as values. This is used to rename the passband
-        entries in the output photometry table to be AAVSO standard versus
-        whatever is in the source list.
+    reject_too_close : bool, optional (Default: True)
+        If ``True``, any sources that are closer than twice the aperture radius
+        are rejected.  If ``False``, all sources in field are used.
+
+    reject_background_outliers : bool, optional (Default: True)
+        If ``True``, sigma clip the pixels in the annulus to reject outlying
+        pixels (e.g. like stars in the annulus)
 
     fwhm_by_fit : bool, optional (default: True)
         If ``True``, the FWHM will be calculated by fitting a Gaussian to
         the star. If ``False``, the FWHM will be calculated by finding the
         second moments of the light distribution. Default is ``True``.
-
-    fname : str, optional ()
-        Name of the image file on which photometry is being performed.
-
-    logline : str, optional (Default: "single_image_photometry:")
-        String to prepend to all log messages.
 
     logfile : str, optional (Default: None)
         Name of the file to which log messages should be written.  If None,
@@ -137,6 +125,18 @@ def single_image_photometry(
         If ``True`` and `logfile` is set, log messages will also be written to
         stdout.  If ``False``, log messages will not be written to stdout
         if `logfile` is set.
+
+    passband_map: dict, optional (Default: None)
+        A dictionary containing instrumental passband names as keys and
+        AAVSO passband names as values. This is used to rename the passband
+        entries in the output photometry table to be AAVSO standard versus
+        whatever is in the source list.
+
+    fname : str, optional (Default: None)
+        Name of the image file on which photometry is being performed.
+
+    logline : str, optional (Default: "single_image_photometry:")
+        String to prepend to all log messages.
 
     Returns
     -------
@@ -595,11 +595,11 @@ def multi_image_photometry(
     include_dig_noise=True,
     reject_too_close=True,
     reject_background_outliers=True,
-    reject_unmatched=True,
-    passband_map=None,
     fwhm_by_fit=True,
     logfile=None,
     console_log=True,
+    passband_map=None,
+    reject_unmatched=True,
 ):
     """
     Perform aperture photometry on a directory of images.
@@ -650,30 +650,18 @@ def multi_image_photometry(
         positions in the sourcelist and the WCS of the `ccd_image` to
         compute the x/y positions on the image.
 
-    reject_background_outliers : bool, optional (Default: True)
-        If ``True``, sigma clip the pixels in the annulus to reject outlying
-        pixels (e.g. like stars in the annulus)
-
-    reject_too_close : bool, optional (Default: True)
-        If ``True``, any sources that are closer than twice the aperture radius
-        are rejected.  If ``False``, all sources in field are used.
-
-    reject_unmatched : bool, optional (Default: True)
-        If ``True``, any sources that are not detected on all the images are
-        rejected.  If you are interested in a source that can intermittently
-        fall below your detection limits, we suggest setting this to ``False``
-        so that all sources detected on each image are reported.
-
     include_dig_noise : bool, optional (Default: True)
         If ``True``, include the digitization noise in the calculation of the
         noise for each observation.  If ``False``, only the Poisson noise from
         the source and the sky will be included.
 
-    passband_map: dict, optional (Default: None)
-        A dictionary containing instrumental passband names as keys and
-        AAVSO passband names as values. This is used to rename the passband
-        entries in the output photometry table to be AAVSO standard versus
-        whatever is in the source list.
+    reject_too_close : bool, optional (Default: True)
+        If ``True``, any sources that are closer than twice the aperture radius
+        are rejected.  If ``False``, all sources in field are used.
+
+    reject_background_outliers : bool, optional (Default: True)
+        If ``True``, sigma clip the pixels in the annulus to reject outlying
+        pixels (e.g. like stars in the annulus)
 
     fwhm_by_fit : bool, optional (default: True)
         If ``True``, the FWHM will be calculated by fitting a Gaussian to
@@ -689,6 +677,18 @@ def multi_image_photometry(
         If ``True`` and `logfile` is set, log messages will also be written to
         stdout.  If ``False``, log messages will not be written to stdout
         if `logfile` is set.
+
+    passband_map: dict, optional (Default: None)
+        A dictionary containing instrumental passband names as keys and
+        AAVSO passband names as values. This is used to rename the passband
+        entries in the output photometry table to be AAVSO standard versus
+        whatever is in the source list.
+
+    reject_unmatched : bool, optional (Default: True)
+        If ``True``, any sources that are not detected on all the images are
+        rejected.  If you are interested in a source that can intermittently
+        fall below your detection limits, we suggest setting this to ``False``
+        so that all sources detected on each image are reported.
 
     Returns
     -------

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -591,6 +591,7 @@ def multi_image_photometry(
     observatory_location,
     photometry_apertures,
     shift_tolerance,
+    use_coordinates="pixel",
     include_dig_noise=True,
     reject_too_close=True,
     reject_background_outliers=True,
@@ -642,6 +643,12 @@ def multi_image_photometry(
         positions and the refined positions, in pixels.  The expected
         shift shift should not be more than the FWHM, so a measured FWHM
         might be a good value to provide here.
+
+    use_coordinates : str, optional (Default: 'sky')
+        If ``'pixel'``, use the x/y positions in the sourcelist for
+        performing aperture photometry.  If ``'sky'``, use the ra/dec
+        positions in the sourcelist and the WCS of the `ccd_image` to
+        compute the x/y positions on the image.
 
     reject_background_outliers : bool, optional (Default: True)
         If ``True``, sigma clip the pixels in the annulus to reject outlying
@@ -774,7 +781,7 @@ def multi_image_photometry(
             observatory_location,
             photometry_apertures,
             shift_tolerance,
-            use_coordinates="sky",
+            use_coordinates=use_coordinates,
             include_dig_noise=include_dig_noise,
             reject_too_close=reject_too_close,
             reject_background_outliers=reject_background_outliers,

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -105,7 +105,7 @@ def single_image_photometry(
         Photometry data for all the locations in which aperture photometry was
         performed.  This may be a subset of the sources in the sourcelist if
         locations were too close to the edge of the image or to each other for
-        successful apeture photometry.  If pixel (x/y) positions were used for
+        successful aperture photometry.  If pixel (x/y) positions were used for
         the photometry, but a valid WCS header was not available for `ccd_image`,
         the output 'ra', 'dec', and 'bjd' columns will have np.nan values
 
@@ -604,7 +604,7 @@ def multi_image_photometry(
         Photometry data for all the sources on which aperture photometry was
         performed in all the images. This may be a subset of the sources in
         the sourcelist if locations were too close to the edge of any one image
-        or to each other for successful apeture photometry.
+        or to each other for successful aperture photometry.
 
     """
 

--- a/stellarphot/photometry/tests/test_detection.py
+++ b/stellarphot/photometry/tests/test_detection.py
@@ -6,9 +6,9 @@ from astropy import units as u
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
-from fake_image import FakeImage
 
 from stellarphot.photometry import compute_fwhm, source_detection
+from stellarphot.photometry.tests.fake_image import FakeImage
 
 # Make sure the tests are deterministic by using a random seed
 SEED = 5432985

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -448,9 +448,6 @@ def test_photometry_on_directory(coords):
         ]
         # Write the CCDData objects to files
         for i, image in enumerate(fake_images):
-            from time import sleep
-
-            sleep(1)
             image.write(temp_file_names[i])
 
         object_name = fake_images[0].header["OBJECT"]

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -9,7 +9,6 @@ from astropy import units as u
 from astropy.io import ascii
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.metadata.exceptions import MergeConflictWarning
-from fake_image import FakeCCDImage, shift_FakeCCDImage
 
 from stellarphot.core import SourceListData
 from stellarphot.photometry import (
@@ -19,6 +18,7 @@ from stellarphot.photometry import (
     single_image_photometry,
     source_detection,
 )
+from stellarphot.photometry.tests.fake_image import FakeCCDImage, shift_FakeCCDImage
 from stellarphot.settings import (
     Camera,
     Observatory,
@@ -549,11 +549,19 @@ def test_photometry_on_directory(coords):
             # less than the expected one sigma deviation.
             assert np.abs(expected_flux - obs_avg_net_cnts) < expected_deviation
         else:
-            # The expected result is that either obs_avg_net_cnts is nan or the
-            # difference is bigger than the expected_deviation.
+            # In this case we are trying to do photometry in pixel coordinates,
+            # using the pixel location of the sources as found in the first image --
+            # see the line where found_sources is defined.
+            #
+            # However, the images are shifted with respect to each other by
+            # list_of_fakes, so there are no long stars at those positions in the
+            # other images.
+            #
+            # Because of that, the expected result is that either obs_avg_net_cnts
+            # is nan or the difference is bigger than the expected_deviation.
             assert (
                 np.isnan(obs_avg_net_cnts)
-                or np.abs(expected_flux - obs_avg_net_cnts) < expected_deviation
+                or np.abs(expected_flux - obs_avg_net_cnts) > expected_deviation
             )
 
 

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.coordinates import EarthLocation
 from astropy.io import ascii
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.metadata.exceptions import MergeConflictWarning
@@ -20,7 +19,7 @@ from stellarphot.photometry import (
     single_image_photometry,
     source_detection,
 )
-from stellarphot.settings import Camera, PhotometryApertures
+from stellarphot.settings import Camera, Observatory, PhotometryApertures
 
 # Constants for the tests
 
@@ -54,7 +53,9 @@ ZERO_CAMERA = Camera(
 )
 
 # Fake observatory location
-FAKE_OBS = EarthLocation(lat=0 * u.deg, lon=0 * u.deg, height=0 * u.m)
+FAKE_OBS = Observatory(
+    name="test observatory", latitude=0 * u.deg, longitude=0 * u.deg, elevation=0 * u.m
+)
 
 # The default coordinate system to use for the tests
 COORDS2USE = "pixel"

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -71,7 +71,7 @@ FAKE_OBS = Observatory(
 # The fake image used for testing
 FAKE_CCD_IMAGE = FakeCCDImage(seed=SEED)
 
-# Build default PhotometrySettings for the tests based on the fake image
+# Build default PhotometryOptions for the tests based on the fake image
 DEFAULT_PHOTOMETRY_APERTURES = PhotometryApertures(
     radius=FAKE_CCD_IMAGE.sources["aperture"][0],
     gap=FAKE_CCD_IMAGE.sources["aperture"][0],
@@ -536,12 +536,10 @@ def test_photometry_on_directory(coords):
         expected_deviation = np.pi * aperture**2 * noise_dev
 
         # We have two cases to consider: use_coordinates="sky" and
-        # use_coordinates="pixel". In the former case, the expected
-        # result is the test below. In the latter case, the expected
-        # result is that either obs_avg_net_cnts is nan or the difference
-        # is bigger than the expected_deviation.
-
+        # use_coordinates="pixel".
         if coords == "sky":
+            # In this case, the expected result is the test below.
+
             # We could require that the result be within some reasonable
             # number of those expected variations or we could count up the
             # actual number of background counts at each of the source
@@ -551,6 +549,8 @@ def test_photometry_on_directory(coords):
             # less than the expected one sigma deviation.
             assert np.abs(expected_flux - obs_avg_net_cnts) < expected_deviation
         else:
+            # The expected result is that either obs_avg_net_cnts is nan or the
+            # difference is bigger than the expected_deviation.
             assert (
                 np.isnan(obs_avg_net_cnts)
                 or np.abs(expected_flux - obs_avg_net_cnts) < expected_deviation

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -421,7 +421,7 @@ class PhotometryOptions(BaseModelWithTableRep):
     shift_tolerance : `pydantic.NonNegativeFloat`
         Since source positions need to be computed on each image using
         the sky position and WCS, the computed x/y positions are refined
-        afterward by centroiding the sources.  This setting constrols
+        afterward by centroiding the sources.  This setting controls
         the tolerance in pixels for the shift between the the computed
         positions and the refined positions, in pixels.  The expected
         shift shift should not be more than the FWHM, so a measured FWHM

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -460,6 +460,42 @@ class PhotometryOptions(BaseModelWithTableRep):
         If ``True`` and `logfile` is set, log messages will also be written to
         stdout.  If ``False``, log messages will not be written to stdout
         if `logfile` is set.
+
+    Examples
+    --------
+
+    The only option that must be set explicitly is the `shift_tolerance`:
+
+    >>> from stellarphot.settings import PhotometryOptions
+    >>> photometry_options = PhotometryOptions(shift_tolerance=5.2)
+    >>> photometry_options
+    PhotometryOptions(shift_tolerance=5.2, use_coordinates='sky',
+    include_dig_noise=True, reject_too_close=True, reject_background_outliers=True,
+    fwhm_by_fit=True, logfile=None, console_log=True)
+
+
+    You can also set the other options explicitly when you create the options:
+
+    >>> photometry_options = PhotometryOptions(
+    ...     shift_tolerance=5.2,
+    ...     use_coordinates="pixel",
+    ...     include_dig_noise=True,
+    ...     reject_too_close=False,
+    ...     reject_background_outliers=True,
+    ...     fwhm_by_fit=True,
+    ...     logfile=None,
+    ...     console_log=True
+    ... )
+    >>> photometry_options
+    PhotometryOptions(shift_tolerance=5.2, use_coordinates='pixel',
+    include_dig_noise=True, reject_too_close=False, reject_background_outliers=True,
+    fwhm_by_fit=True, logfile=None, console_log=True)
+
+    You can also change individual options after the object is created:
+
+    >>> photometry_options.use_coordinates = "sky"
+    >>> photometry_options.use_coordinates
+    'sky'
     """
 
     model_config = MODEL_DEFAULT_CONFIGURATION

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -13,6 +13,7 @@ from stellarphot.settings.models import (
     Exoplanet,
     Observatory,
     PhotometryApertures,
+    PhotometryOptions,
 )
 
 DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
@@ -48,6 +49,20 @@ DEFAULT_OBSERVATORY_SETTINGS = dict(
 )
 
 
+# The first setting here is required, the rest are optional. The optional
+# settings below are different than the defaults in the model definition.
+DEFAULT_PHOTOMETRY_SETTINGS = dict(
+    shift_tolerance=5,
+    use_coordinates="pixel",
+    include_dig_noise=False,
+    reject_too_close=False,
+    reject_background_outliers=False,
+    fwhm_by_fit=False,
+    logfile="test.log",
+    console_log=False,
+)
+
+
 @pytest.mark.parametrize(
     "model,settings",
     [
@@ -55,6 +70,7 @@ DEFAULT_OBSERVATORY_SETTINGS = dict(
         [PhotometryApertures, DEFAULT_APERTURE_SETTINGS],
         [Exoplanet, DEFAULT_EXOPLANET_SETTINGS],
         [Observatory, DEFAULT_OBSERVATORY_SETTINGS],
+        [PhotometryOptions, DEFAULT_PHOTOMETRY_SETTINGS],
     ],
 )
 class TestModelAgnosticActions:
@@ -286,6 +302,16 @@ def test_observatory_lat_long_as_float():
     settings["longitude"] = settings["longitude"].value
     obs = Observatory(**settings)
     assert obs == Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+
+
+def test_photometry_settings_negative_shift_tolerance():
+    # Check that a negative shift tolerance raises an error
+    settings = dict(DEFAULT_PHOTOMETRY_SETTINGS)
+    settings["shift_tolerance"] = -1
+    with pytest.raises(
+        ValidationError, match="Input should be greater than or equal to 0"
+    ):
+        PhotometryOptions(**settings)
 
 
 def test_create_invalid_exoplanet():

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import SkyCoord
 from astropy.io import ascii, fits
 from astropy.nddata import CCDData
 from astropy.table import Table
@@ -20,7 +20,7 @@ from stellarphot.core import (
     apass_dr9,
     vsx_vizier,
 )
-from stellarphot.settings import Camera
+from stellarphot.settings import Camera, Observatory
 
 # Create several test descriptions for use in base_enhanced_table tests.
 test_descript = {
@@ -87,7 +87,9 @@ feder_cg_16m = Camera(
     max_data_value=50000 * u.adu,
 )
 feder_passbands = {"up": "SU", "gp": "SG", "rp": "SR", "zp": "SZ", "ip": "SI"}
-feder_obs = EarthLocation(lat=46.86678, lon=-96.45328, height=311)
+feder_obs = Observatory(
+    name="Feder Observatory", latitude=46.86678, longitude=-96.45328, elevation="311 m"
+)
 
 
 def test_base_enhanced_table_blank():
@@ -480,12 +482,16 @@ def test_photometry_data():
     assert phot_data.camera.read_noise == 10.0 * u.electron
     assert phot_data.camera.dark_current == 0.01 * u.electron / u.second
     assert phot_data.camera.pixel_scale == 0.563 * u.arcsec / u.pix
-    np.testing.assert_almost_equal(phot_data.observatory.lat.value, 46.86678)
-    assert phot_data.observatory.lat.unit == u.deg
-    np.testing.assert_almost_equal(phot_data.observatory.lon.value, -96.45328)
-    assert phot_data.observatory.lon.unit == u.deg
-    assert round(phot_data.observatory.height.value) == 311
-    assert phot_data.observatory.height.unit == u.m
+    np.testing.assert_almost_equal(
+        phot_data.observatory.earth_location.lat.value, 46.86678
+    )
+    assert phot_data.observatory.earth_location.lat.unit == u.deg
+    np.testing.assert_almost_equal(
+        phot_data.observatory.earth_location.lon.value, -96.45328
+    )
+    assert phot_data.observatory.earth_location.lon.unit == u.deg
+    assert round(phot_data.observatory.earth_location.height.value) == 311
+    assert phot_data.observatory.earth_location.height.unit == u.m
     assert phot_data["night"][0] == 59909
 
     # Checking the BJD computation against Ohio State online calculator for
@@ -531,12 +537,16 @@ def test_photometry_slicing():
     assert two_cols.camera.read_noise == 10.0 * u.electron
     assert two_cols.camera.dark_current == 0.01 * u.electron / u.second
     assert two_cols.camera.pixel_scale == 0.563 * u.arcsec / u.pix
-    np.testing.assert_almost_equal(two_cols.observatory.lat.value, 46.86678)
-    assert two_cols.observatory.lat.unit == u.deg
-    np.testing.assert_almost_equal(two_cols.observatory.lon.value, -96.45328)
-    assert two_cols.observatory.lon.unit == u.deg
-    assert round(two_cols.observatory.height.value) == 311
-    assert two_cols.observatory.height.unit == u.m
+    np.testing.assert_almost_equal(
+        two_cols.observatory.earth_location.lat.value, 46.86678
+    )
+    assert two_cols.observatory.earth_location.lat.unit == u.deg
+    np.testing.assert_almost_equal(
+        two_cols.observatory.earth_location.lon.value, -96.45328
+    )
+    assert two_cols.observatory.earth_location.lon.unit == u.deg
+    assert round(two_cols.observatory.earth_location.height.value) == 311
+    assert two_cols.observatory.earth_location.height.unit == u.m
 
 
 def test_photometry_recursive():


### PR DESCRIPTION
This is another fairly big one. It does a few things:

- Rearrange the order of keyword arguments in `single_image_photometry` and `multi_image_photometry` so the order is the same, with keywords specific to each function at the end of each signature.
- Adds a `PhotometryOptions` object that includes `shift_tolerance` and all of the keyword options that were common to `single_image_photometry` and `multi_image_photometry`. Also adds tests of the new object.
- Uses that object in place of `shift_tolerance` and the keyword options that were common to both.
- Modifies tests as needed to accommodate the new arguments.
- Fixes a few bugs where arguments in `multi_image_photometry` were not being passed through to `single_image_photometry` 😀 

@JuanCab -- my step will be to use these to turn the photometry functions into a class. I'm going to start building that based on this, but can of course modify in response to suggestions here. 

If you can review this one by early next week that would be great. The next one, "class"-ifying photometry, will be much less extensive than this I think.

Closes #149 