### PR TITLE
Make name of field match snake case version of class name

### DIFF
--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -458,7 +458,7 @@ class ComparisonViewer:
         """
         self.photometry_settings.save(
             PartialPhotometrySettings(
-                source_locations=self.source_locations.value,
+                source_location_settings=self.source_locations.value,
             ),
             update=True,
         )

--- a/stellarphot/gui_tools/tests/test_comparison_functions.py
+++ b/stellarphot/gui_tools/tests/test_comparison_functions.py
@@ -113,6 +113,6 @@ def test_comparison_properties(tmp_path, has_object, source_file_name):
     # settings have saved correctly.
     partial_settings = PhotometryWorkingDirSettings().load()
     assert (
-        partial_settings.source_locations.model_dump()
+        partial_settings.source_location_settings.model_dump()
         == comparison_widget.source_locations.value
     )

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -170,7 +170,7 @@ def single_image_photometry(
     """
 
     sourcelist = SourceListData.read(
-        photometry_settings.source_locations.source_list_file
+        photometry_settings.source_location_settings.source_list_file
     )
     camera = photometry_settings.camera
     observatory = photometry_settings.observatory
@@ -178,7 +178,7 @@ def single_image_photometry(
     photometry_options = photometry_settings.photometry_optional_settings
     logging_options = photometry_settings.logging_settings
     passband_map = photometry_settings.passband_map
-    use_coordinates = photometry_settings.source_locations.use_coordinates
+    use_coordinates = photometry_settings.source_location_settings.use_coordinates
 
     # Check that the input parameters are valid
     if not isinstance(ccd_image, CCDData):
@@ -396,7 +396,8 @@ def single_image_photometry(
             # The center really shouldn't move more than about the fwhm, could
             # rework this in the future to use that instead.
             too_much_shift = (
-                center_diff > photometry_settings.source_locations.shift_tolerance
+                center_diff
+                > photometry_settings.source_location_settings.shift_tolerance
             )
 
             # If the shift is too large, use the WCS-derived positions instead
@@ -656,7 +657,7 @@ def multi_image_photometry(
 
     """
     sourcelist = SourceListData.read(
-        photometry_settings.source_locations.source_list_file
+        photometry_settings.source_location_settings.source_list_file
     )
 
     # Initialize lists to track all PhotometryData objects and all dropped sources

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -105,7 +105,7 @@ DEFAULT_PHOTOMETRY_SETTINGS = PhotometrySettings(
     camera=FAKE_CAMERA,
     observatory=FAKE_OBS,
     photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
-    source_locations=DEFAULT_SOURCE_LOCATIONS,
+    source_location_settings=DEFAULT_SOURCE_LOCATIONS,
     photometry_optional_settings=PHOTOMETRY_OPTIONS,
     passband_map=PASSBAND_MAP,
     logging_settings=DEFAULT_LOGGING_SETTINGS,
@@ -161,7 +161,9 @@ class TestAperturePhotometry:
         source_list.write(source_list_file, overwrite=True)
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
 
         # Create an AperturePhotometry object
         ap_phot = AperturePhotometry(settings=photometry_settings)
@@ -213,7 +215,7 @@ class TestAperturePhotometry:
             camera=FAKE_CAMERA,
             observatory=FAKE_OBS,
             photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
-            source_locations=source_locations,
+            source_location_settings=source_locations,
             photometry_optional_settings=phot_options,
             passband_map=PASSBAND_MAP,
             logging_settings=DEFAULT_LOGGING_SETTINGS,
@@ -298,7 +300,9 @@ class TestAperturePhotometry:
         phot_options.include_dig_noise = True
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
         photometry_settings.photometry_optional_settings = phot_options
 
         image_file = tmp_path / "fake_image.fits"
@@ -367,7 +371,9 @@ class TestAperturePhotometry:
         phot_options.method = "center"
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
         photometry_settings.photometry_optional_settings = phot_options
 
         ap_phot = AperturePhotometry(settings=photometry_settings)
@@ -428,8 +434,8 @@ class TestAperturePhotometry:
 
             photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
             photometry_settings.photometry_optional_settings = phot_options
-            photometry_settings.source_locations.use_coordinates = coords
-            photometry_settings.source_locations.source_list_file = str(
+            photometry_settings.source_location_settings.use_coordinates = coords
+            photometry_settings.source_location_settings.source_list_file = str(
                 source_list_file
             )
             with warnings.catch_warnings():
@@ -550,11 +556,11 @@ class TestAperturePhotometry:
 
             photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
             photometry_settings.photometry_optional_settings = phot_options
-            photometry_settings.source_locations.source_list_file = str(
+            photometry_settings.source_location_settings.source_list_file = str(
                 source_list_file
             )
             # The setting below was implicit in the old default
-            photometry_settings.source_locations.use_coordinates = "sky"
+            photometry_settings.source_location_settings.use_coordinates = "sky"
 
             ap_phot = AperturePhotometry(settings=photometry_settings)
             with pytest.raises(ValueError):
@@ -606,11 +612,11 @@ class TestAperturePhotometry:
 
             photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
             photometry_settings.photometry_optional_settings = phot_options
-            photometry_settings.source_locations.source_list_file = str(
+            photometry_settings.source_location_settings.source_list_file = str(
                 source_list_file
             )
             # The settings below was implicit in the old default
-            photometry_settings.source_locations.use_coordinates = "sky"
+            photometry_settings.source_location_settings.use_coordinates = "sky"
 
             ap_phot = AperturePhotometry(settings=photometry_settings)
             # Since none of the images will be valid, it should raise a RuntimeError
@@ -669,7 +675,7 @@ class TestAperturePhotometry:
             camera=FAKE_CAMERA,
             observatory=FAKE_OBS,
             photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
-            source_locations=source_locations,
+            source_location_settings=source_locations,
             photometry_optional_settings=phot_options,
             passband_map=PASSBAND_MAP,
             logging_settings=logging_settings,
@@ -742,8 +748,8 @@ class TestAperturePhotometry:
 
             photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
             photometry_settings.photometry_optional_settings = phot_options
-            photometry_settings.source_locations.use_coordinates = "sky"
-            photometry_settings.source_locations.source_list_file = str(
+            photometry_settings.source_location_settings.use_coordinates = "sky"
+            photometry_settings.source_location_settings.source_list_file = str(
                 source_list_file
             )
 
@@ -1019,7 +1025,7 @@ def test_aperture_photometry_no_outlier_rejection(int_data, tmp_path):
         camera=FAKE_CAMERA,
         observatory=FAKE_OBS,
         photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
-        source_locations=source_locations,
+        source_location_settings=source_locations,
         photometry_optional_settings=phot_options,
         passband_map=PASSBAND_MAP,
         logging_settings=DEFAULT_LOGGING_SETTINGS,
@@ -1106,7 +1112,9 @@ def test_aperture_photometry_with_outlier_rejection(reject, tmp_path):
     phot_options.include_dig_noise = True
 
     photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
-    photometry_settings.source_locations.source_list_file = str(source_list_file)
+    photometry_settings.source_location_settings.source_list_file = str(
+        source_list_file
+    )
     photometry_settings.photometry_optional_settings = phot_options
 
     phot, missing_sources = single_image_photometry(
@@ -1216,8 +1224,10 @@ def test_photometry_on_directory(coords):
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
         photometry_settings.photometry_optional_settings = phot_options
-        photometry_settings.source_locations.use_coordinates = coords
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.use_coordinates = coords
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", message="Cannot merge meta key", category=MergeConflictWarning
@@ -1332,9 +1342,11 @@ def test_photometry_on_directory_with_no_ra_dec():
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
         photometry_settings.photometry_optional_settings = phot_options
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
         # The setting below was implicit in the old default
-        photometry_settings.source_locations.use_coordinates = "sky"
+        photometry_settings.source_location_settings.use_coordinates = "sky"
 
         with pytest.raises(ValueError):
             multi_image_photometry(
@@ -1386,9 +1398,11 @@ def test_photometry_on_directory_with_bad_fits():
 
         photometry_settings = DEFAULT_PHOTOMETRY_SETTINGS.model_copy()
         photometry_settings.photometry_optional_settings = phot_options
-        photometry_settings.source_locations.source_list_file = str(source_list_file)
+        photometry_settings.source_location_settings.source_list_file = str(
+            source_list_file
+        )
         # The settings below was implicit in the old default
-        photometry_settings.source_locations.use_coordinates = "sky"
+        photometry_settings.source_location_settings.use_coordinates = "sky"
 
         # Since none of the images will be valid, it should raise a RuntimeError
         with pytest.raises(RuntimeError):

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -974,7 +974,7 @@ class PhotometrySettings(BaseModelWithTableRep):
             json_schema_extra=SCHEMA_EXTRAS,
         ),
     ]
-    source_locations: Annotated[
+    source_location_settings: Annotated[
         SourceLocationSettings,
         Field(
             description=_extract_short_description(SourceLocationSettings.__doc__),

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -99,7 +99,7 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
     camera=Camera(**TEST_CAMERA_VALUES),
     observatory=Observatory(**DEFAULT_OBSERVATORY_SETTINGS),
     photometry_apertures=PhotometryApertures(**DEFAULT_APERTURE_SETTINGS),
-    source_locations=SourceLocationSettings(**DEFAULT_SOURCE_LOCATION_SETTINGS),
+    source_location_settings=SourceLocationSettings(**DEFAULT_SOURCE_LOCATION_SETTINGS),
     photometry_optional_settings=PhotometryOptionalSettings(
         **DEFAULT_PHOTOMETRY_OPTIONS
     ),


### PR DESCRIPTION
For reasons I cannot recall, the name for the `SourceLocationSettings` in `PhotometrySettings` is `source_locations`. For all of the fields in `PhotometrySettings` the name of the field is the snake case version of the class name. So `PhotometryApertures` is `photometry_apertures`, etc.

It will turn out to be convenient for the last set of widgets if the name is *always* the snake case version o f the class name.]

This PR does that.

@JuanCab -- it would be great if this could get a quick review.