### PR TITLE
Class for creating, and separate class for saving, photometry settings in the working directory 

### DIFF
--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -417,8 +417,6 @@ class PhotometryWorkingDirSettings:
                 )
             except ValidationError as e:
                 raise ValueError(f"Error loading partial settings: {e}") from e
-            else:
-                self._valid_partial_settings = True
 
         # Now load full settings if they exist
         if self._settings_file.exists():
@@ -429,8 +427,6 @@ class PhotometryWorkingDirSettings:
                 self._settings = PhotometrySettings.model_validate_json(content)
             except ValidationError as e:
                 raise ValueError(f"Error loading settings: {e}") from e
-            else:
-                self._valid_full_settings = True
 
         # Handle case where we have valid partial and valid full settings
         self._resolve_full_partial_conflict()

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -17,7 +17,7 @@ __all__ = ["SavedSettings", "SETTINGS_FILE_VERSION", "PhotometryWorkingDirSettin
 
 # We will have to version settings formats, I think. Hopefully this changes rarely
 # or never.
-SETTINGS_FILE_VERSION = "2"  # value chosen to match amjor version of stellarphot
+SETTINGS_FILE_VERSION = "2"  # value chosen to match major version of stellarphot
 
 ENCODING = "utf-8"
 
@@ -309,7 +309,7 @@ class PhotometryWorkingDirSettings:
         """
         return self._partial_settings
 
-    # Properties for seetings file and partial settings file
+    # Properties for settings file and partial settings file
     @property
     def settings_file(self):
         return self._settings_file
@@ -365,7 +365,8 @@ class PhotometryWorkingDirSettings:
                     raise ValueError(
                         "Cannot save partial settings when full settings already exist."
                     )
-                # Are these settings actually full settings?
+                # set variable file to point to appropriate (partial or full)
+                # settings file location.
                 if self._are_partial_actually_full(settings):
                     self._settings = settings
                     file = self._settings_file
@@ -388,6 +389,9 @@ class PhotometryWorkingDirSettings:
             self._partial_settings_file.unlink(missing_ok=True)
             self._partial_settings = None
 
+        # Write the settings to a file. The settings themselves are models, so we
+        # are guaranteed to write the correct model type (partial or full settings)
+        # to the file.
         with file.open("w", encoding=ENCODING) as f:
             f.write(settings.model_dump_json(indent=4))
 
@@ -416,6 +420,7 @@ class PhotometryWorkingDirSettings:
             else:
                 self._valid_partial_settings = True
 
+        # Now load full settings if they exist
         if self._settings_file.exists():
             with self._settings_file.open(encoding=ENCODING) as f:
                 content = f.read()
@@ -442,6 +447,7 @@ class PhotometryWorkingDirSettings:
         4. Partial settings, full settings, and they match: delete partial settings.
         5. Partial settings, full settings, and they don't match: raise ValueError.
         """
+        # Handle cases 1 through 3 -- no conflicts in these cases
         if self._partial_settings is None or self._settings is None:
             # Nothing to do, return
             return

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+import random
 import re
 
 import astropy.units as u
@@ -14,6 +15,7 @@ from stellarphot.settings.models import (
     Exoplanet,
     LoggingSettings,
     Observatory,
+    PartialPhotometrySettings,
     PassbandMap,
     PassbandMapEntry,
     PhotometryApertures,
@@ -333,6 +335,28 @@ class TestModelExamples:
                     assert model_value == u.Unit(v)
                 else:
                     assert model_value == v
+
+
+def test_partial_photometry_settings():
+    """
+    Test that we can create a PhotometrySettings object with only a subset of
+    the normally required fields.
+    """
+    # Loop over the individual default photometry settings and make sure we can
+    # create a PartialPhotometrySettings object with just that field.
+
+    for k, v in DEFAULT_PHOTOMETRY_SETTINGS.items():
+        pps = PartialPhotometrySettings(**{k: v})
+        assert getattr(pps, k) == v
+
+    choices = list(DEFAULT_PHOTOMETRY_SETTINGS.items())
+    for i in range(2, 5):
+        # Try a few random subsets of fields
+        fields = random.choices(choices, k=i)
+        settings = {k: v for k, v in fields}
+        pps = PartialPhotometrySettings(**settings)
+        for k, v in settings.items():
+            assert getattr(pps, k) == v
 
 
 def test_camera_unitscheck():


### PR DESCRIPTION
This pull request adds two things:

1. In `models.py`, a new class called `PartialPhotometrySettings` that is `PhotometrySettings` except each of the fields can be none. Note that this class is generated by a function, `_make_partial_model`, gleaned from stack overflow.
2. In `settings_files.py`, a new class called `PhotometryWorkingDirSettings` to handle saving settings that will be used for photometry in the user's current working directory.

More about item 2:

+ Depending on how far along the user is, settings are saved in either a file called `photometry_settings.json` or `partial_photometry_settings.json`.
+ It is an error to have both of those at once. The `save` method tries to be careful not to create both.
+ The `load` method checks for the existence of both files and if it finds both, raises an error.
+ The `save` method saves to `photometry_settings.json` if partial settings are passed in but all of the settings are there, so they could be full settings. It blithely nukes the `partial_photometry_settings.json` in that case.