### PR TITLE
Use new way to make source images in photutils

### DIFF
--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -7,7 +7,7 @@ import matplotlib
 import pytest
 from astropy.nddata import CCDData
 from astrowidgets import ImageWidget
-from photutils.datasets import make_gaussian_sources_image, make_noise_image
+from photutils.datasets import make_noise_image
 
 from stellarphot.gui_tools import (
     seeing_profile_functions as spf,
@@ -16,6 +16,7 @@ from stellarphot.gui_tools.seeing_profile_functions import (
     AP_SETTING_NEEDS_SAVE,
     AP_SETTING_SAVED,
 )
+from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
 from stellarphot.photometry.tests.test_profiles import RANDOM_SEED, SHAPE, STARS
 from stellarphot.settings import (
     Camera,

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -6,9 +6,10 @@ from astropy.modeling.models import Gaussian1D
 from astropy.nddata import CCDData
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
-from photutils.datasets import make_gaussian_sources_image, make_noise_image
+from photutils.datasets import make_noise_image
 
 from stellarphot.photometry import CenterAndProfile, find_center
+from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
 from stellarphot.settings import Camera
 from stellarphot.settings.tests.test_models import TEST_CAMERA_VALUES
 


### PR DESCRIPTION
This fixes #378 by defining `make_gaussian_image_sources` in stellarphot based on its definition in stellarphot. stellarphot will at some point remove this function because it has been deprecated.