### PR TITLE
This rearranges some of the photometry settings and adds an `AperturePhotometry` class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,70 @@
 Documentation
 =============
 
-This is the documentation for stellarphot.
-This is a package for doing stellar photometry that relies on astropy.
+Stellarphot is a package for performing photometry on astronomical images. It
+provides a simple interface for performing aperture photometry of either a single
+image or a directory with multiple images.
+
+
+Getting Started
+===============
+
+Installation
+------------
+
+Install it with pip or conda.
+
+Overview
+--------
+
+Using ``stellarphot`` starts with defining a bunch of configuration settings. Some of these,
+like details about your observing location and camera, will change infrequently.
+Others, like what size apertures to use for photometry and where in each image those
+apertures should be placed, may change from night to night.
+
+Provide your observatory information
+-------------------------------------
+
+TBD
+
+Provide your camera information
+-------------------------------
+
+TBD
+
+Provide a source list
+---------------------
+
+TBD
+
+Some optional settings
+-----------------------
+
+TBD
+
+Performing photometry
+---------------------
+
+Once you have made your settings doing photometry is a two line process. First, you
+create a photometry object:
+
+```python
+from stellarphot.photometry import AperurePhotometry
+phot = AperurePhotometry(photometry_settings)
+```
+
+Then you can perform photometry on a single image:
+
+```python
+phot(image)
+```
+
+If you have a directory of images you can perform photometry on all of them at once like this:
+
+```python
+phot(directory, object_of_interest="M13")
+```
+
 
 .. toctree::
   :maxdepth: 3

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -79,10 +79,11 @@ def single_image_photometry(
         This image  must also have a WCS header associated with it if you want to
         use sky positions as inputs.
 
-    sourcelist : `stellarphot.SourceList`
-        Table of extracted sources with positions in terms of pixel coordinates OR
-        RA/Dec coordinates. If both positions provided, pixel coordinates will be used.
-        For RA/Dec coordinates to be used, `ccd_image` must have a valid WCS.
+    photometry_settings : `stellarphot.settings.PhotometrySettings`
+        Photometry settings to use for the photometry.  This includes the camera,
+        observatory, the aperture and annulus radii to use for the photometry, a map
+        of passbands from your filters to AAVSO filter names, and options for the
+        photometry. See `stellarphot.settings.PhotometrySettings` for more information.
 
     fname : str, optional (Default: None)
         Name of the image file on which photometry is being performed.
@@ -539,8 +540,6 @@ def single_image_photometry(
 def multi_image_photometry(
     directory_with_images,
     photometry_settings,
-    object_of_interest,
-    sourcelist,
     reject_unmatched=True,
 ):
     """
@@ -556,6 +555,12 @@ def multi_image_photometry(
         DATE-OBS, an exposure time header (which can be any of the following: EXPOSURE,
         EXPTIME, TELAPSE, ELAPTIME, ONTIME, or LIVETIME), and FILTER.  If AIRMASS is
         available it will be added to `phot_table`.
+
+    photometry_settings : `stellarphot.settings.PhotometrySettings`
+        Photometry settings to use for the photometry.  This includes the camera,
+        observatory, the aperture and annulus radii to use for the photometry, a map
+        of passbands from your filters to AAVSO filter names, and options for the
+        photometry. See `stellarphot.settings.PhotometrySettings` for more information.
 
     reject_unmatched : bool, optional (Default: True)
         If ``True``, any sources that are not detected on all the images are
@@ -573,6 +578,7 @@ def multi_image_photometry(
         or to each other for successful aperture photometry.
 
     """
+    sourcelist = SourceListData.read(photometry_settings.source_list_file)
 
     # Initialize lists to track all PhotometryData objects and all dropped sources
     phots = []

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -554,7 +554,7 @@ def test_photometry_on_directory(coords):
             # see the line where found_sources is defined.
             #
             # However, the images are shifted with respect to each other by
-            # list_of_fakes, so there are no long stars at those positions in the
+            # list_of_fakes, so there are no longer stars at those positions in the
             # other images.
             #
             # Because of that, the expected result is that either obs_avg_net_cnts

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -70,6 +70,9 @@ class BaseModelWithTableRep(BaseModel):
     Class to add to a pydantic model YAML serialization to an Astropy table.
     """
 
+    # NOTE WELL that this will set the configuration for all subclasses of this
+    model_config = MODEL_DEFAULT_CONFIGURATION
+
     def __init__(self, *arg, **kwargs):
         super().__init__(*arg, **kwargs)
         self.generate_table_representers()
@@ -312,8 +315,6 @@ class PhotometryApertures(BaseModelWithTableRep):
     ... )
     """
 
-    model_config = MODEL_DEFAULT_CONFIGURATION
-
     radius: Annotated[
         PositiveInt,
         Field(default=1, json_schema_extra=dict(autoui="ipywidgets.BoundedIntText")),
@@ -348,8 +349,6 @@ class PhotometryFileSettings(BaseModelWithTableRep):
     """
     An evolutionary step on the way to having a monolithic set of photometry settings.
     """
-
-    model_config = MODEL_DEFAULT_CONFIGURATION
 
     image_folder: Path = Field(
         show_only_dirs=True,
@@ -388,8 +387,6 @@ class Observatory(BaseModelWithTableRep):
     TESS_telescope_code : str, optional
         TESS telescope code.
     """
-
-    model_config = MODEL_DEFAULT_CONFIGURATION
 
     name: str
     latitude: Annotated[
@@ -500,8 +497,6 @@ class PhotometryOptions(BaseModelWithTableRep):
     'sky'
     """
 
-    model_config = MODEL_DEFAULT_CONFIGURATION
-
     shift_tolerance: NonNegativeFloat
     use_coordinates: Literal["sky", "pixel"] = "sky"
     include_dig_noise: bool = True
@@ -555,8 +550,6 @@ class PhotometrySettings(BaseModelWithTableRep):
         pixel coordinates will be used. For RA/Dec coordinates to be used, `ccd_image`
         must have a valid WCS.
     """
-
-    model_config = MODEL_DEFAULT_CONFIGURATION
 
     camera: Camera
     observatory: Observatory

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -631,11 +631,6 @@ class PhotometrySettings(BaseModelWithTableRep):
         Settings for logging. See the documentation for
         `~stellarphot.settings.LoggingSettings` for details.
 
-    object_of_interest : str
-        Name of the object of interest. The only files on which photometry
-        will be done are those whose header contains the keyword ``OBJECT``
-        whose value is ``object_of_interest``.
-
     """
 
     camera: Camera
@@ -645,7 +640,6 @@ class PhotometrySettings(BaseModelWithTableRep):
     photometry_options: PhotometryOptions
     passband_map: PassbandMap | None
     logging_settings: LoggingSettings
-    object_of_interest: str
 
 
 class Exoplanet(BaseModelWithTableRep):

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -538,7 +538,7 @@ class PhotometrySettings(BaseModelWithTableRep):
         Several options for the details of performing the photometry. See the
         documentation for `~stellarphot.settings.PhotometryOptions` for details.
 
-    passband_map: `stellarphot.settings.PassbandMap`
+    passband_map: `stellarphot.settings.PassbandMap`, optional
         A dictionary containing instrumental passband names as keys and
         AAVSO passband names as values. This is used to rename the passband
         entries in the output photometry table from what is in the source list

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -1,5 +1,6 @@
 # Objects that contains the user settings for the program.
 
+from pathlib import Path
 from typing import Annotated, Literal
 
 from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
@@ -31,6 +32,7 @@ __all__ = [
     "Camera",
     "PassbandMap",
     "PhotometryApertures",
+    "PhotometryFileSettings",
     "PhotometrySettings",
     "PhotometryOptions",
     "Exoplanet",
@@ -340,6 +342,24 @@ class PhotometryApertures(BaseModelWithTableRep):
         Radius of the outer annulus in pixels.
         """
         return self.inner_annulus + self.annulus_width
+
+
+class PhotometryFileSettings(BaseModelWithTableRep):
+    """
+    An evolutionary step on the way to having a monolithic set of photometry settings.
+    """
+
+    model_config = MODEL_DEFAULT_CONFIGURATION
+
+    image_folder: Path = Field(
+        show_only_dirs=True,
+        default="",
+        description="Folder containing the calibrated images",
+    )
+    aperture_settings_file: Path = Field(filter_pattern="*.json", default="")
+    aperture_locations_file: Path = Field(
+        filter_pattern=["*.ecsv", "*.csv"], default=""
+    )
 
 
 class Observatory(BaseModelWithTableRep):

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -388,6 +388,34 @@ class Observatory(BaseModelWithTableRep):
 
     TESS_telescope_code : str, optional
         TESS telescope code.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import Latitude, Longitude
+    >>> from astropy import units as u
+    >>> from stellarphot.settings import Observatory
+    >>> observatory = Observatory(
+    ...     name="test observatory",
+    ...     latitude=Latitude(30.0 * u.deg),
+    ...     longitude=Longitude(-100.0 * u.deg),
+    ...     elevation=1000 * u.m,
+    ... )
+    >>> observatory
+    Observatory(name='test observatory', latitude=<Latitude 30. deg>,
+    longitude=<Longitude 260. deg>, elevation=<Quantity 1000. m>, AAVSO_code=None,
+    TESS_telescope_code=None)
+    >>> # You can also just provide numbers for the latitude and longitude
+    >>> observatory = Observatory(
+    ...     name="test observatory",
+    ...     latitude=30.0,
+    ...     longitude=-100.0,
+    ...     elevation=1000 * u.m,
+    ... )
+    >>> observatory
+    Observatory(name='test observatory', latitude=<Latitude 30. deg>,
+    longitude=<Longitude 260. deg>, elevation=<Quantity 1000. m>, AAVSO_code=None,
+    TESS_telescope_code=None)
+
     """
 
     name: str
@@ -439,6 +467,18 @@ class SourceLocationSettings(BaseModelWithTableRep):
         positions and the refined positions, in pixels.  The expected
         shift shift should not be more than the FWHM, so a measured FWHM
         might be a good value to provide here.
+
+    Examples
+    --------
+    >>> from stellarphot.settings import SourceLocationSettings
+    >>> source_location_settings = SourceLocationSettings(
+    ...     source_list_file="source_list.ecsv",
+    ...     use_coordinates="sky",
+    ...     shift_tolerance=5.0
+    ... )
+    >>> source_location_settings
+    SourceLocationSettings(source_list_file='source_list.ecsv', use_coordinates='sky',
+    shift_tolerance=5.0)
     """
 
     source_list_file: str
@@ -506,7 +546,24 @@ class PhotometryOptions(BaseModelWithTableRep):
 
 
 class PassbandMap(BaseModelWithTableRep):
-    """Class to represent a mapping from one set of filter names to another."""
+    """
+    Class to represent a mapping from one set of filter names to another.
+
+    Parameters
+    ----------
+    yours_to_aavso : dict[str, str]
+        A dictionary containing instrumental passband names as keys and
+        AAVSO passband names as values. This is used to rename the passband
+        entries in the output photometry table.
+
+    Examples
+    --------
+    >>> from stellarphot.settings import PassbandMap
+    >>> passband_map = PassbandMap(yours_to_aavso={"B": "B", "V": "V"})
+    >>> passband_map
+    PassbandMap(yours_to_aavso={'B': 'B', 'V': 'V'})
+
+    """
 
     yours_to_aavso: dict[str, str]
 
@@ -526,6 +583,13 @@ class LoggingSettings(BaseModelWithTableRep):
         If ``True`` and `logfile` is set, log messages will also be written to
         stdout.  If ``False``, log messages will not be written to stdout
         if `logfile` is set.
+
+    Examples
+    --------
+    >>> from stellarphot.settings import LoggingSettings
+    >>> logging_settings = LoggingSettings()
+    >>> logging_settings
+    LoggingSettings(logfile=None, console_log=True)
     """
 
     logfile: str | None = None
@@ -548,6 +612,11 @@ class PhotometrySettings(BaseModelWithTableRep):
     photometry_apertures : `stellarphot.settings.PhotometryApertures`
         Radius, inner and outer annulus radii settings and FWHM.
 
+    source_locations : `stellarphot.settings.SourceLocationSettings`
+        Settings for the location of the sources for which photometry
+        will be performed. See the documentation for
+        `~stellarphot.settings.SourceLocationSettings` for details.
+
     photometry_options : `stellarphot.settings.PhotometryOptions`
         Several options for the details of performing the photometry. See the
         documentation for `~stellarphot.settings.PhotometryOptions` for details.
@@ -557,6 +626,10 @@ class PhotometrySettings(BaseModelWithTableRep):
         AAVSO passband names as values. This is used to rename the passband
         entries in the output photometry table from what is in the source list
         to be AAVSO standard names, if available for that filter.
+
+    logging_settings : `stellarphot.settings.LoggingSettings`
+        Settings for logging. See the documentation for
+        `~stellarphot.settings.LoggingSettings` for details.
 
     object_of_interest : str
         Name of the object of interest. The only files on which photometry

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -12,8 +12,10 @@ from stellarphot.settings.models import (
     Camera,
     Exoplanet,
     Observatory,
+    PassbandMap,
     PhotometryApertures,
     PhotometryOptions,
+    PhotometrySettings,
 )
 
 DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
@@ -48,10 +50,9 @@ DEFAULT_OBSERVATORY_SETTINGS = dict(
     TESS_telescope_code="tess test",
 )
 
-
 # The first setting here is required, the rest are optional. The optional
 # settings below are different than the defaults in the model definition.
-DEFAULT_PHOTOMETRY_SETTINGS = dict(
+DEFAULT_PHOTOMETRY_OPTIONS = dict(
     shift_tolerance=5,
     use_coordinates="pixel",
     include_dig_noise=False,
@@ -62,6 +63,24 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
     console_log=False,
 )
 
+DEFAULT_PASSBAND_MAP = dict(
+    yours_to_aavso=dict(
+        V="V",
+        B="B",
+        rp="SR",
+    )
+)
+
+DEFAULT_PHOTOMETRY_SETTINGS = dict(
+    camera=Camera(**TEST_CAMERA_VALUES),
+    observatory=Observatory(**DEFAULT_OBSERVATORY_SETTINGS),
+    photometry_apertures=PhotometryApertures(**DEFAULT_APERTURE_SETTINGS),
+    photometry_options=PhotometryOptions(**DEFAULT_PHOTOMETRY_OPTIONS),
+    passband_map=PassbandMap(**DEFAULT_PASSBAND_MAP),
+    object_of_interest="test",
+    source_list_file="test.ecsv",
+)
+
 
 @pytest.mark.parametrize(
     "model,settings",
@@ -70,7 +89,9 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
         [PhotometryApertures, DEFAULT_APERTURE_SETTINGS],
         [Exoplanet, DEFAULT_EXOPLANET_SETTINGS],
         [Observatory, DEFAULT_OBSERVATORY_SETTINGS],
-        [PhotometryOptions, DEFAULT_PHOTOMETRY_SETTINGS],
+        [PhotometryOptions, DEFAULT_PHOTOMETRY_OPTIONS],
+        [PassbandMap, DEFAULT_PASSBAND_MAP],
+        [PhotometrySettings, DEFAULT_PHOTOMETRY_SETTINGS],
     ],
 )
 class TestModelAgnosticActions:
@@ -306,7 +327,7 @@ def test_observatory_lat_long_as_float():
 
 def test_photometry_settings_negative_shift_tolerance():
     # Check that a negative shift tolerance raises an error
-    settings = dict(DEFAULT_PHOTOMETRY_SETTINGS)
+    settings = dict(DEFAULT_PHOTOMETRY_OPTIONS)
     settings["shift_tolerance"] = -1
     with pytest.raises(
         ValidationError, match="Input should be greater than or equal to 0"

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -11,11 +11,13 @@ from stellarphot.settings import ui_generator
 from stellarphot.settings.models import (
     Camera,
     Exoplanet,
+    LoggingSettings,
     Observatory,
     PassbandMap,
     PhotometryApertures,
     PhotometryOptions,
     PhotometrySettings,
+    SourceLocationSettings,
 )
 
 DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
@@ -53,14 +55,10 @@ DEFAULT_OBSERVATORY_SETTINGS = dict(
 # The first setting here is required, the rest are optional. The optional
 # settings below are different than the defaults in the model definition.
 DEFAULT_PHOTOMETRY_OPTIONS = dict(
-    shift_tolerance=5,
-    use_coordinates="pixel",
     include_dig_noise=False,
     reject_too_close=False,
     reject_background_outliers=False,
     fwhm_by_fit=False,
-    logfile="test.log",
-    console_log=False,
 )
 
 DEFAULT_PASSBAND_MAP = dict(
@@ -71,14 +69,26 @@ DEFAULT_PASSBAND_MAP = dict(
     )
 )
 
+DEFAULT_LOGGING_SETTINGS = dict(
+    logfile="test.log",
+    console_log=False,
+)
+
+DEFAULT_SOURCE_LOCATION_SETTINGS = dict(
+    shift_tolerance=5,
+    source_list_file="test.ecsv",
+    use_coordinates="pixel",
+)
+
 DEFAULT_PHOTOMETRY_SETTINGS = dict(
     camera=Camera(**TEST_CAMERA_VALUES),
     observatory=Observatory(**DEFAULT_OBSERVATORY_SETTINGS),
     photometry_apertures=PhotometryApertures(**DEFAULT_APERTURE_SETTINGS),
+    source_locations=SourceLocationSettings(**DEFAULT_SOURCE_LOCATION_SETTINGS),
     photometry_options=PhotometryOptions(**DEFAULT_PHOTOMETRY_OPTIONS),
     passband_map=PassbandMap(**DEFAULT_PASSBAND_MAP),
+    logging_settings=LoggingSettings(**DEFAULT_LOGGING_SETTINGS),
     object_of_interest="test",
-    source_list_file="test.ecsv",
 )
 
 
@@ -92,6 +102,8 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
         [PhotometryOptions, DEFAULT_PHOTOMETRY_OPTIONS],
         [PassbandMap, DEFAULT_PASSBAND_MAP],
         [PhotometrySettings, DEFAULT_PHOTOMETRY_SETTINGS],
+        [LoggingSettings, DEFAULT_LOGGING_SETTINGS],
+        [SourceLocationSettings, DEFAULT_SOURCE_LOCATION_SETTINGS],
     ],
 )
 class TestModelAgnosticActions:
@@ -329,14 +341,14 @@ def test_observatory_lat_long_as_float():
     assert obs == Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
 
 
-def test_photometry_settings_negative_shift_tolerance():
+def test_source_locations_negative_shift_tolerance():
     # Check that a negative shift tolerance raises an error
-    settings = dict(DEFAULT_PHOTOMETRY_OPTIONS)
+    settings = dict(DEFAULT_SOURCE_LOCATION_SETTINGS)
     settings["shift_tolerance"] = -1
     with pytest.raises(
         ValidationError, match="Input should be greater than or equal to 0"
     ):
-        PhotometryOptions(**settings)
+        SourceLocationSettings(**settings)
 
 
 def test_create_invalid_exoplanet():

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -137,7 +137,11 @@ class TestModelAgnosticActions:
         new_table = Table.read(table_path)
         assert new_table.meta["model"] == mod
 
-    def test_aperture_settings_ui_generation(self, model, settings):
+    def test_settings_ui_generation(self, model, settings):
+        if model == PhotometrySettings or model == PassbandMap:
+            pytest.xfail(
+                reason="PassbandMap needs a dict widget -- https://github.com/feder-observatory/stellarphot/issues/274"
+            )
         # Check a few things about the UI generation:
         # 1) The UI is generated
         # 2) The UI model matches our input

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -88,7 +88,6 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
     photometry_options=PhotometryOptions(**DEFAULT_PHOTOMETRY_OPTIONS),
     passband_map=PassbandMap(**DEFAULT_PASSBAND_MAP),
     logging_settings=LoggingSettings(**DEFAULT_LOGGING_SETTINGS),
-    object_of_interest="test",
 )
 
 


### PR DESCRIPTION
There are still a couple things to be resolved:

+ Should single/multi image photometry become methods of `AperturePhotometry`?
+ Is `AperturePhotometry` even needed?

Marking this as a draft for the moment, but if you get a chance to take a peek, @JuanCab, feedback would be welcome. WOn't get back to it myself until Sunday.