### PR TITLE
Require filter name in PassbandMapEntry to not have weird whitespace

### DIFF
--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -758,11 +758,9 @@ class PassbandMapEntry(BaseModel):
     """
 
     your_filter_name: Annotated[
-        str, Field(description="Instrumental Filter Name", examples=["Sloan r"])
+        NonEmptyStr, Field(description="Instrumental Filter Name")
     ]
-    aavso_filter_name: Annotated[
-        AAVSOFilters, Field(title="AAVSO Filter Name", default="SR")
-    ]
+    aavso_filter_name: Annotated[AAVSOFilters, Field(title="AAVSO Filter Name")]
 
 
 class PassbandMap(BaseModelWithTableRep):

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -563,6 +563,12 @@ def test_passband_map_init_with_passband_map():
     assert pb_map == pb_map2
 
 
+def test_passband_map_entry_empty_name_raises_error():
+    # Name of your filter cannot be empty
+    with pytest.raises(ValidationError, match="name must not be empty"):
+        PassbandMapEntry(your_filter_name="", aavso_filter_name="V")
+
+
 def test_create_invalid_exoplanet():
     # Set some bad values and make sure they raise validation errors
     values = DEFAULT_EXOPLANET_SETTINGS.copy()


### PR DESCRIPTION
This fixes #295 by ensuring that `your_filter_name` cannot be 

+ empty
+ whitespace only
+ have leading or trailing whitespace