### PR TITLE
Use different marker shapes and colors in comparison viewer

### DIFF
--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -85,11 +85,25 @@ def make_markers(iw, RD, vsx, ent, name_or_coord=None):
             iw.center_on(name_or_coord)
 
     if vsx:
-        iw.marker = {"type": "circle", "color": "blue", "radius": 10}
+        # TODO: if astrowidgets ever gets more sensible marker types use those instead
+        # of using the internal interface to marker
+        iw._marker = functools.partial(
+            iw.dc.Box,
+            xradius=10,
+            yradius=10,
+            color="blue",
+        )
         iw.add_markers(
             vsx, skycoord_colname="coords", use_skycoord=True, marker_name="VSX"
         )
-    iw.marker = {"type": "circle", "color": "red", "radius": 10}
+    # TODO: if astrowidgets ever gets more sensible marker types use those instead
+    # of using the internal interface to marker
+    iw._marker = functools.partial(
+        iw.dc.Triangle,
+        xradius=10,
+        yradius=10,
+        color="red",
+    )
     iw.add_markers(
         ent,
         skycoord_colname="coords",
@@ -493,8 +507,8 @@ class ComparisonViewer:
             value="""
         <ul>
         <li>Green circles -- Gaia stars within 2.5 arcmin of target</li>
-        <li>Red circles -- APASS stars within 1 mag of target</li>
-        <li>Blue circles -- VSX variables</li>
+        <li>Red triangles -- Comparison stars from APASS</li>
+        <li>Blue squares -- VSX variables</li>
         <li>Red × -- Exclude as target or comp</li>
         </ul>
         """

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -1017,8 +1017,8 @@ class PhotometryRunner(ipw.VBox):
         self.fitsopen = FitsOpener(
             title=(
                 "Choose an image of the object of interest to you.</br>Photometry "
-                "will be performed on all images of that object in the folder containing "
-                "the selected image."
+                "will be performed on all images of that object in the folder "
+                "containing the selected image."
             )
         )
         self.info_box = ipw.HTML()

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -1017,8 +1017,8 @@ class PhotometryRunner(ipw.VBox):
         self.fitsopen = FitsOpener(
             title=(
                 "Choose an image of the object of interest to you.</br>Photometry "
-                 "will be performed on all images of that object in the folder containing "
-                 "the selected image."
+                "will be performed on all images of that object in the folder containing "
+                "the selected image."
             )
         )
         self.info_box = ipw.HTML()


### PR DESCRIPTION
Fixes #368 by using markers of different shape to indicate whether a star is a target from Gaia, a comparison from APASS or a variable from VSX. The colors are also still different, but this should make the markers distinguishable for people with color blindness.

The legend has been updated to match the markers.

Last one of the day, @JuanCab, I promise!