### PR TITLE
Update minimum ipyautoui version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "bottleneck",
     "ccdproc",
     "ginga",
-    "ipyautoui >=0.7.12",
+    "ipyautoui >=0.7.15",
     "ipyfilechooser",
     "ipywidgets",
     "matplotlib",


### PR DESCRIPTION
This version fixes a bug in FileChooser that prevented filtering of the files listed in the viewer. Fixes #282 