### PR TITLE
Impose restrictions on name field

### DIFF
--- a/docs/stellarphot/settings.rst
+++ b/docs/stellarphot/settings.rst
@@ -127,14 +127,14 @@ Deleting just the camera settings would be done like this::
         from stellarphot.settings import SavedSettings
 
         saved_settings = SavedSettings()
-        saved_settings.cameras(confirm=True)
+        saved_settings.cameras.delete(confirm=True)
 
 Finally, you can delete a single camera from the saved settings like this::
 
         from stellarphot.settings import SavedSettings
 
         saved_settings = SavedSettings()
-        saved_settings.cameras.delete("My Fancy Camera", confirm=True)
+        saved_settings.cameras.delete(name="My Fancy Camera", confirm=True)
 
 Reference/API
 =============

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -474,7 +474,13 @@ class TessTargetFile:
         result = requests.get(
             self.aperture_server + "cgi-bin/gaia_to_aij/upload_request.cgi",
             params=params,
+            timeout=15,  # If no response in 15 seconds we won't ever get one...
         )
+        if result.status_code != 200:
+            raise requests.ConnectionError(
+                f"Failed to retrieve target file: {result.text}"
+            )
+
         links = re.search(
             'href="(.+)"',
             result.text.replace("\n", ""),

--- a/stellarphot/io/tests/test_tess_submission.py
+++ b/stellarphot/io/tests/test_tess_submission.py
@@ -3,7 +3,7 @@ import warnings
 
 import pytest
 from astropy.coordinates import SkyCoord
-from requests import ConnectionError
+from requests import ConnectionError, ReadTimeout
 
 from stellarphot.io.tess import TessSubmission, TessTargetFile
 
@@ -85,7 +85,7 @@ def test_target_file():
 
     try:
         tess_target = TessTargetFile(tic_742648307, magnitude=12, depth=10)
-    except ConnectionError:
+    except (ConnectionError, ReadTimeout):
         server_down = True
         tess_target = None  # Assure tess_target is defined so that we can delete it
     except ValueError:

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -215,6 +215,48 @@ class TestModelAgnosticActions:
         assert all(title_present)
 
 
+@pytest.mark.parametrize(
+    "model,settings",
+    [
+        [Camera, TEST_CAMERA_VALUES.copy()],
+        [Observatory, DEFAULT_OBSERVATORY_SETTINGS.copy()],
+        [PassbandMap, DEFAULT_PASSBAND_MAP.copy()],
+    ],
+)
+class TestModelsWithName:
+    """
+    Tests that are specific to models that have a name property.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_name,error_msg",
+        [
+            ("", "name must not be empty or contain only whitespace"),
+            (" ", "name must not be empty or contain only whitespace"),
+            ("  ", "name must not be empty or contain only whitespace"),
+            (
+                "name with trailing spaces ",
+                "name must not have leading or trailing whitespace",
+            ),
+            (
+                " name with leading spaces",
+                "name must not have leading or trailing whitespace",
+            ),
+        ],
+    )
+    def test_name_cannot_have_awkward_whitespace(
+        self, model, settings, bad_name, error_msg
+    ):
+        settings["name"] = bad_name
+        with pytest.raises(ValidationError, match=error_msg):
+            model(**settings)
+
+    def test_name_unicode_is_ok(self, model, settings):
+        # Test that the name field can be unicode
+        settings["name"] = "π"
+        assert model(**settings).name == "π"
+
+
 def test_camera_unitscheck():
     # Check that the units are checked properly
 


### PR DESCRIPTION
I realized while working on the form for entering `Camera` and other named objects that it allowed a bunch of bad names, like `""` or `"  "`. Since leading or trailing whitespace in a name also seemed like a bad idea, this PR adds (and tests) this constraint on the name field:

+ Must be one or more non-whitespace characters
+ Cannot have leading or trailing whitespace

A quick review on this would be helpful...