### PR TITLE
Fix test that breaks in numpy 2.0

### DIFF
--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -708,7 +708,7 @@ def test_catalog_colname_map():
     )
 
     assert catalog_dat["id"][0] == "ASASSN-V J000052.03+002216.6"
-    assert np.abs(catalog_dat["mag"][0].value - 12.660) < 1e-7
+    assert np.abs(catalog_dat["mag"][0].value - 12.660) < 2e-7
     assert catalog_dat["passband"][0] == "g"
     assert catalog_dat.catalog_name == "VSX"
     assert catalog_dat.catalog_source == "Vizier"

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -708,7 +708,7 @@ def test_catalog_colname_map():
     )
 
     assert catalog_dat["id"][0] == "ASASSN-V J000052.03+002216.6"
-    assert np.abs(catalog_dat["mag"][0].value - 12.660)
+    assert np.abs(catalog_dat["mag"][0].value - 12.660) < 1e-7
     assert catalog_dat["passband"][0] == "g"
     assert catalog_dat.catalog_name == "VSX"
     assert catalog_dat.catalog_source == "Vizier"


### PR DESCRIPTION
@JuanCab -- this should be a pretty quick one to review for a change. I'm not quite sure how this test every worked, but it definitely fails with numpy 2 (See #374 for example). The change here fixes it.