### PR TITLE
Add better unicode test

### DIFF
--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -12,6 +12,8 @@ __all__ = ["SavedSettings", "SETTINGS_FILE_VERSION"]
 # or never.
 SETTINGS_FILE_VERSION = "2"  # value chosen to match amjor version of stellarphot
 
+ENCODING = "utf-8"
+
 
 class SavedFileOperations:
     # Provide a place to store the path to the settings file. Annotate as a ClassVar
@@ -22,7 +24,7 @@ class SavedFileOperations:
     def save(self):
         file_path = self._settings_path / self._file_name
         json_data = self.model_dump_json(indent=4)
-        with file_path.open("w") as f:
+        with file_path.open("w", encoding=ENCODING) as f:
             f.write(json_data)
 
     def get(self, name):
@@ -42,7 +44,7 @@ class SavedFileOperations:
         if not file_path.exists():
             instance = cls(as_dict={})
         else:
-            with file_path.open() as f:
+            with file_path.open(encoding=ENCODING) as f:
                 instance = cls.model_validate_json(f.read())
 
         return instance

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -283,3 +283,23 @@ class TestSavedSettings:
         camera = Camera.model_validate_json(CAMERA)
         with pytest.raises(ValueError, match="not found in"):
             saved_settings.delete_item(camera, confirm=True)
+
+    def test_saved_settings_round_trip_with_unicode_name(self, tmp_path):
+        # Test that items with unicode names can be saved and loaded.
+        saved_settings = SavedSettings(_testing_path=tmp_path)
+        # Add a camera. This particular name causes a failure on Windows because the
+        # default encoding doesn't include Korean characters.
+        camera_name = "크레이그"
+        camera = Camera(
+            name=camera_name,
+            data_unit="adu",
+            gain="1.5 electron / adu",
+            read_noise="10.0 electron",
+            dark_current="0.01 electron / s",
+            pixel_scale="0.6 arcsec / pix",
+            max_data_value="50000.0 adu",
+        )
+        saved_settings.add_item(camera)
+        # Load the camera.
+        loaded_camera = saved_settings.get_items("camera").as_dict[camera_name]
+        assert loaded_camera == camera


### PR DESCRIPTION
It turns out that, on Windows, the default encoding used for text files is not UTF-8. Whatever the encoding is includes Greek characters, like π, that were used in the original test for unicode names, but not Korean characters as in 크레이그.

When complete, this pull request will close #305. The first commit here I am hoping to see a failure on Windows to make sure we are actually testing a case that fails.