### PR TITLE
Include proper files in sdist so they land in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,16 +59,24 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "stellarphot/_version.py"
 
+[tool.hatch.build.targets.sdist]
+# This section determines what files are included in the source distribution
+include = [
+    # The source code
+    "/stellarphot",
+    # Logo for JupyterLab launcher
+    "/docs/_static/stellarphot-logo.svg",
+    # Configuration for jupyter-app-launcher
+    "/.jp_app_launcher_stellarphot.yaml"
+]
+
 [tool.hatch.build.targets.wheel.shared-data]
-"stellarphot/notebooks/photometry" = "share/jupyter/stellarphot/photometry"
+# This section determines what data files are included in the wheel
+# and where they should eventually be installed in the user's environment.
+"docs/_static/stellarphot-logo.svg" = "share/jupyter/stellarphot/stellarphot-logo.svg"
+# This includes the notebooks used in the launcher
 "stellarphot/notebooks" = "share/jupyter/stellarphot"
 ".jp_app_launcher_stellarphot.yaml" = "share/jupyter/jupyter_app_launcher/jp_app_launcher_stellarphot.yaml"
-"docs/_static/stellarphot-logo.svg" = "share/jupyter/stellarphot/stellarphot-logo.svg"
-
-[tool.hatch.build.targets.sdist]
-include = [
-    "/stellarphot",
-]
 
 [tool.coverage]
 


### PR DESCRIPTION
This fixes #406. The fundamental issue was that the wheel is built from the sdist, and the sdist did not include the logo or jupyter-app-launcher, so the wheel didn't include them. Unfortunate that wheel building didn't raise an error when it didn't find the files, but the missing files are in the sdist now, and a duplicate entry in the wheel section was removed.

~~Also removes a couple of `__init__.py` that are really unnecessary and were ending up in the environment's jupyter data folder.~~ Turns out at least one of them is necessary because we use `get_pkg_data_filename` to get the location of the photometry runner notebook.