### PR TITLE
Update AAVSO filter list to match latest AAVSO update

### DIFF
--- a/stellarphot/settings/aavso_models.py
+++ b/stellarphot/settings/aavso_models.py
@@ -2,13 +2,17 @@ from enum import Enum
 
 
 class AAVSOFilters(str, Enum):
+    """
+    The definitive list of AAVSO filters is at https://www.aavso.org/filters
+    """
+
     U = "U"
     B = "B"
     V = "V"
-    R = "R"
+    RJ = "RJ"
     Rc = "R"
-    I = "I"  # noqa: E741
     Ic = "I"
+    IJ = "IJ"
     J = "J"
     H = "H"
     K = "K"
@@ -35,4 +39,5 @@ class AAVSOFilters(str, Enum):
     Y = "Y"
     HA = "HA"
     HAC = "HAC"
+    CBB = "CBB"
     O = "O"  # noqa: E741


### PR DESCRIPTION
This also fixes #382 because the duplicate R and I entries have been removed.

I *think* the definitive source of filter names is https://www.aavso.org/filters -- I've asked in the AAVSO slack to make sure.

Another quickie @JuanCab 😬 -- good news is that there are not very many open issues milestoned to 2.0.0 left 😀 