### PR TITLE
Remove redundant names detected in a ruff check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,6 @@ select = [
 "__init__.py" = ["E402", "F403"]
 # Ignore F405 (variable may be from star imports) in docs/conf.py
 "docs/conf.py" = ["F405"]
-# Ignore F811 (redefinition of unused) in core for the moment
-"core.py" = ["F811"]
 
 [tool.codespell]
 skip = '*.svg'

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -649,8 +649,6 @@ class CatalogData(BaseEnhancedTable):
         "mag": None,
         "passband": None,
     }
-    catalog_name = None
-    catalog_source = None
 
     def __init__(
         self,

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -712,6 +712,12 @@ def test_catalog_colname_map():
     assert catalog_dat["passband"][0] == "g"
     assert catalog_dat.catalog_name == "VSX"
     assert catalog_dat.catalog_source == "Vizier"
+    catalog_dat.add_row(catalog_dat[0])
+    catalog_dat.add_row(catalog_dat[0])
+    catalog_dat.add_row(catalog_dat[0])
+    catalog_slice = catalog_dat[0:2]
+    assert catalog_slice.catalog_name == "VSX"
+    assert catalog_slice.catalog_source == "Vizier"
 
 
 def test_catalog_bandpassmap():


### PR DESCRIPTION
This removes what was a redundant definition of a couple of properties of catalogs and also adds a test of slicing catalog data to make sure metadata is preserved in a slice

Fixes #376

@JuanCab -- if you could give this one a quick look that would be great.