### PR TITLE
Make the revert button reset to saved value

### DIFF
--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -224,6 +224,9 @@ class ChooseOrMakeNew(ipw.VBox):
         # Update the current state of the widget
         self._editing = True
 
+        # Enable the revert button so that the user can cancel the edit
+        self._item_widget.savebuttonbar.bn_revert.disabled = False
+
     def _set_disable_state_nested_models(self, top, value):
         """
         When a one model contains another and the top-level model widget
@@ -297,9 +300,26 @@ class ChooseOrMakeNew(ipw.VBox):
                 # Make sure the edit button is displayed
                 self._edit_button.layout.display = "flex"
 
+        def revert_to_saved_value():
+            """
+            Revert the widget to the saved value and end editing.
+
+            This should only apply while editing. If you are making a new
+            item you can either select a different item (if there are any) or
+            you really need to make a new one.
+            """
+            if self._editing:
+                # We have a selection so we need to stop editing...
+                self._editing = False
+
+                # ...and trigger the selection handler.
+                self._handle_selection({"new": self._choose_existing.value})
+
         # This is the mechanism for adding callbacks to the save button.
         new_widget.savebuttonbar.fns_onsave_add_action(saver)
         new_widget.savebuttonbar.fns_onsave_add_action(update_choices_and_select_new)
+        new_widget.savebuttonbar.fns_onrevert_add_action(revert_to_saved_value)
+
         return new_widget, new_widget.value.copy()
 
     def _handle_confirmation(self):

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -331,6 +331,76 @@ class TestChooseOrMakeNew:
         # The save button should be disabled
         assert choose_or_make_new._item_widget.savebuttonbar.bn_save.disabled
 
+    def test_revert_button_is_enabled_after_clicking_edit(self, tmp_path):
+        # The revert button should be enabled after clicking the edit button so
+        # the user can cancel the edit.
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+
+        # The revert button should be enabled
+        assert not choose_or_make_new._item_widget.savebuttonbar.bn_revert.disabled
+
+    def test_clicking_revert_button_cancels_edit(self, tmp_path):
+        # Clicking the revert button should cancel the edit
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+
+        # Simulate a click on the revert button...
+        choose_or_make_new._item_widget.savebuttonbar.bn_revert.click()
+
+        # The camera should not have been changed
+        assert choose_or_make_new._item_widget.value == TEST_CAMERA_VALUES
+
+        # The edit button should be displayed
+        assert choose_or_make_new._edit_button.layout.display != "none"
+
+        # We should not be in editing mode anymore
+        assert not choose_or_make_new._editing
+
+    def test_revert_button_remains_enabled_with_invalid_value_and_actually_reverts(
+        self, tmp_path
+    ):
+        # The revert button should remain enabled if the value is invalid and reverting
+        # should actually revert the value.
+        saved = SavedSettings(_testing_path=tmp_path)
+        camera = Camera(**TEST_CAMERA_VALUES)
+        saved.add_item(camera)
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        # Simulate a click on the edit button...
+        choose_or_make_new._edit_button.click()
+
+        # Set an invalid value
+        choose_or_make_new._item_widget.di_widgets["name"].value = ""
+
+        # unsaved_changes should be true
+        assert choose_or_make_new._item_widget.savebuttonbar.unsaved_changes
+
+        # Make sure the change is really there
+        assert choose_or_make_new._item_widget.value != TEST_CAMERA_VALUES
+
+        # The revert button should be enabled
+        assert not choose_or_make_new._item_widget.savebuttonbar.bn_revert.disabled
+
+        # Save should still be disabled
+        assert choose_or_make_new._item_widget.savebuttonbar.bn_save.disabled
+
+        # Click the revert button
+        choose_or_make_new._item_widget.savebuttonbar.bn_revert.click()
+
+        # The camera should not have been changed
+        assert choose_or_make_new._item_widget.value == TEST_CAMERA_VALUES
+
 
 class TestConfirm:
     def test_initial_value(self):


### PR DESCRIPTION
This PR fixes #312 by making the revert button end an edit and reset the widget value back whatever settings were there pre-edit.

Note that the revert button doesn't do anything if you click while making a new item. That is deliberate (at least for now) because either i) there are no items so the user needs to make a valid one and can edit fields as needed to get there or ii) the user can use the dropdown to select an existing item.

@Tanner728 -- the revert button should do something now 😀 