### PR TITLE
Add a widget for settings like Camera that can be saved with names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "ipyautoui >=0.7.15",
     "ipyfilechooser",
     "ipywidgets",
+    "jupyter-app-launcher",
     "matplotlib",
     "pandas",
     "photutils >=1.9",
@@ -55,6 +56,11 @@ source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "stellarphot/_version.py"
+
+[tool.hatch.build.targets.wheel.shared-data]
+"stellarphot/notebooks/photometry" = "share/jupyter/stellarphot/photometry"
+"stellarphot/notebooks" = "share/jupyter/stellarphot"
+"stellarphot/notebooks/jp_app_launcher_stellarphot.yaml" = "share/jupyter/jupyter_app_launcher/jp_app_launcher_stellarphot.yaml"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,5 +157,7 @@ filterwarnings = [
     # pandas will require pyarrow at some point, which is good to know, I guess...
     'ignore:[.\n]*Pyarrow will become a required dependency of pandas[.\n]*:DeprecationWarning',
     # ipyautoui is generating this on import because they still have some pydantic changes to make
-    'ignore:Using extra keyword arguments on `Field` is deprecated:'
+    'ignore:Using extra keyword arguments on `Field` is deprecated:',
+    # ipywidgets is using something deprecated in traitlets
+    'ignore:Deprecated in traitlets 4.1, use the instance:DeprecationWarning',
 ]

--- a/stellarphot/notebooks/jp_app_launcher_stellarphot.yaml
+++ b/stellarphot/notebooks/jp_app_launcher_stellarphot.yaml
@@ -1,0 +1,7 @@
+- title: Saveable settings for testing
+  description: Settings for camera, observatory and passbands
+  source: ../stellarphot/saveable-settings.ipynb
+  icon: ../stellarphot/photometry/glowing-waffle-3-smaller.svg
+  cwd: not_used
+  type: notebook
+  catalog: Stellarphot

--- a/stellarphot/notebooks/saveable-settings.ipynb
+++ b/stellarphot/notebooks/saveable-settings.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4cd2d431-7993-4aa6-9fc9-34e4a46be376",
+   "metadata": {},
+   "source": [
+    "# Instructions for testing\n",
+    "\n",
+    "As you try this notebook out please take notes on anything you are confused by or have questions about, or things you especially like.\n",
+    "\n",
+    "You can email those to Matt Craig or make an issue at https://github.com/feder-observatory/stellarphot/issues/new\n",
+    "\n",
+    "1. Try making at least two of each type of object: camera, telescope, passband map.\n",
+    "2. The names of the two need to be different but the rest of the values can be the same.\n",
+    "3. For the camera and observatory it is fine to use the example values that are displayed.\n",
+    "4. For the passband map, give the map a name, then click the \"+\" button to start adding entries. For each entry, you type in the name of a filter on the first line and choose an item from the dropdown in the second line. Add at least one entry; more than that is up to you.\n",
+    "5. Try editing one of the values.\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6993b7c8-bb85-4fc4-a477-8b934cc7bc69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as ipw\n",
+    "\n",
+    "from stellarphot.settings.custom_widgets import ChooseOrMakeNew"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2aecde7e-27db-4287-8c51-653bb496c2f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "to_make = [\"camera\", \"observatory\", \"passband_map\"]\n",
+    "widgets = [ChooseOrMakeNew(item) for item in to_make]\n",
+    "\n",
+    "tabs = ipw.Tab(children=widgets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40abe658-40a9-4237-8c83-0eae2249b476",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "tabs.titles = [item.replace(\"_\", \" \").capitalize() for item in to_make]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef72e7d8-0a4c-4bec-9c36-2f976ca42542",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tabs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "424e3b5e-18a7-4a6c-a8fe-7f9f7734b3b2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -292,6 +292,24 @@ class ChooseOrMakeNew(ipw.VBox):
 
         # Use a closure here to capture the current state of the widget
         def save_confirm_handler(change):
+            """
+            This handles interactions with the confirmation widget, which is displayed
+            when the user either tries to save a new item with the same name as an
+            existing one or tries to save an edited item with the same name as an
+            existing one.
+
+            The widget has three possible values: True (yes), False (no), and None
+
+            This widget is called whent the widget value changes, which can happen two
+            ways:
+
+            1. The user clicks the "yes" or "no" button, in which case the value will
+                be True or False, respectively.
+            2. This handler sets the value to None after the user has clicked Yes or No.
+
+            The second case is the reason most of the handler is wrapped in an
+            if statement.
+            """
             # value of None means the widget has been reset to not answered
             if change["new"] is not None:
                 item = self._item_widget.model(**self._item_widget.value)

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -1,0 +1,391 @@
+# Some settings require custom widgets to be displayed in the GUI. These are defined in
+# this module.
+
+import ipywidgets as ipw
+import traitlets as tr
+from ipyautoui.autoobject import AutoObject
+
+from stellarphot.settings import (
+    Camera,
+    Observatory,
+    PassbandMap,
+    SavedSettings,
+    ui_generator,
+)
+
+
+class ChooseOrMakeNew(ipw.VBox):
+    """
+    Widget to present a list of existing items or the option to make a new one.
+
+    Parameters
+    ----------
+
+    item_type_name : str
+        Name of the item type to be displayed in the widget. Must be one of
+        "camera", "observatory", "passband_map", "Camera", "Observatory"
+        or "PassbandMap".
+    """
+
+    _known_types = [
+        "camera",
+        "observatory",
+        "passband_map",
+        Camera.__name__,
+        Observatory.__name__,
+        PassbandMap.__name__,
+    ]
+
+    def __init__(self, item_type_name, *arg, _testing_path=None, **kwargs):
+        if item_type_name not in self._known_types:
+            raise ValueError(
+                f"Unknown item type {item_type_name}. Must "
+                f"be {', '.join(self._known_types)}"
+            )
+        # Get the widgety goodness from the parent class
+        super().__init__(*arg, **kwargs)
+
+        self._saved_settings = SavedSettings(_testing_path=_testing_path)
+        self._item_type_name = item_type_name
+
+        # keep track of whether we are editing an existing item
+        self._editing = False
+
+        self._display_name = item_type_name.replace("_", " ")
+
+        # Create the child widgets
+        self._title = ipw.HTML(
+            value=(f"<h2>Choose a {self._display_name} " "or make a new one</h2>")
+        )
+
+        self._choose_existing = ipw.Dropdown(description="")
+
+        self._edit_button = ipw.Button(
+            description=f"Edit this {self._display_name}",
+            # width below was chosen to match the dropdown...would prefer to
+            # determine this programmatically but don't know how.
+            layout={"width": "300px"},
+        )
+
+        self._confirm_edit = Confirm(
+            message=f"Replace value of this {self._display_name}?",
+        )
+
+        self._item_widget = self._make_new_widget()
+
+        self._edit_button.on_click(self._edit_button_action)
+
+        # Build the main widget
+        self.children = [
+            self._title,
+            self._choose_existing,
+            self._edit_button,
+            self._confirm_edit,
+            self._item_widget,
+        ]
+
+        # Set up the dropdown widget
+        self._construct_choices()
+        # Set the selection to the first choice if there is one
+        self._choose_existing.value = self._choose_existing.options[0][1]
+
+        if len(self._choose_existing.options) == 1:
+            # There are no items, so we are making a new one
+            self._choose_existing.disabled = True
+            self._choose_existing.layout.display = "none"
+            self._title.value = f"<h2>Make a new {item_type_name}</h2>"
+        else:
+            self._handle_selection({"new": self._choose_existing.value})
+
+        # A couple of styling choices for the way existing objects appear
+        # in this UI. The title/description is clear from the title of this
+        # widget.
+        self._item_widget.show_title = False
+        self._item_widget.show_description = False
+        # Really only applies to PassbandMap, which has nested models,
+        # but does no harm in the other cases (true of both lines below)
+        self._item_widget.open_nested = True
+
+        self._item_widget.savebuttonbar.fns_onsave_add_action(self._save_confirmation())
+
+        # Link validation value to save button. The use of directional link
+        # is important to make sure the validation state controls
+        # the save button state and not the other way around.
+        ipw.dlink(
+            (self._item_widget.is_valid, "value"),
+            (self._item_widget.savebuttonbar.bn_save, "disabled"),
+            transform=lambda x: not x,
+        )
+
+        # Set up some observers
+
+        # Respond to user interacting with a confirmation widget
+        # Hide the save button bar so the user gets the confirmation instead
+        self._confirm_edit.widget_to_hide = self._item_widget.savebuttonbar
+        # Add the observer
+        self._confirm_edit.observe(self._handle_confirmation(), names="value")
+
+        # Respond when user wants to make a new thing
+        self._choose_existing.observe(self._handle_selection, names="value")
+
+    def _save_confirmation(self):
+        """
+        Function to attach to the save button to show the confirmation widget if
+        the save button was clicked while editing an existing item.
+        """
+
+        def f():
+            # This function will be run every time the save button is clicked but
+            # we only want to ask for confirmation if we are editing an existing item
+            # rather than saving a new one.
+            if self._editing:
+                self._confirm_edit.show()
+
+        return f
+
+    def _construct_choices(self):
+        """
+        Set up the choices for the selection widget.
+        """
+        saved_items = self._saved_settings.get_items(self._item_type_name)
+        existing_choices = [(k, v) for k, v in saved_items.as_dict.items()]
+        existing_choices = sorted(existing_choices, key=lambda x: x[0].lower())
+        choices = existing_choices + [(f"Make new {self._display_name}", "none")]
+        # This sets the options but doesn't select any of them
+        self._choose_existing.options = choices
+
+    def _handle_selection(self, change):
+        if change["new"] == "none":
+
+            # We are making a new item...
+
+            # Hide the edit button
+            self._edit_button.layout.display = "none"
+
+            # This sets the ui back to its original state when created, i.e.
+            # everything is empty.
+            self._item_widget._init_ui()
+            self._item_widget.show_savebuttonbar = True
+            self._item_widget.disabled = False
+
+            # Set the validation status to invalid since the user must
+            # fill in the fields, and display the validation status
+            self._item_widget.is_valid.value = False
+            self._item_widget.is_valid.layout.display = "flex"
+
+            # Really only applies to PassbandMap, which has nested models,
+            # but does no harm in the other cases (true of both lines below)
+            # (and yes, both lines below are needed...this is a bug in ipyautoui,
+            #  I think, because open_nested=True isn't respected when we _init_ui.
+            #  Forcing a *change* in the value triggers the behavior we want.)
+            self._item_widget.open_nested = False
+            self._item_widget.open_nested = True
+
+        else:
+            # Display the selected item...
+            self._item_widget.show_savebuttonbar = False
+            self._item_widget.disabled = True
+            self._item_widget.is_valid.layout.display = "none"
+            self._item_widget.value = self._get_item(change["new"].name)
+
+            # Really only applies to PassbandMap, which has nested models,
+            # but does no harm in the other cases
+            self._set_disable_state_nested_models(self._item_widget, True)
+
+    def _edit_button_action(self, _):
+        """
+        Handle the edit button being clicked.
+        """
+        # Replace the display of the edit button with the save button bar...
+        self._edit_button.layout.display = "none"
+        self._item_widget.show_savebuttonbar = True
+        # ...enable the widget...
+        self._item_widget.disabled = False
+        # ...and show the validation status
+        self._item_widget.is_valid.layout.display = "flex"
+
+        # Enable the nested model components
+        self._set_disable_state_nested_models(self._item_widget, False)
+
+        # disable the name control, since the whole point of this
+        # is to be able to replace the values for a particular name
+        self._item_widget.di_widgets["name"].disabled = True
+
+        # Thie really only applies to PassbandMap, which has nested models,
+        # but does no harm in the other cases (true of both lines below)
+        # (and yes, both lines below are needed...this is a bug in ipyautoui,
+        #  I think, because open_nested=True isn't respected when we _init_ui.
+        #  Forcing a *change* in the value triggers the behavior we want.)
+        self._item_widget.open_nested = False
+        self._item_widget.open_nested = True
+
+        # Update the current state of the widget
+        self._editing = True
+
+    def _set_disable_state_nested_models(self, top, value):
+        """
+        When a one model contains another and the top-level model widget
+        sets disabled=True that does not actually disable the nested model.
+        This method handles that in a crude way by walking the tree of
+        widgets in the top-level model widget and disabling them all.
+
+        Parameters
+        ----------
+
+        top : `ipyautoui.AutoUi`
+            Top-level widget that may have nested models.
+
+        value : bool
+            State that ``disabled`` should be set to.
+        """
+
+        if hasattr(top, "disabled") or isinstance(top, AutoObject):
+            top.disabled = value
+        try:
+            for child in top.children:
+                self._set_disable_state_nested_models(child, value)
+        except AttributeError:
+            # No children...
+            pass
+
+    def _make_new_widget(self):
+        """
+        Make a new widget for the item type and set up actions for the save button.
+        """
+        match self._item_type_name:
+            case "camera" | Camera.__name__:
+                new_widget = ui_generator(Camera)
+            case "observatory" | Observatory.__name__:
+                new_widget = ui_generator(Observatory)
+            case "passband_map" | PassbandMap.__name__:
+                new_widget = ui_generator(PassbandMap)
+
+        def saver():
+            """
+            Tries to save the new item, and if it fails, shows the confirmation widget.
+            """
+            try:
+                self._saved_settings.add_item(new_widget.model(**new_widget.value))
+            except ValueError:
+                # This will happen if the item already exists
+                self._confirm_edit.show()
+
+        def update_choices_and_select_new():
+            """
+            Update the choices after a new item is saved, update the choices
+            and select the new item.
+            """
+            if not self._editing:
+                value_to_select = new_widget.model(**new_widget.value)
+                self._construct_choices()
+                self._choose_existing.value = value_to_select
+
+        # This is the mechanism for adding callbacks to the save button.
+        new_widget.savebuttonbar.fns_onsave_add_action(saver)
+        new_widget.savebuttonbar.fns_onsave_add_action(update_choices_and_select_new)
+        return new_widget
+
+    def _handle_confirmation(self):
+        """
+        Handle the confirmation of a save operation.
+        """
+
+        # Use a closure here to capture the current state of the widget
+        def save_confirm_handler(change):
+            # value of None means the widget has been reset to not answered
+            if change["new"] is not None:
+                item = self._item_widget.model(**self._item_widget.value)
+                if change["new"]:
+                    # Use has said yes to updating the item, which we do by
+                    # deleting the old one and adding the new one.
+                    self._saved_settings.delete_item(item, confirm=True)
+                    self._saved_settings.add_item(item)
+                    # Rebuild the dropdown list
+                    self._construct_choices()
+                    # Select the edited item
+                    self._choose_existing.value = item
+                else:
+                    # Use has said no to updating the item, so we just
+                    # act as though the user has selected this item.
+                    self._handle_selection({"new": item})
+
+                # Reset the confirmation widget to unanswered
+                self._confirm_edit.value = None
+            # We are done editing regardless of the confirmation outcome
+            self._editing = False
+            # Bring the edit button back
+            self._edit_button.layout.display = "flex"
+
+        return save_confirm_handler
+
+    def _get_item(self, item_name):
+        """
+        Get an item from the saved settings by name.
+        """
+        match self._item_type_name:
+            case "camera" | Camera.__name__:
+                container = self._saved_settings.cameras
+            case "observatory" | Observatory.__name__:
+                container = self._saved_settings.observatories
+            case "passband_map" | PassbandMap.__name__:
+                container = self._saved_settings.passband_maps
+
+        return container.as_dict[item_name]
+
+
+class Confirm(ipw.HBox):
+    """
+    Widget to confirm a choice.
+
+    The value of this widget will be ``True`` if the user confirms the choice, ``False``
+    if they do not, and ``None`` if they have not yet answered.
+    """
+
+    def __init__(self, message="", widget_to_hide=None, *arg, **kwargs):
+        super().__init__(*arg, **kwargs)
+        # Hide this widget until it is needed
+        self.layout.display = "none"
+        self._other_widget = widget_to_hide
+        self._message = ipw.HTML(value=message)
+        button_layout = ipw.Layout(width="50px")
+        self._yes = ipw.Button(
+            description="Yes", button_style="success", layout=button_layout
+        )
+        self._no = ipw.Button(
+            description="No", button_style="danger", layout=button_layout
+        )
+        self._yes.on_click(self._handle_yes)
+        self._no.on_click(self._handle_no)
+        self.children = [self._message, self._yes, self._no]
+        # Value van be either True (yes), False (no), or None (not yet answered)
+        self.add_traits(value=tr.Bool(allow_none=True))
+        self.value = None
+
+    @property
+    def message(self):
+        return self._message.value
+
+    @message.setter
+    def message(self, value):
+        self._message.value = value
+
+    def show(self):
+        """
+        Display the confrimation widget and, if desired, hide the widget it replaces.
+        """
+        self.layout.display = "flex"
+        if self._other_widget is not None:
+            self._other_widget.layout.display = "none"
+
+    # THere ought to be a way to refactor these two, but this works for now.
+    def _handle_yes(self, _):
+        self.layout.display = "none"
+        if self._other_widget is not None:
+            self._other_widget.layout.display = "flex"
+        self.value = True
+
+    def _handle_no(self, _):
+        self.layout.display = "none"
+        if self._other_widget is not None:
+            self._other_widget.layout.display = "flex"
+        self.value = False

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -815,18 +815,15 @@ class PassbandMap(BaseModelWithTableRep):
             examples=["Filter wheel 1"],
         ),
     ]
-    your_filter_names_to_aavso: list[PassbandMapEntry] | None
+    your_filter_names_to_aavso: list[PassbandMapEntry]
 
     def model_post_init(self, __context: Any) -> None:
         # Create a dictionary from the list of entries so that the object
         # can behave like a dictionary.
-        if self.your_filter_names_to_aavso is None:
-            self._dict = {}
-        else:
-            self._dict = {
-                entry.your_filter_name: entry.aavso_filter_name.value
-                for entry in self.your_filter_names_to_aavso
-            }
+        self._dict = {
+            entry.your_filter_name: entry.aavso_filter_name.value
+            for entry in self.your_filter_names_to_aavso
+        }
 
     @field_validator("your_filter_names_to_aavso", mode="before")
     @classmethod
@@ -956,7 +953,7 @@ class PhotometrySettings(BaseModelWithTableRep):
         ),
     ]
     passband_map: Annotated[
-        PassbandMap,
+        PassbandMap | None,
         Field(
             description=_extract_short_description(PassbandMap.__doc__),
             json_schema_extra=SCHEMA_EXTRAS,

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -771,13 +771,13 @@ class PassbandMap(BaseModelWithTableRep):
     your_filter_names_to_aavso : list[`stellarphot.settings.PassbandMapEntry`]
         A list of pairs of your filter name and the corresponding AAVSO filter name.
         This is used to rename the passband entries in the output photometry table.
-        Note that, as shown in the example below, you can intialize this with a
+        Note that, as shown in the example below, you can initialize this with a
         dictionary, and it will be converted to a list of `PassbandMapEntry` objects.
 
     Notes
     -----
 
-    This class behaves like a dictionary interms of accessing individual entries but
+    This class behaves like a dictionary in terms of accessing individual entries but
     you _cannot_ use the `dict` methods to modify the object. This means, for example,
     that if ``my_map`` is a `PassbandMap` object, you can access the AAVSO passband
     that corresponds to your ``B`` passband with ``my_map["B"]`` but you _cannot_

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -173,11 +173,11 @@ class SavedSettings:
             The type of item to get.
         """
         match item_type:
-            case Camera() | "camera":
+            case Camera() | "camera" | Camera.__name__:
                 return self.cameras
-            case Observatory() | "observatory":
+            case Observatory() | "observatory" | Observatory.__name__:
                 return self.observatories
-            case PassbandMap() | "passband_map":
+            case PassbandMap() | "passband_map" | PassbandMap.__name__:
                 return self.passband_maps
             case _:
                 raise ValueError(
@@ -234,3 +234,30 @@ class SavedSettings:
         PassbandMaps.delete(confirm=confirm)
         if delete_settings_folder:
             self.settings_path.rmdir()
+
+    def delete_item(self, item, confirm=False):
+        """
+        Delete an item from the settings.
+
+        Parameters
+        ----------
+        item : Camera | Observatory | PassbandMap
+            The item to delete.
+
+        confirm : bool, optional
+            If True, the item is deleted. If False, a ValueError is raised.
+        """
+        match item:
+            case Camera() as to_delete:
+                klass = Cameras
+            case Observatory() as to_delete:
+                klass = Observatories
+            case PassbandMap() as to_delete:
+                klass = PassbandMaps
+            case _:
+                raise ValueError(
+                    f"Unknown item {item} of type {type(item)}. Must be Camera, "
+                    "Observatory, or PassbandMap"
+                )
+
+        klass.delete(confirm=confirm, name=to_delete.name)

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -1,0 +1,255 @@
+import ipywidgets as ipw
+import pytest
+
+from stellarphot.settings import Camera, Observatory, PassbandMap, SavedSettings
+from stellarphot.settings.custom_widgets import ChooseOrMakeNew, Confirm
+from stellarphot.settings.tests.test_models import (
+    DEFAULT_OBSERVATORY_SETTINGS,
+    DEFAULT_PASSBAND_MAP,
+    TEST_CAMERA_VALUES,
+)
+
+
+class TestChooseOrMakeNew:
+    """
+    Class for testing the ChooseOrMakeNew widget.
+    """
+
+    def test_creation_without_type_raises_error(self):
+        # Should raise an error if no type is provided
+        with pytest.raises(TypeError):
+            ChooseOrMakeNew()
+
+    def test_creation_unknown_item_type_raises_error(self):
+        # Should raise an error if an unknown item type is provided
+        with pytest.raises(ValueError, match="Unknown item type unknown"):
+            ChooseOrMakeNew("unknown")
+
+    @pytest.mark.parametrize(
+        "item_type",
+        [
+            "camera",
+            "observatory",
+            "passband_map",
+            "Camera",
+            "PassbandMap",
+            "Observatory",
+        ],
+    )
+    def test_creation(self, item_type):
+        # Should create a widget with a dropdown and a button
+        choose_or_make_new = ChooseOrMakeNew(item_type)
+        assert choose_or_make_new._item_type_name == item_type
+
+    def test_initial_configuration_with_no_items(self, tmp_path):
+        # Should have a dropdown with one item, "Make new passband map"
+        # using passband_map here to also test that underscores get converted to spaces
+        choose_or_make_new = ChooseOrMakeNew("passband_map", _testing_path=tmp_path)
+        assert len(choose_or_make_new._choose_existing.options) == 1
+        assert choose_or_make_new._choose_existing.options[0] == (
+            "Make new passband map",
+            "none",
+        )
+
+    def test_make_new_makes_a_new_item(self, tmp_path):
+        # We will test this with Camera, should work for the others too since the code
+        # path is the same.
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Set the values for the new item
+        choose_or_make_new._item_widget.value = TEST_CAMERA_VALUES
+
+        # Simulate a click on the save button...
+        choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
+        # No need for the confirmation dialog because we are not overwriting
+        # anything.
+
+        # Check what we created using SavedSettings...
+        saved = SavedSettings(_testing_path=tmp_path)
+        cameras = saved.get_items("camera")
+        assert len(cameras.as_dict) == 1
+        assert list(cameras.as_dict.values())[0].model_dump() == TEST_CAMERA_VALUES
+
+    def test_edit_requires_confirmation(self, tmp_path):
+        # Should require confirmation if the item already exists
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # the edit button should be displayed and the confirm widget should be hidden
+        # note: display typically start as None or an empty string, so we just check
+        # that it is not "none", which is what it will be set to when it is hidden.
+        assert choose_or_make_new._edit_button.layout.display != "none"
+        assert choose_or_make_new._confirm_edit.layout.display == "none"
+
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+        # The edit button should now be hidden
+        assert choose_or_make_new._edit_button.layout.display == "none"
+
+        # The savebuttonbar should be displayed
+        assert choose_or_make_new._item_widget.savebuttonbar.layout.display != "none"
+
+        # Click on the save button
+        choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
+
+        # The confirm dialog should be displayed
+        assert choose_or_make_new._confirm_edit.layout.display != "none"
+
+    def test_edit_item_saved_after_confirm(self, tmp_path):
+        # Should save the item after confirmation
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+
+        # Change a value in the camera so we can check that the new value is saved.
+        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        choose_or_make_new._item_widget.di_widgets["gain"].value = str(new_gain)
+        # Simulate a click on the save button...
+        choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
+        # Simulate a click on the confirm button...
+        choose_or_make_new._confirm_edit._yes.click()
+
+        cameras = saved.get_items("camera")
+        assert cameras.as_dict[camera.name].gain == new_gain
+
+    def test_edit_item_not_saved_after_cancel(self, tmp_path):
+        # Should not save the item after clicking the No button
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+
+        # Change a value in the camera so we can check that the new value is saved.
+        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        choose_or_make_new._item_widget.di_widgets["gain"].value = str(new_gain)
+        # Simulate a click on the save button...
+        choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
+        # Simulate a click on the cancel button...
+        choose_or_make_new._confirm_edit._no.click()
+
+        cameras = saved.get_items("camera")
+        assert cameras.as_dict[camera.name].gain == TEST_CAMERA_VALUES["gain"]
+
+    def test_selecting_make_new_as_selection_works(self, tmp_path):
+        # Should allow the user to select "Make new" as a selection
+
+        # Make a camera so that we can test that selecting "Make new" works
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # This is the value for the "Make new...." option
+        choose_or_make_new._choose_existing.value = "none"
+
+        # edit button should go away
+        assert choose_or_make_new._edit_button.layout.display == "none"
+
+        # Widget should be enabled
+        assert choose_or_make_new._item_widget.disabled is False
+
+        # save button bar should be displayed
+        assert choose_or_make_new._item_widget.savebuttonbar.layout.display != "none"
+
+    def test_choosing_different_item_updates_display(self, tmp_path):
+        # Should update the display when a different item is chosen
+        saved = SavedSettings(_testing_path=tmp_path)
+        observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+        saved.add_item(observatory)
+
+        observatory2 = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+        # Make sure this name sorts lower than the first observatory
+        observatory2.name = "zzzz" + observatory2.name
+        observatory2.elevation = "-200 m"
+
+        saved.add_item(observatory2)
+
+        choose_or_make_new = ChooseOrMakeNew("observatory", _testing_path=tmp_path)
+
+        # There should be three choices in the dropdown
+        assert len(choose_or_make_new._choose_existing.options) == 3
+
+        # Make sure the correct first observatory is selected
+        assert choose_or_make_new._choose_existing.value == observatory
+        print(f"{choose_or_make_new._item_widget.value=}")
+        print(f"{observatory.model_dump()=}")
+        assert Observatory(**choose_or_make_new._item_widget.value) == observatory
+
+        # Select the other observatory
+        choose_or_make_new._choose_existing.value = observatory2
+
+        # The item widget should now have the values of the second observatory
+        assert Observatory(**choose_or_make_new._item_widget.value) == observatory2
+
+    def test_make_passband_map(self, tmp_path):
+        # Make a passband map and save it, then check that it is in the dropdown
+        saved = SavedSettings(_testing_path=tmp_path)
+        passband_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
+        saved.add_item(passband_map)
+
+        # Should create a new passband map
+        choose_or_make_new = ChooseOrMakeNew("passband_map", _testing_path=tmp_path)
+        assert len(choose_or_make_new._choose_existing.options) == 2
+        assert choose_or_make_new._choose_existing.options[0][0] == passband_map.name
+
+
+class TestConfirm:
+    def test_initial_value(self):
+        # Should initialize with value of None
+        confirm = Confirm()
+        assert confirm.value is None
+
+    def test_initial_display(self):
+        # Should initialize not displayed
+        confirm = Confirm()
+        assert confirm.layout.display == "none"
+
+    def test_message(self):
+        # Should initialize with a message
+        confirm = Confirm(message="Hello")
+        assert confirm.message == "Hello"
+        # message should be settable
+        confirm.message = "Goodbye"
+        assert confirm.message == "Goodbye"
+
+    def test_widget_structure(self):
+        # Should have a message, yes, and no buttons
+        confirm = Confirm()
+        assert isinstance(confirm.children[0], ipw.HTML)
+        assert isinstance(confirm.children[1], ipw.Button)
+        assert isinstance(confirm.children[2], ipw.Button)
+
+    @pytest.mark.parametrize("other_widget", [None, ipw.Dropdown()])
+    def test_show(self, other_widget):
+        # Should display when show is called
+        confirm = Confirm(widget_to_hide=other_widget)
+        if other_widget:
+            assert other_widget.layout.display != "none"
+        confirm.show()
+        assert confirm.layout.display == "flex"
+        if other_widget:
+            assert other_widget.layout.display == "none"
+
+    @pytest.mark.parametrize("yes_or_no", ["yes", "no"])
+    @pytest.mark.parametrize("other_widget", [None, ipw.Dropdown()])
+    def test_clicking_yes_or_no(self, yes_or_no, other_widget):
+        # Should set value to True when yes is "clicked"
+        confirm = Confirm(widget_to_hide=other_widget)
+        # These are the handlers for a click on yes or no -- it takes an argument but we
+        #  don't use it. The widget API requires that the function be able to take an
+        # argument.
+        if yes_or_no == "yes":
+            confirm._yes.click()
+        else:
+            confirm._no.click()
+
+        assert confirm.value == (yes_or_no == "yes")
+        assert confirm.layout.display == "none"
+        if other_widget:
+            assert other_widget.layout.display != "none"

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -460,8 +460,8 @@ class TestPassbandMapDictMethods:
 
 
 def test_passband_map_init_with_none():
-    pb_map = PassbandMap(name="Test", your_filter_names_to_aavso=None)
-    assert pb_map._dict == {}
+    with pytest.raises(ValidationError, match="1 validation error for PassbandMap"):
+        PassbandMap(name="Test", your_filter_names_to_aavso=None)
 
 
 def test_passband_map_init_with_passband_map():

--- a/stellarphot/settings/views.py
+++ b/stellarphot/settings/views.py
@@ -24,6 +24,10 @@ def ui_generator(model):
     # the user to understand if they are shown but disabled.
     ui.show_null = True
 
+    # In the same spirit, the button to show/hide nullables should be hidden
+    # too.
+    ui.bn_shownull.layout.display = "none"
+
     # Set the description to the first sentence of the docstring. The default is
     # to use the entire docstring, which is often too long.
     ui.description = _extract_short_description(model.__doc__)


### PR DESCRIPTION
This PR has a few things:

1. Adds a couple of custom widgets to support saving settings like camera that have names.
2. Tests for those widgets.
3. A notebook to use for testing out the widget, integrated into the jupyterlab launcher.

In addition to the code review please try going through the notebook. Once you have done a `pip install -e .` with this branch in your environment, you should see the button in the launcher:

![JupyterLab](https://github.com/feder-observatory/stellarphot/assets/1147167/310e9cdf-a587-42a1-877f-1ce6eade74c2)


@JuanCab -- if you could review by early next week that would be great.