### PR TITLE
Use pytest-mock to create testing path for saved settings

### DIFF
--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -41,9 +41,7 @@ class ChooseOrMakeNew(ipw.VBox):
         PassbandMap.__name__,
     ]
 
-    def __init__(
-        self, item_type_name, *arg, details_hideable=False, _testing_path=None, **kwargs
-    ):
+    def __init__(self, item_type_name, *arg, details_hideable=False, **kwargs):
         if item_type_name not in self._known_types:
             raise ValueError(
                 f"Unknown item type {item_type_name}. Must "
@@ -52,7 +50,7 @@ class ChooseOrMakeNew(ipw.VBox):
         # Get the widgety goodness from the parent class
         super().__init__(*arg, **kwargs)
 
-        self._saved_settings = SavedSettings(_testing_path=_testing_path)
+        self._saved_settings = SavedSettings()
         self._item_type_name = item_type_name
 
         # keep track of whether we are editing an existing item

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -129,12 +129,9 @@ class SavedSettings:
             not exist. If False, the directory is not created, which is useful for
             testing.
         """
-        if _testing_path is not None:
-            data_dir = _testing_path
-        else:
-            data_dir = PlatformDirs(
-                "stellarphot", version=SETTINGS_FILE_VERSION
-            ).user_data_dir
+        data_dir = PlatformDirs(
+            "stellarphot", version=SETTINGS_FILE_VERSION
+        ).user_data_dir
         self._settings_path = Path(data_dir)
         if _create_path:
             if not self.settings_path.exists():
@@ -441,6 +438,11 @@ class PhotometryWorkingDirSettings:
     def load(self):
         """
         Load full or partial settings.
+
+        Returns
+        -------
+        PhotometrySettings | PartialPhotometrySettings | None
+            The settings loaded from disk, or None if there are no settings files.
         """
         # Assume we have nothing to begin....
         self._partial_settings = None

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -27,6 +27,9 @@ class TestChooseOrMakeNew:
     Class for testing the ChooseOrMakeNew widget.
     """
 
+    # See test_settings_file.TestSavedSettings for a detailed description of what the
+    # following fixture does. In brief, it patches the settings_files.PlatformDirs class
+    # so that the user_data_dir method returns the temporary directory.
     @pytest.fixture(autouse=True)
     def fake_settings_dir(self, mocker, tmp_path):
         mocker.patch.object(

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -7,6 +7,7 @@ from stellarphot.settings import (
     Observatory,
     PassbandMap,
     SavedSettings,
+    settings_files,
     ui_generator,
 )
 from stellarphot.settings.custom_widgets import (
@@ -26,12 +27,18 @@ class TestChooseOrMakeNew:
     Class for testing the ChooseOrMakeNew widget.
     """
 
-    def make_test_camera(self, path):
+    @pytest.fixture(autouse=True)
+    def fake_settings_dir(self, mocker, tmp_path):
+        mocker.patch.object(
+            settings_files.PlatformDirs, "user_data_dir", tmp_path / "stellarphot"
+        )
+
+    def make_test_camera(self):
         """
         Make a camera with the default testing values and save it. This came
         up often enough to warrant its own method.
         """
-        saved = SavedSettings(_testing_path=path)
+        saved = SavedSettings()
         camera = Camera(**TEST_CAMERA_VALUES)
         saved.add_item(camera)
 
@@ -61,21 +68,21 @@ class TestChooseOrMakeNew:
         choose_or_make_new = ChooseOrMakeNew(item_type)
         assert choose_or_make_new._item_type_name == item_type
 
-    def test_initial_configuration_with_no_items(self, tmp_path):
+    def test_initial_configuration_with_no_items(self):
         # Should have a dropdown with one item, "Make new passband map"
         # using passband_map here to also test that underscores get converted to spaces
-        choose_or_make_new = ChooseOrMakeNew("passband_map", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("passband_map")
         assert len(choose_or_make_new._choose_existing.options) == 1
         assert choose_or_make_new._choose_existing.options[0] == (
             "Make new passband map",
             "none",
         )
 
-    def test_make_new_makes_a_new_item(self, tmp_path):
+    def test_make_new_makes_a_new_item(self):
         # We will test this with Camera, should work for the others too since the code
         # path is the same.
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Set the values for the new item
         choose_or_make_new._item_widget.value = TEST_CAMERA_VALUES
 
@@ -88,7 +95,7 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._making_new is False
 
         # Check what we created using SavedSettings...
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         cameras = saved.get_items("camera")
         assert len(cameras.as_dict) == 1
         assert list(cameras.as_dict.values())[0].model_dump() == TEST_CAMERA_VALUES
@@ -101,30 +108,28 @@ class TestChooseOrMakeNew:
             ("passband_map", DEFAULT_PASSBAND_MAP),
         ],
     )
-    def test_make_new_with_existing_item_resets_value(
-        self, tmp_path, item_type, setting
-    ):
+    def test_make_new_with_existing_item_resets_value(self, item_type, setting):
         # When "make a new" item is selected the value of the widget should be
         # the same as when a widget of that type is created.
 
         # Make a camera widget just to get the value for a new item.
-        choose_or_make_new = ChooseOrMakeNew(item_type, _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew(item_type)
         value_when_new = choose_or_make_new._item_widget.value.copy()
 
         # Make a camera
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         item = choose_or_make_new._item_widget.model(**setting)
         saved.add_item(item)
 
         # Make a camera widget and select "Make new"
-        choose_or_make_new = ChooseOrMakeNew(item_type, _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew(item_type)
         choose_or_make_new._choose_existing.value = "none"
         assert choose_or_make_new._item_widget.value == value_when_new
 
-    def test_edit_requires_confirmation(self, tmp_path):
+    def test_edit_requires_confirmation(self):
         # Should require confirmation if the item already exists
-        self.make_test_camera(tmp_path)
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        self.make_test_camera()
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # the edit button should be displayed and the confirm widget should be hidden
         # note: display typically start as None or an empty string, so we just check
         # that it is not "none", which is what it will be set to when it is hidden.
@@ -148,11 +153,11 @@ class TestChooseOrMakeNew:
         # The confirmation dialog should contain the word "replace"
         assert "replace" in choose_or_make_new._confirm_edit_delete.message.lower()
 
-    def test_edit_item_saved_after_confirm(self, tmp_path):
+    def test_edit_item_saved_after_confirm(self):
         # Should save the item after confirmation
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
@@ -164,15 +169,15 @@ class TestChooseOrMakeNew:
         # Simulate a click on the confirm button...
         choose_or_make_new._confirm_edit_delete._yes.click()
 
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         cameras = saved.get_items("camera")
         assert cameras.as_dict[TEST_CAMERA_VALUES["name"]].gain == new_gain
 
-    def test_edit_item_not_saved_after_cancel(self, tmp_path):
+    def test_edit_item_not_saved_after_cancel(self):
         # Should not save the item after clicking the No button
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
@@ -184,20 +189,20 @@ class TestChooseOrMakeNew:
         # Simulate a click on the cancel button...
         choose_or_make_new._confirm_edit_delete._no.click()
 
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         cameras = saved.get_items("camera")
         assert (
             cameras.as_dict[TEST_CAMERA_VALUES["name"]].gain
             == TEST_CAMERA_VALUES["gain"]
         )
 
-    def test_selecting_make_new_as_selection_works(self, tmp_path):
+    def test_selecting_make_new_as_selection_works(self):
         # Should allow the user to select "Make new" as a selection
 
         # Make a camera so that we can test that selecting "Make new" works
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # This is the value for the "Make new...." option
         choose_or_make_new._choose_existing.value = "none"
 
@@ -210,9 +215,9 @@ class TestChooseOrMakeNew:
         # save button bar should be displayed
         assert choose_or_make_new._item_widget.savebuttonbar.layout.display != "none"
 
-    def test_choosing_different_item_updates_display(self, tmp_path):
+    def test_choosing_different_item_updates_display(self):
         # Should update the display when a different item is chosen
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
         saved.add_item(observatory)
 
@@ -223,7 +228,7 @@ class TestChooseOrMakeNew:
 
         saved.add_item(observatory2)
 
-        choose_or_make_new = ChooseOrMakeNew("observatory", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("observatory")
 
         # There should be three choices in the dropdown
         assert len(choose_or_make_new._choose_existing.options) == 3
@@ -238,14 +243,14 @@ class TestChooseOrMakeNew:
         # The item widget should now have the values of the second observatory
         assert Observatory(**choose_or_make_new._item_widget.value) == observatory2
 
-    def test_passband_map_buttons_are_disabled_or_enabled(self, tmp_path):
+    def test_passband_map_buttons_are_disabled_or_enabled(self):
         # When an existing PassbandMap is selected the add/remove buttons
         # for individual rows should not be displayed.
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         passband_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
         saved.add_item(passband_map)
 
-        choose_or_make_new = ChooseOrMakeNew("passband_map", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("passband_map")
 
         # There is no great way to get to the ItemBox widget that contains and controls
         # the add/remove buttons, so we keep going down through widget children until we
@@ -268,31 +273,31 @@ class TestChooseOrMakeNew:
         item_box = find_item_box(choose_or_make_new)
         assert item_box.add_remove_controls == ItemControl.add_remove
 
-    def test_make_passband_map(self, tmp_path):
+    def test_make_passband_map(self):
         # Make a passband map and save it, then check that it is in the dropdown
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         passband_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
         saved.add_item(passband_map)
 
         # Should create a new passband map
-        choose_or_make_new = ChooseOrMakeNew("passband_map", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("passband_map")
         assert len(choose_or_make_new._choose_existing.options) == 2
         assert choose_or_make_new._choose_existing.options[0][0] == passband_map.name
 
-    def test_no_edit_button_when_there_are_no_items(self, tmp_path):
+    def test_no_edit_button_when_there_are_no_items(self):
         # Should not have an edit button when there are no items
-        saved = SavedSettings(_testing_path=tmp_path)
+        saved = SavedSettings()
         # Make sure there are no cameras
         assert len(saved.get_items("camera").as_dict) == 0
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         assert choose_or_make_new._edit_delete_container.layout.display == "none"
 
-    def test_edit_button_returns_after_making_new_item(self, tmp_path):
+    def test_edit_button_returns_after_making_new_item(self):
         # After making a new item the edit button should be displayed
 
         # There are no cameras so this puts us into the form to make a new one
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
 
         # Make sure the edit button is hidden
         assert choose_or_make_new._edit_delete_container.layout.display == "none"
@@ -317,15 +322,15 @@ class TestChooseOrMakeNew:
         # The edit button should now be displayed
         assert choose_or_make_new._edit_delete_container.layout.display != "none"
 
-    def test_save_button_disabled_when_no_changes(self, tmp_path):
+    def test_save_button_disabled_when_no_changes(self):
         # Immediately after the edit button has been clicked, the save button should be
         # disabled because no changes have been made yet.
         #
         # That should remain true even after the user makes a change, then saves it
         # and then edits again but has not yet made any changes.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
@@ -351,23 +356,23 @@ class TestChooseOrMakeNew:
         # The save button should be disabled
         assert choose_or_make_new._item_widget.savebuttonbar.bn_save.disabled
 
-    def test_revert_button_is_enabled_after_clicking_edit(self, tmp_path):
+    def test_revert_button_is_enabled_after_clicking_edit(self):
         # The revert button should be enabled after clicking the edit button so
         # the user can cancel the edit.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
         # The revert button should be enabled
         assert not choose_or_make_new._item_widget.savebuttonbar.bn_revert.disabled
 
-    def test_clicking_revert_button_cancels_edit(self, tmp_path):
+    def test_clicking_revert_button_cancels_edit(self):
         # Clicking the revert button should cancel the edit
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
@@ -384,13 +389,13 @@ class TestChooseOrMakeNew:
         assert not choose_or_make_new._editing
 
     def test_revert_button_remains_enabled_with_invalid_value_and_actually_reverts(
-        self, tmp_path
+        self,
     ):
         # The revert button should remain enabled if the value is invalid and reverting
         # should actually revert the value.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Simulate a click on the edit button...
         choose_or_make_new._edit_button.click()
 
@@ -415,13 +420,13 @@ class TestChooseOrMakeNew:
         # The camera should not have been changed
         assert choose_or_make_new._item_widget.value == TEST_CAMERA_VALUES
 
-    def test_delete_button_click_displays_confirm_dialog(self, tmp_path):
+    def test_delete_button_click_displays_confirm_dialog(self):
         # Clicking "Delete" should display a confirmation dialog
 
         # Make an item to ensure an existing item is displayed when the widget is made
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         choose_or_make_new._delete_button.click()
 
         # Confirm dialog should be displayed
@@ -432,11 +437,11 @@ class TestChooseOrMakeNew:
         assert "delete" in choose_or_make_new._confirm_edit_delete.message.lower()
 
     @pytest.mark.parametrize("click_yes", [True, False])
-    def test_delete_actions_after_confirmation(self, tmp_path, click_yes):
+    def test_delete_actions_after_confirmation(self, click_yes):
         # Clicking "Yes" in the confirmation dialog should delete the item
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         choose_or_make_new._delete_button.click()
 
         if click_yes:
@@ -444,7 +449,7 @@ class TestChooseOrMakeNew:
             choose_or_make_new._confirm_edit_delete._yes.click()
 
             # The camera should be gone
-            saved = SavedSettings(_testing_path=tmp_path)
+            saved = SavedSettings()
             cameras = saved.get_items("camera")
             assert len(cameras.as_dict) == 0
         else:
@@ -452,7 +457,7 @@ class TestChooseOrMakeNew:
             choose_or_make_new._confirm_edit_delete._no.click()
 
             # The camera should still be there
-            saved = SavedSettings(_testing_path=tmp_path)
+            saved = SavedSettings()
             cameras = saved.get_items("camera")
             assert len(cameras.as_dict) == 1
             assert list(cameras.as_dict.values())[0].model_dump() == TEST_CAMERA_VALUES
@@ -472,17 +477,17 @@ class TestChooseOrMakeNew:
         else:
             assert choose_or_make_new._edit_delete_container.layout.display == "none"
 
-    def test_correct_item_selected_after_delete_and_yes(self, tmp_path):
+    def test_correct_item_selected_after_delete_and_yes(self):
         # The correct item should be selected after an item is deleted and the user
         # clicks "Yes" in the confirmation dialog.
         # Make two cameras
-        self.make_test_camera(tmp_path)
-        saved = SavedSettings(_testing_path=tmp_path)
+        self.make_test_camera()
+        saved = SavedSettings()
         camera2 = Camera(**TEST_CAMERA_VALUES)
         camera2.name = "zzzz" + camera2.name
         saved.add_item(camera2)
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         # Select the first camera...
         choose_or_make_new._choose_existing.value = saved.cameras.as_dict[
             TEST_CAMERA_VALUES["name"]
@@ -496,12 +501,12 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._choose_existing.value == camera2
 
     @pytest.mark.parametrize("click_yes", [True, False])
-    def test_making_new_with_same_name_as_existing(self, tmp_path, click_yes):
+    def test_making_new_with_same_name_as_existing(self, click_yes):
         # Making a new item with the same name as an existing item should require
         # confirmation
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
 
         # Click the "Make new" button
         choose_or_make_new._choose_existing.value = "none"
@@ -534,13 +539,13 @@ class TestChooseOrMakeNew:
 
         assert chosen_cam == expected_camera
 
-    def test_weird_sequence_of_no_clicks(self, tmp_path):
+    def test_weird_sequence_of_no_clicks(self):
         # This is a regression test for #320
         # Make a camera
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
         # Make a new camera...
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         choose_or_make_new._choose_existing.value = "none"
         choose_or_make_new._item_widget.value = TEST_CAMERA_VALUES
 
@@ -561,14 +566,12 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._edit_delete_container.layout.display != "none"
 
     @pytest.mark.parametrize("hideable", [True, False])
-    def test_details_hideable_or_not(self, tmp_path, hideable):
+    def test_details_hideable_or_not(self, hideable):
         # The details should be hideable if requested
 
         # Make a camera so that the details can be hidden
-        self.make_test_camera(tmp_path)
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=hideable, _testing_path=tmp_path
-        )
+        self.make_test_camera()
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=hideable)
 
         # New UI element should be in the big box
         assert (
@@ -597,15 +600,13 @@ class TestChooseOrMakeNew:
         choose_or_make_new._show_details_ui.value = True
         assert choose_or_make_new._details_box.layout.display != "none"
 
-    def test_details_hideable_plays_nicely_with_new_item(self, tmp_path):
+    def test_details_hideable_plays_nicely_with_new_item(self):
         # The details should be hideable and should play nicely with making a new item
         # Make an item so that selecting "Make new" will count as a value
         # change later.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=True, _testing_path=tmp_path
-        )
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=True)
 
         assert choose_or_make_new._details_box.layout.display != "none"
 
@@ -638,14 +639,12 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._details_box.layout.display == "none"
         assert not choose_or_make_new._show_details_ui.value
 
-    def test_details_hideable_not_set_preserves_old_behavior(self, tmp_path):
+    def test_details_hideable_not_set_preserves_old_behavior(self):
         # The details should not be hidden if hideable is false
         # Make a camera
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=False, _testing_path=tmp_path
-        )
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=False)
 
         # New UI element should not be in the big box
         assert choose_or_make_new._show_details_ui.layout.display == "none"
@@ -660,17 +659,13 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._details_box.layout.display != "none"
 
     @pytest.mark.parametrize("show_detail_state", [True, False])
-    def test_details_hideable_cancel_making_new_restores_state(
-        self, tmp_path, show_detail_state
-    ):
+    def test_details_hideable_cancel_making_new_restores_state(self, show_detail_state):
         # The details should be hideable and should play nicely with making a new item
         # Make an item so that selecting "Make new" will count as a value
         # change later.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=True, _testing_path=tmp_path
-        )
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=True)
 
         assert choose_or_make_new._details_box.layout.display != "none"
 
@@ -698,20 +693,18 @@ class TestChooseOrMakeNew:
         # Details should match prior state
         assert choose_or_make_new._show_details_ui.value == show_state
 
-    def test_chooser_has_value(self, tmp_path):
+    def test_chooser_has_value(self):
         # The chooser should have a value
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew("camera", _testing_path=tmp_path)
+        choose_or_make_new = ChooseOrMakeNew("camera")
         assert choose_or_make_new.value == Camera(**TEST_CAMERA_VALUES)
 
-    def test_details_can_be_hidden(self, tmp_path):
+    def test_details_can_be_hidden(self):
         # Make sure that item details can be hidden programmatically.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=True, _testing_path=tmp_path
-        )
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=True)
 
         # Check that the details start out displayed
         assert choose_or_make_new._details_box.layout.display != "none"
@@ -723,14 +716,12 @@ class TestChooseOrMakeNew:
         # Check that the details are hidden
         assert choose_or_make_new._details_box.layout.display == "none"
 
-    def test_details_visibilty_cannot_be_changed_when_not_hideable(self, tmp_path):
+    def test_details_visibilty_cannot_be_changed_when_not_hideable(self):
         # Make sure that item details cannot be hidden programmatically when hideable
         # is False.
-        self.make_test_camera(tmp_path)
+        self.make_test_camera()
 
-        choose_or_make_new = ChooseOrMakeNew(
-            "camera", details_hideable=False, _testing_path=tmp_path
-        )
+        choose_or_make_new = ChooseOrMakeNew("camera", details_hideable=False)
 
         # Check that the details start out displayed
         assert choose_or_make_new._details_box.layout.display != "none"

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -13,7 +13,7 @@ from stellarphot.settings import (
     PhotometrySettings,
     PhotometryWorkingDirSettings,
     SavedSettings,
-    settings_files,
+    settings_files,  # This import is needed for mocking -- see TestSavedSettings
 )
 from stellarphot.settings.tests.test_models import DEFAULT_PHOTOMETRY_SETTINGS
 
@@ -82,7 +82,15 @@ class TestSavedSettings:
 
         # One of the confusing things is figuring out what to mock. In this case, we are
         # mocking the user_data_dir attribute of the PlatformDirs class in the
-        # settings_files module. This attribute is used to determine the path to the
+        # settings_files module. To make sure that is the PlatformDirs class we are
+        # mocking, we need to specifically mock settings_files.PlatformDirs. A few
+        # things that wouldn't work, for example, are importing PlatformsDirs directly
+        # from platformdirs in this module and then trying to mock that, or importing
+        # PlatformDirs from settings_files and then trying to mock that. Actually,
+        # that last thing might work, but there is some values in being explicit here.
+        # doing it that way does mean importing the settings_files module.
+        #
+        # This attribute is used to determine the path to the
         # settings directory. By mocking it, we can control where the settings directory
         # is created and use a temporary directory for the tests.
 

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -13,6 +13,7 @@ from stellarphot.settings import (
     PhotometrySettings,
     PhotometryWorkingDirSettings,
     SavedSettings,
+    settings_files,
 )
 from stellarphot.settings.tests.test_models import DEFAULT_PHOTOMETRY_SETTINGS
 
@@ -56,25 +57,36 @@ PASSBAND_MAP = """
 """
 
 
-class TestSavedSettings:
-    def test_settings_path_contains_package_and_version(self):
-        saved_settings = SavedSettings(_create_path=False)
-        assert "stellarphot" in str(saved_settings.settings_path)
-        assert SETTINGS_FILE_VERSION in str(saved_settings.settings_path)
+# Keep this test out of the class so that it uses the real settings path.
+def test_settings_path_contains_package_and_version():
+    # Make sure that the path to the settings file contains the package name and
+    # version.
+    saved_settings = SavedSettings(_create_path=False)
+    assert "stellarphot" in str(saved_settings.settings_path)
+    assert SETTINGS_FILE_VERSION in str(saved_settings.settings_path)
 
-    def test_settings_path_is_created_if_not_exists(self, tmp_path):
-        p = Path(tmp_path / "not a path that exists yet")
-        assert not p.exists()
-        saved_settings = SavedSettings(_testing_path=p)
+
+class TestSavedSettings:
+    @pytest.fixture(autouse=True)
+    def fake_settings_dir(self, mocker, tmp_path):
+        mocker.patch.object(
+            settings_files.PlatformDirs, "user_data_dir", tmp_path / "stellarphot"
+        )
+
+    def test_settings_path_is_created_if_not_exists(self):
+        # p = Path(tmp_path / "stellarphot")
+        # mocker.patch.object(PlatformDirs, 'user_data_dir' / 'stellarphot')
+        assert not Path(settings_files.PlatformDirs.user_data_dir).exists()
+        saved_settings = SavedSettings()
         assert saved_settings.settings_path.exists()
 
     @pytest.mark.parametrize(
         "klass,item_json",
         [(Camera, CAMERA), (Observatory, OBSERVATORY), (PassbandMap, PASSBAND_MAP)],
     )
-    def test_add_saved_item(self, klass, item_json, tmp_path):
+    def test_add_saved_item(self, klass, item_json):
         # Test that items are properly saved and loaded.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         assert saved_settings.settings_path.exists()
         # Add a camera.
         item = klass.model_validate_json(item_json)
@@ -88,9 +100,9 @@ class TestSavedSettings:
         "klass,item_json",
         [(Camera, CAMERA), (Observatory, OBSERVATORY), (PassbandMap, PASSBAND_MAP)],
     )
-    def test_adding_multiple_items_of_same_type(self, klass, item_json, tmp_path):
+    def test_adding_multiple_items_of_same_type(self, klass, item_json):
         # Test that items are properly saved and loaded.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         assert saved_settings.settings_path.exists()
         # Add an item
         item1 = klass.model_validate_json(item_json)
@@ -106,10 +118,10 @@ class TestSavedSettings:
         assert saved_items.as_dict[item2.name] == item2
         assert saved_items.as_dict[item1.name] == item1
 
-    def test_add_existing_saved_item_raises_error(self, tmp_path):
+    def test_add_existing_saved_item_raises_error(self):
         # Test that adding an existing camera raises an error. Other items follow the
         # same pattern, so only cameras are tested.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         item = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(item)
@@ -119,9 +131,9 @@ class TestSavedSettings:
         ):
             saved_settings.add_item(item)
 
-    def test_adding_multiple_types_of_items(self, tmp_path):
+    def test_adding_multiple_types_of_items(self):
         # Test that adding multiple types of items works.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
@@ -142,15 +154,15 @@ class TestSavedSettings:
         assert len(passband_maps.as_dict) == 1
         assert passband_maps.as_dict[passband_map.name] == passband_map
 
-    def test_delete_without_confirm_raises_error(self, tmp_path):
+    def test_delete_without_confirm_raises_error(self):
         # Trying to delete settings without confirming should raise an error.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         with pytest.raises(ValueError, match="You must confirm deletion by passing"):
             saved_settings.cameras.delete()
 
-    def test_delete_with_confirm_deletes_file(self, tmp_path):
+    def test_delete_with_confirm_deletes_file(self):
         # Test that deleting a settings file works.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
@@ -166,9 +178,9 @@ class TestSavedSettings:
         with pytest.raises(ValueError, match="You must confirm deletion by passing"):
             saved_settings.delete()
 
-    def test_delete_all_settings_with_confirm_deletes_files(self, tmp_path):
+    def test_delete_all_settings_with_confirm_deletes_files(self):
         # Test that deleting all settings files works.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
@@ -192,9 +204,9 @@ class TestSavedSettings:
         ).exists()
         assert not saved_settings.settings_path.exists()
 
-    def test_delete_all_with_no_settings_works(self, tmp_path):
+    def test_delete_all_with_no_settings_works(self):
         # Test that deleting all settings files works when no settings are present.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Delete all settings but not the settings folder
         saved_settings.delete(confirm=True)
         assert len(list(saved_settings.settings_path.glob("*"))) == 0
@@ -203,9 +215,9 @@ class TestSavedSettings:
         saved_settings.delete(confirm=True, delete_settings_folder=True)
         assert not saved_settings.settings_path.exists()
 
-    def test_delete_item_from_collection_works(self, tmp_path):
+    def test_delete_item_from_collection_works(self):
         # Test that deleting an item from a collection works.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
@@ -218,17 +230,17 @@ class TestSavedSettings:
         saved_settings.cameras.delete(name=camera2.name, confirm=True)
         assert len(saved_settings.cameras.as_dict) == 1
 
-    def test_delete_item_from_collection_with_unknown_item_fails(self, tmp_path):
+    def test_delete_item_from_collection_with_unknown_item_fails(self):
         # Test that trying to delete an unknown item from a collection fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
         with pytest.raises(ValueError, match="not found in"):
             saved_settings.cameras.delete(name=camera.name + "foo", confirm=True)
 
-    def test_revtrieving_item_by_name_works(self, tmp_path):
+    def test_revtrieving_item_by_name_works(self):
         # Test that retrieving an item by name works.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera.
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
@@ -236,15 +248,15 @@ class TestSavedSettings:
         retrieved_camera = saved_settings.cameras.get(camera.name)
         assert retrieved_camera == camera
 
-    def test_get_item_with_unknown_item_fails(self, tmp_path):
+    def test_get_item_with_unknown_item_fails(self):
         # Test that trying to get an unknown item fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         with pytest.raises(ValueError, match="Unknown item foo of type"):
             saved_settings.get_items("foo")
 
-    def test_add_item_with_unknown_item_fails(self, tmp_path):
+    def test_add_item_with_unknown_item_fails(self):
         # Test that trying to add an unknown item fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         with pytest.raises(ValueError, match="Unknown item foo of type"):
             saved_settings.add_item("foo")
 
@@ -252,9 +264,9 @@ class TestSavedSettings:
         "klass,item_json",
         [(Camera, CAMERA), (Observatory, OBSERVATORY), (PassbandMap, PASSBAND_MAP)],
     )
-    def test_saved_settings_delete_item(self, klass, item_json, tmp_path):
+    def test_saved_settings_delete_item(self, klass, item_json):
         # Test that items can be deleted.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add item.
         item = klass.model_validate_json(item_json)
         saved_settings.add_item(item)
@@ -265,34 +277,32 @@ class TestSavedSettings:
         # Verify that the item was deleted.
         assert len(saved_settings.get_items(klass.__name__).as_dict) == 0
 
-    def test_saved_settings_delete_item_with_unknown_item_fails(self, tmp_path):
+    def test_saved_settings_delete_item_with_unknown_item_fails(self):
         # Test that trying to delete an unknown item fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         with pytest.raises(ValueError, match="Unknown item foo of type"):
             saved_settings.delete_item("foo", confirm=True)
 
-    def test_saved_settings_delete_item_with_confirm_false_fails(self, tmp_path):
+    def test_saved_settings_delete_item_with_confirm_false_fails(self):
         # Test that trying to delete an item without confirming fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Make a camera and save it
         camera = Camera.model_validate_json(CAMERA)
         saved_settings.add_item(camera)
         with pytest.raises(ValueError, match="You must confirm deletion by passing"):
             saved_settings.delete_item(camera, confirm=False)
 
-    def test_saved_settings_delete_item_valid_item_not_in_collection_fails(
-        self, tmp_path
-    ):
+    def test_saved_settings_delete_item_valid_item_not_in_collection_fails(self):
         # Test that trying to delete an item that is not in the collection fails.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Make a camera but don't save it
         camera = Camera.model_validate_json(CAMERA)
         with pytest.raises(ValueError, match="not found in"):
             saved_settings.delete_item(camera, confirm=True)
 
-    def test_saved_settings_round_trip_with_unicode_name(self, tmp_path):
+    def test_saved_settings_round_trip_with_unicode_name(self):
         # Test that items with unicode names can be saved and loaded.
-        saved_settings = SavedSettings(_testing_path=tmp_path)
+        saved_settings = SavedSettings()
         # Add a camera. This particular name causes a failure on Windows because the
         # default encoding doesn't include Korean characters.
         camera_name = "크레이그"

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -67,15 +67,36 @@ def test_settings_path_contains_package_and_version():
 
 
 class TestSavedSettings:
+    # This pytest fixture is used to create a fake settings directory for the tests.
+
+    # Being a fixture means it can be passed into tests or other functions, just like
+    # the fixture tmp_path.
+    # The autouse=True parameter means that this fixture will be provided to every test
+    # in this class without needing to be explicitly passed in.
     @pytest.fixture(autouse=True)
     def fake_settings_dir(self, mocker, tmp_path):
+        # mocker is a pytest fixture provided by the pytest-mock package. It is used to
+        # mock objects and functions.
+        # Mocking means providing a fake version of an object, function, attribute, or
+        # method that can be used in place of the real thing.
+
+        # One of the confusing things is figuring out what to mock. In this case, we are
+        # mocking the user_data_dir attribute of the PlatformDirs class in the
+        # settings_files module. This attribute is used to determine the path to the
+        # settings directory. By mocking it, we can control where the settings directory
+        # is created and use a temporary directory for the tests.
+
+        # stellarphot is added to the name of the directory to make sure we start
+        # without a stellarphot directory for each test.
         mocker.patch.object(
             settings_files.PlatformDirs, "user_data_dir", tmp_path / "stellarphot"
         )
 
     def test_settings_path_is_created_if_not_exists(self):
-        # p = Path(tmp_path / "stellarphot")
-        # mocker.patch.object(PlatformDirs, 'user_data_dir' / 'stellarphot')
+        # Check that the settings path is created if it doesn't exist.
+        # It is important to use settings_files.PlatformDirs instead
+        # of, say, importing PlatformDirs directly because we want to use the mocked
+        # version of the attribute.
         assert not Path(settings_files.PlatformDirs.user_data_dir).exists()
         saved_settings = SavedSettings()
         assert saved_settings.settings_path.exists()


### PR DESCRIPTION
With this, the `_testing_path` argument can be removed from saved settings code. The alternative to going this route was to add `_testing_path` to another class, the `ReviewSettings` widget, which will be in #371.