### PR TITLE
Add a review widget

### DIFF
--- a/.jp_app_launcher_stellarphot.yaml
+++ b/.jp_app_launcher_stellarphot.yaml
@@ -1,12 +1,12 @@
-- title: Saveable settings for testing
+- title: 1 - Saveable settings
   description: Settings for camera, observatory and passbands
-  source: ../stellarphot/saveable-settings.ipynb
+  source: ../stellarphot/1-initial-settings.ipynb
   icon: ../stellarphot/stellarphot-logo.svg
   cwd: not_used
   type: notebook
-  catalog: Stellarphot settings
+  catalog: Stellarphot photometry
 
-- title: Seeing profile
+- title: 2 - Seeing profile
   description: Choose aperture settings
   source: ../stellarphot/photometry/01-viewer-seeing-template.ipynb
   icon: ../stellarphot/stellarphot-logo.svg
@@ -14,9 +14,17 @@
   type: notebook
   catalog: Stellarphot photometry
 
-- title: Comparison stars
+- title: 3 - Comparison stars
   description: Choose comparison stars
   source: ../stellarphot/photometry/02-viewer-comparison-stars-template.ipynb
+  icon: ../stellarphot/stellarphot-logo.svg
+  cwd: not_used
+  type: notebook
+  catalog: Stellarphot photometry
+
+- title: 4 - Review settings
+  description: Choose comparison stars
+  source: ../stellarphot/photometry/4-final-review-of-settings.ipynb
   icon: ../stellarphot/stellarphot-logo.svg
   cwd: not_used
   type: notebook

--- a/.jp_app_launcher_stellarphot.yaml
+++ b/.jp_app_launcher_stellarphot.yaml
@@ -16,7 +16,7 @@
 
 - title: 3 - Comparison stars
   description: Choose comparison stars
-  source: ../stellarphot/photometry/02-viewer-comparison-stars-template.ipynb
+  source: ../stellarphot/photometry/02-comp-star-plotter-template.ipynb
   icon: ../stellarphot/stellarphot-logo.svg
   cwd: not_used
   type: notebook
@@ -24,7 +24,7 @@
 
 - title: 4 - Review settings
   description: Choose comparison stars
-  source: ../stellarphot/photometry/4-final-review-of-settings.ipynb
+  source: ../stellarphot/4-final-review-of-settings.ipynb
   icon: ../stellarphot/stellarphot-logo.svg
   cwd: not_used
   type: notebook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "astroquery",
     "astrowidgets",
     "bottleneck",
+    "camel-converter",
     "ccdproc",
     "ginga",
     "ipyautoui >=0.7.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ select = [
 "__init__.py" = ["E402", "F403"]
 # Ignore F405 (variable may be from star imports) in docs/conf.py
 "docs/conf.py" = ["F405"]
+# Ignore F811 (redefinition of unused) in core for the moment
+"core.py" = ["F811"]
 
 [tool.codespell]
 skip = '*.svg'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,4 +176,6 @@ filterwarnings = [
     'ignore:Deprecated in traitlets 4.1, use the instance:DeprecationWarning',
     # Some WCS headers are issuing warnings
     'ignore:RADECSYS=:',
+    # photutils changed the name of a function again
+    'ignore:The make_gaussian_sources_image function is deprecated',
 ]

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -261,6 +261,8 @@ class ComparisonViewer:
         self.target_coord = object_coordinate
         self.observatory = observatory
 
+        # This function defines several attributes in addition to returning the box and
+        # image viewer. You should take a look at it to see what it does.
         self.box, self.iw = self._viewer()
 
         self.photometry_settings = PhotometryWorkingDirSettings()

--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -266,8 +266,9 @@ class ComparisonViewer:
         self.photometry_settings = PhotometryWorkingDirSettings()
 
         if photom_apertures_file is not None:
-            # Set the source location file name to the name passed in
-            self._set_source_location_file_to_value(photom_apertures_file)
+            original_settings = self.source_locations.value.copy()
+            original_settings["source_list_file"] = photom_apertures_file
+            self.source_locations.value = original_settings
 
         self.overwrite_outputs = overwrite_outputs
 
@@ -469,30 +470,6 @@ class ComparisonViewer:
         # Update the save box title to reflect the save
         self.source_and_title.decorate_title()
 
-    def _set_source_location_file_to_value(self, name=None):
-        # Right now the source location file name will not be set to the default name
-        # properly because of a bug in ipyautoui, so we set it manually here.
-        # Easier once/if https://github.com/maxfordham/ipyautoui/pull/323 is merged
-        # and released. Then we can just set the value of the widget directly like this:
-        #
-        # self.source_locations.value = {'source_list_file': name, ...rest of settings}
-        file_chooser = self.source_locations.di_widgets["source_list_file"]
-        if name is None:
-            # Use the default name
-            name = self.source_locations.model.model_fields["source_list_file"].default
-        # Make sure ipyautoui knows the value has changed
-        file_chooser.value = name
-
-        # Set the value to what we actually want
-        file_chooser.reset(".", name)
-        file_chooser._apply_selection()
-
-        # Because we have updated the value outside of ipyautoui, also force an update
-        # of the widget value.
-        current_value = self.source_locations.value.copy()
-        current_value["source_list_file"] = file_chooser.value
-        self.source_locations.value = current_value
-
     def _viewer(self):
         header = ipw.HTML(
             value="""
@@ -529,7 +506,6 @@ class ComparisonViewer:
             SourceLocationSettings, max_field_width="75px"
         )
 
-        self._set_source_location_file_to_value()
         self.source_and_title = SettingWithTitle(
             "Source location settings", self.source_locations
         )

--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -22,6 +22,7 @@ from stellarphot.settings import (
     Observatory,
     PhotometryApertures,
     PhotometryWorkingDirSettings,
+    settings_files,  # This import is needed for mocking
 )
 from stellarphot.settings.tests.test_models import (
     TEST_CAMERA_VALUES,
@@ -62,6 +63,18 @@ def test_seeing_profile_object_creation():
     # This test simply makes sure we can create the object
     profile_widget = spf.SeeingProfileWidget()
     assert isinstance(profile_widget.box, ipw.Box)
+
+
+@pytest.fixture(autouse=True)
+def fake_settings_dir(mocker, tmp_path):
+    # See test_settings_files.py for more information on this fixture.
+    # It makes a fake settings directory for each test to use.
+
+    # stellarphot is added to the name of the directory to make sure we start
+    # without a stellarphot directory for each test.
+    mocker.patch.object(
+        settings_files.PlatformDirs, "user_data_dir", tmp_path / "stellarphot"
+    )
 
 
 def test_seeing_profile_properties(tmp_path):

--- a/stellarphot/notebooks/1-initial-settings.ipynb
+++ b/stellarphot/notebooks/1-initial-settings.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a7f0b18-4509-474e-b42e-a69edd22913b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from stellarphot.settings import Camera, Observatory, PassbandMap\n",
+    "from stellarphot.settings.custom_widgets import ReviewSettings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37494092-bd26-4dcb-a7d9-d587fd79ca45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "review = ReviewSettings([Camera, Observatory, PassbandMap])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f25dc64e-e0b9-4673-b806-ef0e1f53f84c",
+   "metadata": {},
+   "source": [
+    "# Review or make key settings in the widget below "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe341afc-4171-4094-8165-82faa26706b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "review"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c58cd05-afff-4273-8607-69a0e93f4fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/stellarphot/notebooks/4-final-review-of-settings.ipynb
+++ b/stellarphot/notebooks/4-final-review-of-settings.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b91d12e-97ae-4d6d-970d-562b6bbfd683",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from stellarphot.settings import Camera, LoggingSettings, Observatory, PassbandMap, PhotometryApertures, PhotometryOptionalSettings, SourceLocationSettings\n",
+    "from stellarphot.settings.custom_widgets import ReviewSettings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d57c16cc-c243-47f3-9747-94d6c6898621",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "review = ReviewSettings([Camera, Observatory, PassbandMap, PhotometryApertures, SourceLocationSettings, PhotometryOptionalSettings, LoggingSettings])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36db3d1f-d0d7-413e-ab77-766c6e3d02a1",
+   "metadata": {},
+   "source": [
+    "# Review or make key settings in the widget below "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39491574-cc9f-4d2b-963f-1b175336a16d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "review"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "629f505c-6fab-4bf9-a30a-130bf668d8ac",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/stellarphot/photometry/tests/fake_image.py
+++ b/stellarphot/photometry/tests/fake_image.py
@@ -29,7 +29,7 @@ class FakeImage:
         self._sources = Table.read(data_file)
         self.mean_noise = self.sources["amplitude"].max() / 100
         self.noise_dev = noise_dev
-        self._stars = make_gaussian_sources_image(self.image_shape, self.sources)
+        self._stars = make_gaussian_sources_image(tuple(self.image_shape), self.sources)
         self._noise = make_noise_image(
             self._stars.shape, mean=self.mean_noise, stddev=noise_dev, seed=seed
         )
@@ -194,7 +194,7 @@ def shift_FakeCCDImage(ccd_data, x_shift, y_shift):
 
     # Make image
     srcs = make_gaussian_sources_image(
-        shifted_ccd_data.image_shape, shifted_ccd_data.sources
+        tuple(shifted_ccd_data.image_shape), shifted_ccd_data.sources
     )
     background = make_noise_image(
         srcs.shape, mean=shifted_ccd_data.mean_noise, stddev=shifted_ccd_data.noise_dev

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -904,7 +904,7 @@ class ReviewSettings(ipw.VBox):
         """
         # Once the user has clicked on the tab, the status badge for the
         # tab should just be the badge for the widget it holds, if the
-        # widget has a badge. OTherwise, compare the widget value to the
+        # widget has a badge. Otherwise, compare the widget value to the
         # saved value to determine the badge.
 
         # Get the index

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -798,6 +798,7 @@ class ReviewSettings(ipw.VBox):
 
             # This should be either a valid object or None
             saved_value = getattr(self._current_settings, name)
+
             if saved_value is not None:
                 try:
                     val_to_set.value = saved_value
@@ -839,7 +840,9 @@ class ReviewSettings(ipw.VBox):
                 #    "not saved".
                 try:
                     val_to_set.model()
-                except ValidationError:
+                except ValidationError:  # pragma: no cover
+                    # This should never happen with the code base as of 2024-06-27 but
+                    # might in the future.
                     self.badges.append(SaveStatus.SETTING_NOT_SAVED)
                 else:
                     self.badges.append(SaveStatus.SETTING_SHOULD_BE_REVIEWED)
@@ -873,18 +876,6 @@ class ReviewSettings(ipw.VBox):
             for badge, plain in zip(self.badges, self._plain_names, strict=True)
         ]
 
-    def _get_autoui_widget(self, widget):
-        """
-        Get the autoui widget for a given control.
-
-        Parameters
-        ----------
-
-        widget: AutoUi widget or ChooseOrMakeNew
-            The widget to get the autoui widget from.
-        """
-        return widget._autoui_widget
-
     def _observe_tab_selection(self, change):
         """
         Observer for the tab or accordion selection.
@@ -913,12 +904,6 @@ class ReviewSettings(ipw.VBox):
             self._container.titles = self._make_titles()
 
         return observer
-
-    def _index_of_setting(self, setting):
-        """
-        Get the index of a setting in the list of settings.
-        """
-        return self._settings.index(setting)
 
 
 def _add_saving_to_widget(setting_widget):
@@ -954,4 +939,6 @@ def _add_saving_to_widget(setting_widget):
         setting_widget.savebuttonbar.fns_onsave_add_action(save_wd)
         name = to_snake(setting_widget.model.__name__)
     else:
-        raise ValueError("WTF am i supposed to do?")
+        raise ValueError(
+            f"The widget {setting_widget} is not a recognized type of widget."
+        )

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -917,27 +917,20 @@ class ReviewSettings(ipw.VBox):
             # Check whether the setting is saved or not
             setting_widget = self._setting_widgets[new_selected]
 
-            try:
-                snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
-                print(snake_name)
-                disk_value = getattr(self.current_settings, snake_name)
-            except KeyError:
-                print("KEY KEY KEY KEY ERROR")
+            snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
+
+            disk_value = getattr(self.current_settings, snake_name)
+            if disk_value is None:
                 # The setting is not saved
                 setting_widget = SaveStatus.SETTING_NOT_SAVED
             else:
-                print("ELSE ELSE ELSE ELSE ELSE")
-                print(f"{disk_value=}")
-                print(f"{setting_widget._widget.value=}")
-                print(f"{setting_widget._autoui_widget.value=}")
+                # Set the badge to saved if it has been saved.
                 value_from_widget = setting_widget._autoui_widget.model.model_validate(
                     setting_widget._autoui_widget.value
                 )
-                print(f"{value_from_widget=}")
+
                 if disk_value == value_from_widget:
                     setting_widget.badge = SaveStatus.SETTING_IS_SAVED
-                else:
-                    setting_widget.badge = SaveStatus.SETTING_SHOULD_BE_REVIEWED
 
         self._container.titles = self._make_titles()
 

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -816,7 +816,9 @@ class ReviewSettings(ipw.VBox):
                     raise ValueError(
                         f"The {name} setting saved in the working directory is not "
                         f"consistent with the list of {name} items that are saved "
-                        "in your permanent settings. Please fix this manually."
+                        "in your permanent settings. Please fix this manually "
+                        f"by editing your saved {name} settings or by deleting the "
+                        "working directory settings."
                     ) from e
                 # Add symbol to title to indicate that the setting needs review
                 self.badges.append(SaveStatus.SETTING_SHOULD_BE_REVIEWED)

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -803,6 +803,10 @@ class ReviewSettings(ipw.VBox):
 
             if saved_value is not None:
                 try:
+                    if is_choose_or_make_new:
+                        # Set to None first to ensure there is a change in the value
+                        # when we set it to saved_value.
+                        val_to_set.value = None
                     val_to_set.value = saved_value
                 except tr.TraitError as e:
                     # It can happen, while testing, that a setting gets saved to a local

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -254,7 +254,6 @@ class ChooseOrMakeNew(ipw.VBox):
         if change["new"] is None:
             return
         if change["new"] == "none":
-
             # We are making a new item...
 
             # Hide the edit button
@@ -514,6 +513,7 @@ class ChooseOrMakeNew(ipw.VBox):
             The second case is the reason most of the handler is wrapped in an
             if statement.
             """
+            was_editing = self._editing
             # value of None means the widget has been reset to not answered
             if change["new"] is not None:
                 item = self._item_widget.model(**self._item_widget.value)
@@ -537,13 +537,15 @@ class ChooseOrMakeNew(ipw.VBox):
                     else:
                         # User has said no to updating the item, so we just
                         # act as though the user has selected this item.
-                        if self._editing:
-                            # _handle_selection always gets the value from disk, not
-                            # from the ui, so this resets to the correct value.
+                        if was_editing:
+                            # The user has presumably changed the value in the UI, so
+                            # get the correct value from disk.
+                            item = self._get_item(item.name)
+
                             # To make 100% sure the observer is triggered, we set the
                             # value to None first.
                             self._choose_existing.value = None
-                            self._handle_selection({"new": item})
+                            self._choose_existing.value = item
                         else:
                             # Set the selection to the first choice if there is one
                             # To make 100% sure the observer is triggered, we set the

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -368,7 +368,7 @@ class PhotometryWorkingDirSettings:
         }
 
         # The order matters here. Keys in the argument passed_partial_settings
-        # will overwrite the keys in disk)settings.
+        # will overwrite the keys in disk settings.
         # Note that update works in-place.
         disk_settings.update(passed_partial_settings)
 

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -956,8 +956,9 @@ class TestReviewSettings:
         # and just one type of setting.
         for setting_class in SETTING_CLASSES:
             review_settings = ReviewSettings([setting_class], style=container_type)
-            assert review_settings._container.titles[0].startswith(
+            assert (
                 _to_space(to_snake(setting_class.__name__))
+                in review_settings._container.titles[0]
             )
             if container_type == "tabs":
                 assert isinstance(review_settings._container, ipw.Tab)
@@ -992,12 +993,14 @@ class TestReviewSettings:
             # Make the review widget. It should auto-populate with the item with just
             # created because that is the only item of that type.
             review_settings = ReviewSettings([setting_class])
-            assert review_settings._container.children[0].value == item
+            model_dict = review_settings._container.children[0]._autoui_widget.value
+            assert setting_class(**model_dict) == item
 
             # This setting was made automatically by the widget, so the title of the
             # container should end with SaveStatus.SETTING_SHOULD_BE_REVIEWED
-            assert review_settings._container.titles[0].endswith(
+            assert (
                 SaveStatus.SETTING_SHOULD_BE_REVIEWED
+                in review_settings._container.titles[0]
             )
 
             # The item setting should also have been saved to the working directory
@@ -1021,6 +1024,4 @@ class TestReviewSettings:
         # Select the Observatory tab
         review_settings._container.selected_index = 1
 
-        assert review_settings._container.titles[1].endswith(
-            SaveStatus.SETTING_IS_SAVED
-        )
+        assert SaveStatus.SETTING_IS_SAVED in review_settings._container.titles[1]

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -857,27 +857,20 @@ class TestSettingWithTitle:
         # There should also be no unsaved changes at the moment
         assert not camera_title._autoui_widget.savebuttonbar.unsaved_changes
 
-        # Manually set unsaved_changes then call the change handler, which should
-        # add an indication that there are unsaved changes.
+        # Manually set the value of the gain, which should make the trait
+        # unsaved_changes True...
         camera_title._autoui_widget.di_widgets["gain"].value = str(
             2 * TEST_CAMERA_VALUES["gain"]
         )
-        # camera_title._autoui_widget.savebuttonbar.unsaved_changes = True
-        # camera_title._title_observer()
-        assert SaveStatus.SETTING_NOT_SAVED in camera_title.title.value
-        # # Go back to unsaved_changes being False
-        # camera_title._autoui_widget.savebuttonbar.unsaved_changes = False
 
-        # # Manually call the change handler, which should add an indication that
-        # # saves have been done.
-        # camera_title._title_observer()
-        # Click save
-        # assert SaveStatus.SETTING_IS_SAVED in camera_title.title.value
-        # Now change the camera value, which should trigger the change handler
-        camera_title._autoui_widget.value = TEST_CAMERA_VALUES
-
-        assert camera_title._autoui_widget.savebuttonbar.unsaved_changes
+        # ...and if unsaved_changes is True the "not saved" indicator should be present
         assert SaveStatus.SETTING_NOT_SAVED in camera_title.title.value
+
+        # Click save...
+        camera_title._autoui_widget.savebuttonbar.bn_save.click()
+
+        # ... cand check that the title is decorated with the "saved" indicator
+        assert SaveStatus.SETTING_IS_SAVED in camera_title.title.value
 
         # Finally, click the save button and the title should be decorated with
         # the saved indication.

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -199,14 +199,21 @@ class TestChooseOrMakeNew:
         camera = self.make_test_camera()
 
         # Make an additional test camera so that the result is the *second* camera
-        # in the list, not the first. If it is the first the outcome is the same
-        # whether the user was editing or making a new camera.
+        # in the list, not the first. The workflow being test is that there are
+        # already two cameras, then the second one is selected (so that something is)
+        # selected) and then that second one is edited, but "no" is clicked on the
+        # confirmation dialog.
         saved = SavedSettings()
         camera.name = "zzzz" + camera.name
         saved.add_item(camera)
 
         choose_or_make_new = ChooseOrMakeNew("camera")
+
+        # There should be three choices in the dropdown -- the two cameras and
+        # "Make new"
         assert len(choose_or_make_new._choose_existing.options) == 3
+
+        # Choose the second camera
         choose_or_make_new._choose_existing.value = camera
 
         assert camera == choose_or_make_new.value
@@ -990,6 +997,8 @@ class TestReviewSettings:
                 created_from_defaults = True
 
             if created_from_defaults:
+                # Test whether the setting, which was able to be created from default
+                # values of the fields, is in the partial_settings.
                 wd_settings.load()
                 snake_name = to_snake(setting_class.__name__)
                 assert (
@@ -1239,6 +1248,7 @@ class TestReviewSettings:
         assert review_settings.current_settings == PartialPhotometrySettings()
 
     def test_selecting_table_without_saved_setting_sets_proper_badge(self):
+        # Test that selecting a tab with a saved setting sets a proper "NOT SAVED" badge
         review_settings = ReviewSettings([PhotometryApertures, Camera])
         review_settings._container.selected_index = 1
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[1]

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -200,7 +200,7 @@ class TestChooseOrMakeNew:
 
         # Make an additional test camera so that the result is the *second* camera
         # in the list, not the first. The workflow being test is that there are
-        # already two cameras, then the second one is selected (so that something is)
+        # already two cameras, then the second one is selected (so that something is
         # selected) and then that second one is edited, but "no" is clicked on the
         # confirmation dialog.
         saved = SavedSettings()
@@ -876,7 +876,7 @@ class TestSettingWithTitle:
         # Click save...
         camera_title._autoui_widget.savebuttonbar.bn_save.click()
 
-        # ... cand check that the title is decorated with the "saved" indicator
+        # ... and check that the title is decorated with the "saved" indicator
         assert SaveStatus.SETTING_IS_SAVED in camera_title.title.value
 
         # Finally, click the save button and the title should be decorated with

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -198,7 +198,7 @@ class TestChooseOrMakeNew:
         # Should not save the item after clicking the No button
         camera = self.make_test_camera()
 
-        # Make an additional test camera so that we the result is the *second* camera
+        # Make an additional test camera so that the result is the *second* camera
         # in the list, not the first. If it is the first the outcome is the same
         # whether the user was editing or making a new camera.
         saved = SavedSettings()

--- a/stellarphot/settings/views.py
+++ b/stellarphot/settings/views.py
@@ -176,7 +176,6 @@ def _file_chooser_value_fixer(source_locations_ui):
         if (Path(file_chooser.selected_path) / file_chooser.selected_filename) != Path(
             file_chooser.value
         ):
-            print("😱" * 10)
             file_chooser.reset(
                 file_chooser.selected_path, Path(file_chooser.value).name
             )

--- a/tox.ini
+++ b/tox.ini
@@ -51,4 +51,4 @@ commands =
 skip_install = true
 description = Run lint checks with ruff
 deps = ruff
-commands = ruff {toxinidir}
+commands = ruff check {toxinidir}


### PR DESCRIPTION
This pull request adds what will be the first of the new photometry notebooks (setting camera, observatory, passband map) and the final review-of-settings notebook. 

Remaining to be done:

- [x] add unit tests for `ReviewSettings`
- [x] add notebook for first step
- [x] add notebook for last step
- [x] add launcher entries for notebooks 

Fixes #377 which was uncovered during development of this new widget.
Fixes #182 -- the notebooks were not combined but things have been streamlined a bit.