### PR TITLE
Add option to show/hide item details

### DIFF
--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -98,8 +98,7 @@ class ChooseOrMakeNew(ipw.VBox):
             description=f"Delete this {self._display_name}",
         )
 
-        # Put almost everything into a VBox, which we can perhapds wrap in an
-        # accordian widget.
+        # Put almost everything into a VBox
         self._details_box = ipw.VBox()
 
         self._edit_delete_container.children = [self._edit_button, self._delete_button]

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -599,9 +599,6 @@ class TestChooseOrMakeNew:
         # Set "show details" box to unchecked so details are hidden
         choose_or_make_new._show_details_ui.value = False
 
-        # Note whether the "show details" box is checked or not
-        show_state = False
-
         # Check that details are hidden
         assert choose_or_make_new._details_box.layout.display == "none"
 
@@ -626,7 +623,7 @@ class TestChooseOrMakeNew:
 
         # Details should be hidden
         assert choose_or_make_new._details_box.layout.display == "none"
-        assert choose_or_make_new._show_details_ui.value == show_state
+        assert not choose_or_make_new._show_details_ui.value
 
     def test_details_hideable_not_set_preserves_old_behavior(self, tmp_path):
         # The details should not be hidden if hideable is false

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -685,6 +685,13 @@ class TestChooseOrMakeNew:
         # Details should match prior state
         assert choose_or_make_new._show_details_ui.value == show_state
 
+    def test_chooser_has_value(self, tmp_path):
+        # The chooser should have a value
+        self.make_test_camera(tmp_path)
+
+        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        assert choose_or_make_new.value == Camera(**TEST_CAMERA_VALUES)
+
 
 class TestConfirm:
     def test_initial_value(self):

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -552,7 +552,10 @@ class TestChooseOrMakeNew:
 
     @pytest.mark.parametrize("hideable", [True, False])
     def test_details_hideable_or_not(self, tmp_path, hideable):
-        # The details should be hideable
+        # The details should be hideable if requested
+
+        # Make a camera so that the details can be hidden
+        self.make_test_camera(tmp_path)
         choose_or_make_new = ChooseOrMakeNew(
             "camera", details_hideable=hideable, _testing_path=tmp_path
         )


### PR DESCRIPTION
This adds the option to make the details of a selected object hideable. The motivation is to at least have the option of saving space in the photometry notebooks 1 and 2.

After this change the widget looks like this if hideable is enabled; if it is not enabled then there is no change in appearance:

<img width="921" alt="corm-play-BA…__2__-_JupyterLab" src="https://github.com/feder-observatory/stellarphot/assets/1147167/6e2e6b2a-8736-440e-a9d6-b225e868c77c">

<img width="443" alt="Cursor_and_corm-play-BA…__2__-_JupyterLab" src="https://github.com/feder-observatory/stellarphot/assets/1147167/d01bc84a-ff48-48ba-a66d-34722587fbeb">
