### PR TITLE
Add a system for saving some settings for easier reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pip-wheel-metadata
 .pytest_cache
 .tmp
 .ruff_cache
+.hypothesis
 
 # Sphinx
 docs/api

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ exclude_patterns.append("_templates")
 rst_epilog += """
 """
 
-extensions += ["sphinxcontrib.autodoc_pydantic"]
+# extensions += ["sphinxcontrib.autodoc_pydantic"]
 
 # -- Project information ------------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,8 @@ exclude_patterns.append("_templates")
 rst_epilog += """
 """
 
+extensions += ["sphinxcontrib.autodoc_pydantic"]
+
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,32 +38,7 @@ pip install --pre --upgrade stellarphot
 Overview
 --------
 
-Using ``stellarphot`` starts with defining a bunch of configuration settings. Some of these,
-like details about your observing location and camera, will change infrequently.
-Others, like what size apertures to use for photometry and where in each image those
-apertures should be placed, may change from night to night.
 
-All the settings can be made through a graphical interface, via the command line, or by editing
-an existing settings file.
-
-The settings are grouped into these categories:
-
-- Observatory
-- Camera
-- Passband Map
-- Photometry Apertures
-- Source Location Settings
-- Optional Settings
-- Logging Settings
-
-The first three categories each include a ``name`` property, which is used to identify the
-settings and provides a shortcut to re-using those settings in the future.
-
-A copy of the settings are stored in a file called `stellarphot_settings.json` in the working directory
-where you are using stellarphot. It is these settings that are used when you run the photometry.
-
-Settings can be generated using a jupyter notebook with a graphical interface, by using the command line,
-or by editing a settings file directly.
 
 Graphical interface for generating settings
 -------------------------------------------
@@ -88,32 +63,6 @@ Editing a settings file directly
 
 The settings file is a JSON file that can be edited in any text editor.
 
-
-Provide your observatory information
--------------------------------------
-
-.. autopydantic_field:: stellarphot.settings.Observatory.latitude
-    :field-show-constraints: False
-..     :model-show-config-summary: False
-..     :model-show-field-summary: False
-.. .. autopydantic_model:: stellarphot.settings.Observatory
-..     :model-show-config-summary: False
-..     :model-show-field-summary: False
-
-Provide your camera information
--------------------------------
-
-TBD
-
-Provide a source list
----------------------
-
-TBD
-
-Some optional settings
------------------------
-
-TBD
 
 Performing photometry
 ---------------------
@@ -143,6 +92,7 @@ phot(directory, object_of_interest="M13")
   :maxdepth: 3
 
   stellarphot/index.rst
+  stellarphot/settings.rst
 
 
 Developer Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Overview
 Graphical interface for generating settings
 -------------------------------------------
 
-To generate settings using a graphical interface, start Jupyter lab. In the launcher will be a section called
+To generate settings using a graphical interface, start JupyterLab. In the launcher will be a section called
 "Stellarphot" with a link to "Generate Settings". Clicking on this link will open a notebook where you can enter settings.
 
 Command line interface for generating settings

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,13 @@ programmatically in Python or by editing a file in your favorite text editor.
 Provide your observatory information
 -------------------------------------
 
-TBD
+.. autopydantic_field:: stellarphot.settings.Observatory.latitude
+    :field-show-constraints: False
+..     :model-show-config-summary: False
+..     :model-show-field-summary: False
+.. .. autopydantic_model:: stellarphot.settings.Observatory
+..     :model-show-config-summary: False
+..     :model-show-field-summary: False
 
 Provide your camera information
 -------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,8 +43,51 @@ like details about your observing location and camera, will change infrequently.
 Others, like what size apertures to use for photometry and where in each image those
 apertures should be placed, may change from night to night.
 
-There is a graphical interface for making all of the settings below. They can also be set
-programmatically in Python or by editing a file in your favorite text editor.
+All the settings can be made through a graphical interface, via the command line, or by editing
+an existing settings file.
+
+The settings are grouped into these categories:
+
+- Observatory
+- Camera
+- Passband Map
+- Photometry Apertures
+- Source Location Settings
+- Optional Settings
+- Logging Settings
+
+The first three categories each include a ``name`` property, which is used to identify the
+settings and provides a shortcut to re-using those settings in the future.
+
+A copy of the settings are stored in a file called `stellarphot_settings.json` in the working directory
+where you are using stellarphot. It is these settings that are used when you run the photometry.
+
+Settings can be generated using a jupyter notebook with a graphical interface, by using the command line,
+or by editing a settings file directly.
+
+Graphical interface for generating settings
+-------------------------------------------
+
+To generate settings using a graphical interface, start Jupyter lab. In the launcher will be a section called
+"Stellarphot" with a link to "Generate Settings". Clicking on this link will open a notebook where you can enter settings.
+
+Command line interface for generating settings
+----------------------------------------------
+
+To generate settings using the command line, run the following command:
+
+```bash
+stellarphot-settings
+```
+
+This will generate a settings file in the directory in which you run the command
+called `stellarphot_settings.json`. Edit that file in the editor of your choice.
+
+Editing a settings file directly
+--------------------------------
+
+The settings file is a JSON file that can be edited in any text editor.
+
 
 Provide your observatory information
 -------------------------------------

--- a/docs/stellarphot/index.rst
+++ b/docs/stellarphot/index.rst
@@ -28,7 +28,6 @@ Reference/API
 .. automodapi:: stellarphot.photometry.photometry
 .. automodapi:: stellarphot.photometry.source_detection
 .. automodapi:: stellarphot.plotting
-.. automodapi:: stellarphot.settings
 .. automodapi:: stellarphot.transit_fitting
 .. automodapi:: stellarphot.transit_fitting.gui
 .. automodapi:: stellarphot.transit_fitting.io

--- a/docs/stellarphot/settings.rst
+++ b/docs/stellarphot/settings.rst
@@ -26,7 +26,7 @@ The settings are grouped into these categories:
 A copy of the settings are stored in a file called `stellarphot_settings.json` in the working directory
 where you are using stellarphot. It is these settings that are used when you run the photometry.
 
-Settings can be generated using a jupyter notebook with a graphical interface, by using the command line,
+Settings can be generated using JupyterLab with a graphical interface, by using the command line,
 or by editing a settings file directly.
 
 Settings groups
@@ -66,13 +66,13 @@ and `~stellarphot.settings.PassbandMap`. The ``name`` property of each of these 
 identify the settings.
 
 For example, if you have a camera that you use frequently, you can save the camera settings to a file
-and then load those settings in future sessions. If you are using the Jupyter-based graphical interface,
+and then load those settings in future sessions. If you are using the JupyterLab graphical interface,
 every new camera you create will be saved when you click the "Save" button. If you are working programmatically,
 you can save the camera settings to a file by using the `add_item` method of a
 `~stellarphot.settings.SavedSettings` object.
 
 Suppose you have saved a camera named "My Fancy Camera". To reuse that camera in a future session, you can select
-it in a dropdown in the Jupyter-based graphical interface, or you can load it programmatically by using the
+it in a dropdown in the JupyterLab graphical interface, or you can load it programmatically by using the
 `get_item` method of the `~stellarphot.settings.SavedSettings` class.
 
 An example of creating such a camera, saving it, and then loading is below::

--- a/docs/stellarphot/settings.rst
+++ b/docs/stellarphot/settings.rst
@@ -1,0 +1,142 @@
+Settings
+========
+
+Overview
+--------
+
+Using ``stellarphot`` starts with defining a bunch of configuration settings. Some of these,
+like details about your observing location and camera, will change infrequently.
+Others, like what size apertures to use for photometry and where in each image those
+apertures should be placed, may change from night to night.
+
+All the settings can be made through a graphical interface, via the command line, or by editing
+an existing settings file.
+
+The settings are grouped into these categories:
+
+- `~stellarphot.settings.Observatory`
+- `~stellarphot.settings.Camera`
+- `~stellarphot.settings.PassbandMap`
+- `~stellarphot.settings.PhotometryApertures`
+- `~stellarphot.settings.SourceLocationSettings`
+- `~stellarphot.settings.OptionalSettings`
+- `~stellarphot.settings.LoggingSettings`
+
+
+A copy of the settings are stored in a file called `stellarphot_settings.json` in the working directory
+where you are using stellarphot. It is these settings that are used when you run the photometry.
+
+Settings can be generated using a jupyter notebook with a graphical interface, by using the command line,
+or by editing a settings file directly.
+
+Settings groups
+---------------
+
+
+Observatory information
+^^^^^^^^^^^^^^^^^^^^^^^
+
+TBD
+
+Camera information
+^^^^^^^^^^^^^^^^^^^
+
+TBD
+
+Provide a source list
+^^^^^^^^^^^^^^^^^^^^^^
+
+TBD
+
+Some optional settings
+^^^^^^^^^^^^^^^^^^^^^^
+
+TBD
+
+Entering settings programmatically
+----------------------------------
+
+Saved settings
+--------------
+
+In addition to the settings file that is created in the working directory, you can save some settings
+on your system to make it easier to re-use the settings in the future. The settings that can be saved
+this way are the ones most likely to be reused: `~stellarphot.settings.Camera`, `~stellarphot.settings.Observatory`,
+and `~stellarphot.settings.PassbandMap`. The ``name`` property of each of these objects is used to
+identify the settings.
+
+For example, if you have a camera that you use frequently, you can save the camera settings to a file
+and then load those settings in future sessions. If you are using the Jupyter-based graphical interface,
+every new camera you create will be saved when you click the "Save" button. If you are working programmatically,
+you can save the camera settings to a file by using the `add_item` method of a
+`~stellarphot.settings.SavedSettings` object.
+
+Suppose you have saved a camera named "My Fancy Camera". To reuse that camera in a future session, you can select
+it in a dropdown in the Jupyter-based graphical interface, or you can load it programmatically by using the
+`get_item` method of the `~stellarphot.settings.SavedSettings` class.
+
+An example of creating such a camera, saving it, and then loading is below::
+
+        from stellarphot.settings import Camera, SavedSettings
+
+        # Create a camera
+        camera = Camera(
+            name="My Fancy Camera",
+            data_unit="adu",
+            gain="1.0 electron/adu",
+            read_noise="10.0 electron",
+            dark_current="0.0 electron/s",
+            pixel_scale="1.0 arcsec/pixel",
+            max_data_value="50000 adu",
+        )
+
+        # Get access to the saved settings
+        saved_settings = SavedSettings()
+
+        # Save the camera
+        saved_settings.add_item(camera)
+
+        # Load the camera
+        new_camera = saved_settings.cameras.get("My Fancy Camera")
+
+        # Compare the two cameras to see if they are the same
+        print(camera == new_camera)
+
+More about saved settings
+-------------------------
+
+The `~stellarphot.settings.SavedSettings` class is a container for the saved settings. The location on
+disk depends on the operating system. You can find the location by running the following code::
+
+        from stellarphot.settings import SavedSettings
+
+        saved_settings = SavedSettings()
+        print(saved_settings.settings_path)
+
+All settings can be deleted using the `delete` method of `~stellarphot.settings.SavedSettings`. You can delete
+all settings, or just the camera, observatory, or passband map settings. In each case you must pass in the
+argument ``confirm=True`` or an error will be raised. For example, to delete all settings::
+
+        from stellarphot.settings import SavedSettings
+
+        saved_settings = SavedSettings()
+        saved_settings.delete(confirm=True)
+
+Deleting just the camera settings would be done like this::
+
+        from stellarphot.settings import SavedSettings
+
+        saved_settings = SavedSettings()
+        saved_settings.cameras(confirm=True)
+
+Finally, you can delete a single camera from the saved settings like this::
+
+        from stellarphot.settings import SavedSettings
+
+        saved_settings = SavedSettings()
+        saved_settings.cameras.delete("My Fancy Camera", confirm=True)
+
+Reference/API
+=============
+
+.. automodapi:: stellarphot.settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "photutils >=1.9",
     "pydantic >=2",
     "pyyaml",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]

--- a/stellarphot/settings/__init__.py
+++ b/stellarphot/settings/__init__.py
@@ -1,2 +1,3 @@
 from .models import *
+from .settings_files import *
 from .views import *

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -922,6 +922,13 @@ class PhotometrySettings(BaseModelWithTableRep):
             json_schema_extra=SCHEMA_EXTRAS,
         ),
     ]
+    passband_map: Annotated[
+        PassbandMap,
+        Field(
+            description=_extract_short_description(PassbandMap.__doc__),
+            json_schema_extra=SCHEMA_EXTRAS,
+        ),
+    ]
     photometry_apertures: Annotated[
         PhotometryApertures,
         Field(
@@ -940,13 +947,6 @@ class PhotometrySettings(BaseModelWithTableRep):
         PhotometryOptionalSettings,
         Field(
             description=_extract_short_description(PhotometryOptionalSettings.__doc__),
-            json_schema_extra=SCHEMA_EXTRAS,
-        ),
-    ]
-    passband_map: Annotated[
-        PassbandMap,
-        Field(
-            description=_extract_short_description(PassbandMap.__doc__),
             json_schema_extra=SCHEMA_EXTRAS,
         ),
     ]

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -133,16 +133,16 @@ class Camera(BaseModelWithTableRep):
     Parameters
     ----------
 
+    name : str
+        The name of the camera; can be anything that helps the user identify
+        the camera.
+
     data_unit : `astropy.units.Unit`
         The unit of the data.
 
     gain : `astropy.units.Quantity`
         The gain of the camera in units such the product of `gain`
         times the image data has units equal to that of the `read_noise`.
-
-    name : str
-        The name of the camera; can be anything that helps the user identify
-        the camera.
 
     read_noise : `astropy.units.Quantity`
         The read noise of the camera with units.
@@ -219,6 +219,13 @@ class Camera(BaseModelWithTableRep):
     """
 
     model_config = MODEL_DEFAULT_CONFIGURATION
+
+    name: Annotated[
+        str,
+        Field(
+            description="Name of the camera", examples=["SBIG ST-8300M", "ZWO ASI1600"]
+        ),
+    ]
     data_unit: UnitType = Field(
         description="units of the data", examples=["adu", "counts", "DN", "electrons"]
     )
@@ -226,7 +233,6 @@ class Camera(BaseModelWithTableRep):
         description="unit should be consistent with data and read noise",
         examples=["1.0 electron / adu"],
     )
-    name: str
     read_noise: QuantityType = Field(
         description="unit should be consistent with dark current",
         examples=["10.0 electron"],

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -767,7 +767,7 @@ class PassbandMap(BaseModelWithTableRep):
     >>> # the list of PassbandMapEntry
     >>> passband_map.your_filter_names_to_aavso[1]
     PassbandMapEntry(your_filter_name='rp', aavso_filter_name=<AAVSOFilters.SR: 'SR'>)
-    >>> # Getting the AAVSO filter namee this way is a little cumbersome though:
+    >>> # Getting the AAVSO filter name this way is a little cumbersome though:
     >>> passband_map.your_filter_names_to_aavso[1].aavso_filter_name.value
     'SR'
 

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -172,7 +172,7 @@ class SavedSettings:
         container.as_dict[to_add.name] = to_add
         container.save(self.settings_path)
 
-    def delete(self, confirm=False):
+    def delete(self, confirm=False, delete_settings_folder=False):
         """
         Delete all settings files.
 
@@ -180,10 +180,15 @@ class SavedSettings:
         ----------
         confirm : bool, optional
             If True, the files are deleted. If False, a ValueError is raised.
+
+        delete_settings_folder : bool, optional
+            If True, the directory where settings files are stored is deleted. If False,
+            only the settings files are deleted.
         """
         if not confirm:
             raise ValueError("You must confirm deletion by passing confirm=True")
-        self.cameras.delete(self.settings_path, confirm=confirm)
-        self.observatories.delete(self.settings_path, confirm=confirm)
-        self.passband_maps.delete(self.settings_path, confirm=confirm)
-        self.settings_path.rmdir()
+        Cameras.delete(self.settings_path, confirm=confirm)
+        Observatories.delete(self.settings_path, confirm=confirm)
+        PassbandMaps.delete(self.settings_path, confirm=confirm)
+        if delete_settings_folder:
+            self.settings_path.rmdir()

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -25,6 +25,17 @@ class SavedFileOperations:
         with file_path.open("w") as f:
             f.write(json_data)
 
+    def get(self, name):
+        """
+        Get the item with the given name.
+
+        Parameters
+        ----------
+        name : str
+            Name of the item to get.
+        """
+        return self.as_dict[name]
+
     @classmethod
     def load_model(cls):
         file_path = cls._settings_path / cls._file_name

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -24,7 +24,7 @@ class SavedFileOperations:
     def load_model(cls, path):
         file_path = path / cls._file_name
         if not file_path.exists():
-            return cls(items={})
+            return cls(as_dict={})
         with file_path.open() as f:
             return cls.model_validate_json(f.read())
 
@@ -52,21 +52,21 @@ class Cameras(SavedFileOperations, BaseModel):
     _file_name: ClassVar[str] = "cameras.json"
     "Name of the file where the cameras are saved."
 
-    items: dict[str, Camera]
+    as_dict: dict[str, Camera]
     "Dictionary of cameras, keyed by camera name."
 
 
 class Observatories(SavedFileOperations, BaseModel):
     _file_name: ClassVar[str] = "observatories.json"
     "Name of the file where the observatories are saved."
-    items: dict[str, Observatory]
+    as_dict: dict[str, Observatory]
     "Dictionary of observatories, keyed by observatory name."
 
 
 class PassbandMaps(SavedFileOperations, BaseModel):
     _file_name: ClassVar[str] = "passband_maps.json"
     "Name of the file where the passband maps are saved."
-    items: dict[str, PassbandMap]
+    as_dict: dict[str, PassbandMap]
     "Dictionary of passband maps, keyed by passband map name."
 
 
@@ -111,6 +111,7 @@ class SavedSettings:
         """
         Cameras stored in the settings.
         """
+        # Note that we always reload in case the file has changed.
         return Cameras.load_model(self.settings_path)
 
     @property
@@ -165,10 +166,10 @@ class SavedSettings:
             case _:
                 raise ValueError("Unknown item type")
 
-        if to_add.name in container.items:
+        if to_add.name in container.as_dict:
             raise ValueError(f"{to_add.name} already exists in {container._file_name}")
 
-        container.items[to_add.name] = to_add
+        container.as_dict[to_add.name] = to_add
         container.save(self.settings_path)
 
     def delete(self, confirm=False):

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -6,16 +6,17 @@ from pydantic import BaseModel
 
 from .models import Camera, Observatory, PassbandMap
 
+__all__ = ["SavedSettings", "SETTINGS_FILE_VERSION"]
+
 # We will have to version settings formats, I think. Hopefully this changes rarely
 # or never.
 SETTINGS_FILE_VERSION = "2"  # value chosen to match amjor version of stellarphot
 
 
 class SavedFileOperations:
-    @classmethod
-    def save(cls, path, model):
-        file_path = path / cls.file_name
-        json_data = model.model_dump_json(indent=4)
+    def save(self, path: Path):
+        file_path = path / self.file_name
+        json_data = self.model_dump_json(indent=4)
         with file_path.open("w") as f:
             f.write(json_data)
 
@@ -27,39 +28,160 @@ class SavedFileOperations:
         with file_path.open() as f:
             return cls.model_validate_json(f.read())
 
+    def delete(self, settings_path, confirm=False):
+        """
+        Delete the settings file for this class.
+
+        Parameters
+        ----------
+        confirm : bool, optional
+            If True, the file is deleted. If False, a ValueError is raised.
+        """
+        if confirm:
+            file_path = settings_path / self.file_name
+            file_path.unlink()
+        else:
+            raise ValueError("You must confirm deletion by passing confirm=True")
+
 
 class Cameras(SavedFileOperations, BaseModel):
     # Using the ClassVar annotation means this is treated as a class variable rather
     # than a pydantic field. We don't pydantic storing the name of the settings file in
     # the settings file itself.
     file_name: ClassVar[str] = "cameras.json"
+    "Name of the file where the cameras are saved."
+
     items: dict[str, Camera]
+    "Dictionary of cameras, keyed by camera name."
 
 
-class Observatories(BaseModel):
+class Observatories(SavedFileOperations, BaseModel):
     file_name: ClassVar[str] = "observatories.json"
+    "Name of the file where the observatories are saved."
     items: dict[str, Observatory]
+    "Dictionary of observatories, keyed by observatory name."
 
 
-class PassbandMaps(BaseModel):
+class PassbandMaps(SavedFileOperations, BaseModel):
     file_name: ClassVar[str] = "passband_maps.json"
+    "Name of the file where the passband maps are saved."
     items: dict[str, PassbandMap]
+    "Dictionary of passband maps, keyed by passband map name."
 
 
 class SavedSettings:
-    def __init__(self):
-        data_dir = PlatformDirs(
-            "stellarphot", version=SETTINGS_FILE_VERSION
-        ).user_data_dir
-        self.settings_path = Path(data_dir)
-        if not self.settings_path.exists():
-            self.settings_path.mkdir(parents=True)
+    """
+    Handle loading and saving of settings files from disk.
+    """
+
+    def __init__(self, _testing_path=None, _create_path=True):
+        """
+        Parameters
+        ----------
+
+        _testing_path : Path, optional
+            Path to use for testing purposes. If not provided, the default path is used.
+
+        _create_path : bool, optional
+            If True, the directory where settings files are stored is created if it does
+            not exist. If False, the directory is not created, which is useful for
+            testing.
+        """
+        if _testing_path is not None:
+            data_dir = _testing_path
+        else:
+            data_dir = PlatformDirs(
+                "stellarphot", version=SETTINGS_FILE_VERSION
+            ).user_data_dir
+        self._settings_path = Path(data_dir)
+        if _create_path:
+            if not self.settings_path.exists():
+                self.settings_path.mkdir(parents=True)
+
+    @property
+    def settings_path(self):
+        """
+        Path to the directory where settings files are stored.
+        """
+        return self._settings_path
 
     @property
     def cameras(self) -> Cameras:
-        self._cameras = Cameras.load_model(self.settings_path)
-        return self._cameras
+        """
+        Cameras stored in the settings.
+        """
+        return Cameras.load_model(self.settings_path)
 
-    def add_camera(self, camera: Camera):
-        self.cameras.items[camera.name] = camera
-        Cameras.save(self.settings_path, self._cameras)
+    @property
+    def observatories(self) -> Observatories:
+        """
+        Observatories stored in the settings.
+        """
+        return Observatories.load_model(self.settings_path)
+
+    @property
+    def passband_maps(self) -> PassbandMaps:
+        """
+        Passband maps stored in the settings.
+        """
+        return PassbandMaps.load_model(self.settings_path)
+
+    def get_items(self, item_type):
+        """
+        Get the items of a given type.
+
+        Parameters
+        ----------
+        item_type : str | Camera | Observatory | PassbandMap
+            The type of item to get.
+        """
+        match item_type:
+            case Camera() | "camera":
+                return self.cameras
+            case Observatory() | "observatory":
+                return self.observatories
+            case PassbandMap() | "passband_map":
+                return self.passband_maps
+            case _:
+                raise ValueError(f"Unknown item type {item_type}")
+
+    def add_item(self, item):
+        """
+        Add an item to the settings.
+
+        Parameters
+        ----------
+        item : Camera | Observatory | PassbandMap
+            The item to add.
+        """
+        match item:
+            case Camera() as to_add:
+                container = self.cameras
+            case Observatory() as to_add:
+                container = self.observatories
+            case PassbandMap() as to_add:
+                container = self.passband_maps
+            case _:
+                raise ValueError("Unknown item type")
+
+        if to_add.name in container.items:
+            raise ValueError(f"{to_add.name} already exists in {container.file_name}")
+
+        container.items[to_add.name] = to_add
+        container.save(self.settings_path)
+
+    def delete(self, confirm=False):
+        """
+        Delete all settings files.
+
+        Parameters
+        ----------
+        confirm : bool, optional
+            If True, the files are deleted. If False, a ValueError is raised.
+        """
+        if not confirm:
+            raise ValueError("You must confirm deletion by passing confirm=True")
+        self.cameras.delete(self.settings_path, confirm=confirm)
+        self.observatories.delete(self.settings_path, confirm=confirm)
+        self.passband_maps.delete(self.settings_path, confirm=confirm)
+        self.settings_path.rmdir()

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -180,7 +180,11 @@ class SavedSettings:
             case PassbandMap() | "passband_map":
                 return self.passband_maps
             case _:
-                raise ValueError(f"Unknown item type {item_type}")
+                raise ValueError(
+                    f"Unknown item {item_type} of type {type(item_type)}. Must be "
+                    "Camera, Observatory, or PassbandMap, or "
+                    "'camera', 'observatory', or 'passband_map'"
+                )
 
     def add_item(self, item):
         """
@@ -199,7 +203,10 @@ class SavedSettings:
             case PassbandMap() as to_add:
                 container = self.passband_maps
             case _:
-                raise ValueError("Unknown item type")
+                raise ValueError(
+                    f"Unknown item {item} of type {type(item)}. Must be Camera, "
+                    "Observatory, or PassbandMap"
+                )
 
         if to_add.name in container.as_dict:
             raise ValueError(f"{to_add.name} already exists in {container._file_name}")

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import ClassVar
+
+from platformdirs import PlatformDirs
+from pydantic import BaseModel
+
+from .models import Camera, Observatory, PassbandMap
+
+# We will have to version settings formats, I think. Hopefully this changes rarely
+# or never.
+SETTINGS_FILE_VERSION = "2"  # value chosen to match amjor version of stellarphot
+
+
+class SavedFileOperations:
+    @classmethod
+    def save(cls, path, model):
+        file_path = path / cls.file_name
+        json_data = model.model_dump_json(indent=4)
+        with file_path.open("w") as f:
+            f.write(json_data)
+
+    @classmethod
+    def load_model(cls, path):
+        file_path = path / cls.file_name
+        if not file_path.exists():
+            return cls(items={})
+        with file_path.open() as f:
+            return cls.model_validate_json(f.read())
+
+
+class Cameras(SavedFileOperations, BaseModel):
+    # Using the ClassVar annotation means this is treated as a class variable rather
+    # than a pydantic field. We don't pydantic storing the name of the settings file in
+    # the settings file itself.
+    file_name: ClassVar[str] = "cameras.json"
+    items: dict[str, Camera]
+
+
+class Observatories(BaseModel):
+    file_name: ClassVar[str] = "observatories.json"
+    items: dict[str, Observatory]
+
+
+class PassbandMaps(BaseModel):
+    file_name: ClassVar[str] = "passband_maps.json"
+    items: dict[str, PassbandMap]
+
+
+class SavedSettings:
+    def __init__(self):
+        data_dir = PlatformDirs(
+            "stellarphot", version=SETTINGS_FILE_VERSION
+        ).user_data_dir
+        self.settings_path = Path(data_dir)
+        if not self.settings_path.exists():
+            self.settings_path.mkdir(parents=True)
+
+    @property
+    def cameras(self) -> Cameras:
+        self._cameras = Cameras.load_model(self.settings_path)
+        return self._cameras
+
+    def add_camera(self, camera: Camera):
+        self.cameras.items[camera.name] = camera
+        Cameras.save(self.settings_path, self._cameras)

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -79,8 +79,8 @@ class SavedFileOperations:
 
 class Cameras(SavedFileOperations, BaseModel):
     # Using the ClassVar annotation means this is treated as a class variable rather
-    # than a pydantic field. We don't pydantic storing the name of the settings file in
-    # the settings file itself.
+    # than a pydantic field. We don't want pydantic storing the name of the settings
+    # file in the settings file itself.
     _file_name: ClassVar[str] = "cameras.json"
     "Name of the file where the cameras are saved."
 

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -143,7 +143,7 @@ class TestSavedSettings:
         # Delete the camera.
         saved_settings.cameras.delete(saved_settings.settings_path, confirm=True)
         assert not (
-            saved_settings.settings_path / saved_settings.cameras.file_name
+            saved_settings.settings_path / saved_settings.cameras._file_name
         ).exists()
 
     def test_deleting_all_settings_without_confirm_raises_error(self):

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -1,0 +1,179 @@
+import pytest
+
+from stellarphot.settings import (
+    SETTINGS_FILE_VERSION,
+    Camera,
+    Observatory,
+    PassbandMap,
+    SavedSettings,
+)
+
+CAMERA = """
+{
+    "name": "Aspen CG 16m",
+    "data_unit": "adu",
+    "gain": "1.5 electron / adu",
+    "read_noise": "10.0 electron",
+    "dark_current": "0.01 electron / s",
+    "pixel_scale": "0.6 arcsec / pix",
+    "max_data_value": "50000.0 adu"
+}
+"""
+
+OBSERVATORY = """
+{
+    "name": "Feder",
+    "latitude": "46d52m25.68s",
+    "longitude": "263d13m55.92s",
+    "elevation": "311.0 m",
+    "AAVSO_code": null,
+    "TESS_telescope_code": null
+}
+"""
+
+PASSBAND_MAP = """
+{
+    "name": "Filter wheel 1",
+    "your_filter_names_to_aavso": [
+        {
+            "your_filter_name": "rp",
+            "aavso_filter_name": "SR"
+        },
+        {
+            "your_filter_name": "gp",
+            "aavso_filter_name": "SG"
+        }
+    ]
+}
+"""
+
+
+class TestSavedSettings:
+    def test_settings_path_contains_package_and_version(self):
+        saved_settings = SavedSettings(_create_path=False)
+        assert "stellarphot" in str(saved_settings.settings_path)
+        assert SETTINGS_FILE_VERSION in str(saved_settings.settings_path)
+
+    @pytest.mark.parametrize(
+        "klass,item_json",
+        [(Camera, CAMERA), (Observatory, OBSERVATORY), (PassbandMap, PASSBAND_MAP)],
+    )
+    def test_add_saved_item(self, klass, item_json, tmp_path):
+        # Test that items are properly saved and loaded.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        assert saved_settings.settings_path.exists()
+        # Add a camera.
+        item = klass.model_validate_json(item_json)
+        saved_settings.add_item(item)
+        # Load the cameras
+        saved_items = saved_settings.get_items(item)
+        assert len(saved_items.items) == 1
+        assert saved_items.items[item.name] == item
+
+    @pytest.mark.parametrize(
+        "klass,item_json",
+        [(Camera, CAMERA), (Observatory, OBSERVATORY), (PassbandMap, PASSBAND_MAP)],
+    )
+    def test_adding_multiple_items_of_same_type(self, klass, item_json, tmp_path):
+        # Test that items are properly saved and loaded.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        assert saved_settings.settings_path.exists()
+        # Add an item
+        item1 = klass.model_validate_json(item_json)
+        item2 = klass.model_validate_json(
+            item_json.replace(item1.name, item1.name + "2")
+        )
+        saved_settings.add_item(item1)
+        saved_settings.add_item(item2)
+        # Load the items -- any instance of the class (e.g. Camera) or a
+        # string (e.g. "camera") should work for getting the items.
+        saved_items = saved_settings.get_items(item1)
+        assert len(saved_items.items) == 2
+        assert saved_items.items[item2.name] == item2
+        assert saved_items.items[item1.name] == item1
+
+    def test_add_existing_saved_item_raises_error(self, tmp_path):
+        # Test that adding an existing camera raises an error. Other items follow the
+        # same pattern, so only cameras are tested.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        item = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(item)
+        # Add the same camera again.
+        with pytest.raises(
+            ValueError, match="Aspen CG 16m already exists in cameras.json"
+        ):
+            saved_settings.add_item(item)
+
+    def test_adding_multiple_types_of_items(self, tmp_path):
+        # Test that adding multiple types of items works.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        # Add an observatory.
+        observatory = Observatory.model_validate_json(OBSERVATORY)
+        saved_settings.add_item(observatory)
+        # Add a passband map.
+        passband_map = PassbandMap.model_validate_json(PASSBAND_MAP)
+        saved_settings.add_item(passband_map)
+        # Load the items
+        cameras = saved_settings.get_items("camera")
+        assert len(cameras.items) == 1
+        assert cameras.items[camera.name] == camera
+        observatories = saved_settings.get_items("observatory")
+        assert len(observatories.items) == 1
+        assert observatories.items[observatory.name] == observatory
+        passband_maps = saved_settings.get_items("passband_map")
+        assert len(passband_maps.items) == 1
+        assert passband_maps.items[passband_map.name] == passband_map
+
+    def test_delete_without_confirm_raises_error(self):
+        # Trying to delete settings without confirming should raise an error.
+        saved_settings = SavedSettings(_create_path=False)
+        with pytest.raises(ValueError, match="You must confirm deletion by passing"):
+            saved_settings.cameras.delete(saved_settings.settings_path)
+
+    def test_delete_with_confirm_deletes_file(self, tmp_path):
+        # Test that deleting a settings file works.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        # Delete the camera.
+        saved_settings.cameras.delete(saved_settings.settings_path, confirm=True)
+        assert not (
+            saved_settings.settings_path / saved_settings.cameras.file_name
+        ).exists()
+
+    def test_deleting_all_settings_without_confirm_raises_error(self):
+        # Trying to delete all settings without confirming should raise an error.
+        saved_settings = SavedSettings(_create_path=False)
+        with pytest.raises(ValueError, match="You must confirm deletion by passing"):
+            saved_settings.delete()
+
+    def test_delete_all_settings_with_confirm_deletes_files(self, tmp_path):
+        # Test that deleting all settings files works.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        # Add an observatory.
+        observatory = Observatory.model_validate_json(OBSERVATORY)
+        saved_settings.add_item(observatory)
+        # Add a passband map.
+        passband_map = PassbandMap.model_validate_json(PASSBAND_MAP)
+        saved_settings.add_item(passband_map)
+
+        # Delete all settings.
+        saved_settings.delete(confirm=True)
+        assert not (
+            saved_settings.settings_path / saved_settings.cameras.file_name
+        ).exists()
+        assert not (
+            saved_settings.settings_path / saved_settings.observatories.file_name
+        ).exists()
+        assert not (
+            saved_settings.settings_path / saved_settings.passband_maps.file_name
+        ).exists()
+        assert not saved_settings.settings_path.exists()

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -212,6 +212,14 @@ class TestSavedSettings:
         saved_settings.cameras.delete(name=camera2.name, confirm=True)
         assert len(saved_settings.cameras.as_dict) == 1
 
+    def test_delete_item_from_collection_with_unknown_item_fails(self, tmp_path):
+        # Test that trying to delete an unknown item from a collection fails.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        with pytest.raises(ValueError, match="not found in"):
+            saved_settings.cameras.delete(name=camera.name + "foo", confirm=True)
+
     def test_revtrieving_item_by_name_works(self, tmp_path):
         # Test that retrieving an item by name works.
         saved_settings = SavedSettings(_testing_path=tmp_path)

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from stellarphot.settings import (
@@ -53,6 +55,12 @@ class TestSavedSettings:
         saved_settings = SavedSettings(_create_path=False)
         assert "stellarphot" in str(saved_settings.settings_path)
         assert SETTINGS_FILE_VERSION in str(saved_settings.settings_path)
+
+    def test_settings_path_is_created_if_not_exists(self, tmp_path):
+        p = Path(tmp_path / "not a path that exists yet")
+        assert not p.exists()
+        saved_settings = SavedSettings(_testing_path=p)
+        assert saved_settings.settings_path.exists()
 
     @pytest.mark.parametrize(
         "klass,item_json",
@@ -213,3 +221,15 @@ class TestSavedSettings:
         # Retrieve the camera by name.
         retrieved_camera = saved_settings.cameras.get(camera.name)
         assert retrieved_camera == camera
+
+    def test_get_item_with_unknown_item_fails(self, tmp_path):
+        # Test that trying to get an unknown item fails.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        with pytest.raises(ValueError, match="Unknown item foo of type"):
+            saved_settings.get_items("foo")
+
+    def test_add_item_with_unknown_item_fails(self, tmp_path):
+        # Test that trying to add an unknown item fails.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        with pytest.raises(ValueError, match="Unknown item foo of type"):
+            saved_settings.add_item("foo")

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -203,3 +203,13 @@ class TestSavedSettings:
         # Delete the second camera.
         saved_settings.cameras.delete(name=camera2.name, confirm=True)
         assert len(saved_settings.cameras.as_dict) == 1
+
+    def test_revtrieving_item_by_name_works(self, tmp_path):
+        # Test that retrieving an item by name works.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        # Retrieve the camera by name.
+        retrieved_camera = saved_settings.cameras.get(camera.name)
+        assert retrieved_camera == camera

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -132,7 +132,7 @@ class TestSavedSettings:
         # Trying to delete settings without confirming should raise an error.
         saved_settings = SavedSettings(_testing_path=tmp_path)
         with pytest.raises(ValueError, match="You must confirm deletion by passing"):
-            saved_settings.cameras.delete(saved_settings.settings_path)
+            saved_settings.cameras.delete()
 
     def test_delete_with_confirm_deletes_file(self, tmp_path):
         # Test that deleting a settings file works.
@@ -141,7 +141,7 @@ class TestSavedSettings:
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
         # Delete the camera.
-        saved_settings.cameras.delete(saved_settings.settings_path, confirm=True)
+        saved_settings.cameras.delete(confirm=True)
         assert not (
             saved_settings.settings_path / saved_settings.cameras._file_name
         ).exists()
@@ -188,3 +188,18 @@ class TestSavedSettings:
         # Delete all settings and the settings folder
         saved_settings.delete(confirm=True, delete_settings_folder=True)
         assert not saved_settings.settings_path.exists()
+
+    def test_delete_item_from_collection_works(self, tmp_path):
+        # Test that deleting an item from a collection works.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera.
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        camera2 = Camera.model_validate_json(CAMERA.replace("Aspen CG 16m", "foo"))
+        saved_settings.add_item(camera2)
+
+        # Make sure both cameras are in the collection.
+        assert len(saved_settings.cameras.as_dict) == 2
+        # Delete the second camera.
+        saved_settings.cameras.delete(name=camera2.name, confirm=True)
+        assert len(saved_settings.cameras.as_dict) == 1

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -166,14 +166,25 @@ class TestSavedSettings:
         saved_settings.add_item(passband_map)
 
         # Delete all settings.
+        saved_settings.delete(confirm=True, delete_settings_folder=True)
+        assert not (
+            saved_settings.settings_path / saved_settings.cameras._file_name
+        ).exists()
+        assert not (
+            saved_settings.settings_path / saved_settings.observatories._file_name
+        ).exists()
+        assert not (
+            saved_settings.settings_path / saved_settings.passband_maps._file_name
+        ).exists()
+        assert not saved_settings.settings_path.exists()
+
+    def test_delete_all_with_no_settings_works(self, tmp_path):
+        # Test that deleting all settings files works when no settings are present.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Delete all settings but not the settings folder
         saved_settings.delete(confirm=True)
-        assert not (
-            saved_settings.settings_path / saved_settings.cameras.file_name
-        ).exists()
-        assert not (
-            saved_settings.settings_path / saved_settings.observatories.file_name
-        ).exists()
-        assert not (
-            saved_settings.settings_path / saved_settings.passband_maps.file_name
-        ).exists()
+        assert len(list(saved_settings.settings_path.glob("*"))) == 0
+
+        # Delete all settings and the settings folder
+        saved_settings.delete(confirm=True, delete_settings_folder=True)
         assert not saved_settings.settings_path.exists()

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -67,8 +67,8 @@ class TestSavedSettings:
         saved_settings.add_item(item)
         # Load the cameras
         saved_items = saved_settings.get_items(item)
-        assert len(saved_items.items) == 1
-        assert saved_items.items[item.name] == item
+        assert len(saved_items.as_dict) == 1
+        assert saved_items.as_dict[item.name] == item
 
     @pytest.mark.parametrize(
         "klass,item_json",
@@ -88,9 +88,9 @@ class TestSavedSettings:
         # Load the items -- any instance of the class (e.g. Camera) or a
         # string (e.g. "camera") should work for getting the items.
         saved_items = saved_settings.get_items(item1)
-        assert len(saved_items.items) == 2
-        assert saved_items.items[item2.name] == item2
-        assert saved_items.items[item1.name] == item1
+        assert len(saved_items.as_dict) == 2
+        assert saved_items.as_dict[item2.name] == item2
+        assert saved_items.as_dict[item1.name] == item1
 
     def test_add_existing_saved_item_raises_error(self, tmp_path):
         # Test that adding an existing camera raises an error. Other items follow the
@@ -119,18 +119,18 @@ class TestSavedSettings:
         saved_settings.add_item(passband_map)
         # Load the items
         cameras = saved_settings.get_items("camera")
-        assert len(cameras.items) == 1
-        assert cameras.items[camera.name] == camera
+        assert len(cameras.as_dict) == 1
+        assert cameras.as_dict[camera.name] == camera
         observatories = saved_settings.get_items("observatory")
-        assert len(observatories.items) == 1
-        assert observatories.items[observatory.name] == observatory
+        assert len(observatories.as_dict) == 1
+        assert observatories.as_dict[observatory.name] == observatory
         passband_maps = saved_settings.get_items("passband_map")
-        assert len(passband_maps.items) == 1
-        assert passband_maps.items[passband_map.name] == passband_map
+        assert len(passband_maps.as_dict) == 1
+        assert passband_maps.as_dict[passband_map.name] == passband_map
 
-    def test_delete_without_confirm_raises_error(self):
+    def test_delete_without_confirm_raises_error(self, tmp_path):
         # Trying to delete settings without confirming should raise an error.
-        saved_settings = SavedSettings(_create_path=False)
+        saved_settings = SavedSettings(_testing_path=tmp_path)
         with pytest.raises(ValueError, match="You must confirm deletion by passing"):
             saved_settings.cameras.delete(saved_settings.settings_path)
 


### PR DESCRIPTION
The motivation of this pull request is to add a system for saving some settings -- those with a ``name`` field -- in a way that makes reuse easier.

The main additions are in the file `stellarphot/settings/saved_settings.py`, in particular the `SavedSettings` class.  I also fleshed out some of the settings code a little more.

This does add a new dependency, on (`platformdirs`)[https://github.com/platformdirs/platformdirs] which handles figuring out where user data should be stored on each platform. On Mac this ends up being inside `~/Library/Application Support/stellarphot/2`, where `2` refers the the version number of the code.

Once this in I'll open a PR with some notebooks that use this to make re-using settings easier. The idea is that camera, observatory, and passband map will be represented by dropdowns with the current cameras, etc, and an option to create a new camera.

Not sure I'll work up a UI to manage the saved settings more extensively or not, but adding this resolves one of the things I'd been confused about: how to make it easy to re-use camera, observatory or passband map without having to do a bunch of copy/paste.