### PR TITLE
Remove code from tests executed on import in `test_models.py`

### DIFF
--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -1026,7 +1026,7 @@ class TestReviewSettings:
             saved = SavedSettings()
             # Make an instance of the class
             snake_name = to_snake(setting_class.__name__)
-            item = TEST_PHOTOMETRY_SETTINGS[snake_name]
+            item = setting_class.model_validate(TEST_PHOTOMETRY_SETTINGS[snake_name])
             # Save the instance to saved settings file
             saved.add_item(item)
 

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import ipywidgets as ipw
 import pytest
+from astropy.units import Quantity
 from camel_converter import to_snake
 from ipyautoui.custom.iterable import ItemBox, ItemControl
 from pydantic import ValidationError
@@ -183,7 +184,7 @@ class TestChooseOrMakeNew:
         choose_or_make_new._edit_button.click()
 
         # Change a value in the camera so we can check that the new value is saved.
-        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        new_gain = 2 * Quantity(TEST_CAMERA_VALUES["gain"])
         choose_or_make_new._item_widget.di_widgets["gain"].value = str(new_gain)
         # Simulate a click on the save button...
         choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
@@ -222,7 +223,7 @@ class TestChooseOrMakeNew:
         choose_or_make_new._edit_button.click()
 
         # Change a value in the camera so we can check that the new value is saved.
-        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        new_gain = 2 * Quantity(TEST_CAMERA_VALUES["gain"])
         choose_or_make_new._item_widget.di_widgets["gain"].value = str(new_gain)
         # Simulate a click on the save button...
         choose_or_make_new._item_widget.savebuttonbar.bn_save.click()
@@ -372,7 +373,7 @@ class TestChooseOrMakeNew:
         assert choose_or_make_new._item_widget.savebuttonbar.bn_save.disabled
 
         # Edit a value in the camera so the save button is enabled
-        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        new_gain = 2 * Quantity(TEST_CAMERA_VALUES["gain"])
         choose_or_make_new._item_widget.di_widgets["gain"].value = str(new_gain)
 
         # The save button should now be enabled
@@ -547,7 +548,7 @@ class TestChooseOrMakeNew:
 
         # set the item widget value to the existing camera with double the gain
         camera_values = TEST_CAMERA_VALUES.copy()
-        camera_values["gain"] = 2 * camera_values["gain"]
+        camera_values["gain"] = 2 * Quantity(camera_values["gain"])
         choose_or_make_new._item_widget.value = Camera(**camera_values)
 
         # Simulate a click on the save button...
@@ -910,7 +911,7 @@ class TestSettingWithTitle:
         camera_title._widget._edit_button.click()
 
         # Edit a value in the camera so the save button is enabled
-        new_gain = 2 * TEST_CAMERA_VALUES["gain"]
+        new_gain = 2 * Quantity(TEST_CAMERA_VALUES["gain"])
         camera_title._widget._item_widget.di_widgets["gain"].value = str(new_gain)
 
         assert SaveStatus.SETTING_NOT_SAVED in camera_title.title.value

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -30,10 +30,10 @@ from stellarphot.settings.custom_widgets import (
     _add_saving_to_widget,
 )
 from stellarphot.settings.tests.test_models import (
-    DEFAULT_OBSERVATORY_SETTINGS,
-    DEFAULT_PASSBAND_MAP,
-    DEFAULT_PHOTOMETRY_SETTINGS,
     TEST_CAMERA_VALUES,
+    TEST_OBSERVATORY_SETTINGS,
+    TEST_PASSBAND_MAP,
+    TEST_PHOTOMETRY_SETTINGS,
 )
 
 
@@ -125,8 +125,8 @@ class TestChooseOrMakeNew:
         "item_type,setting",
         [
             ("camera", TEST_CAMERA_VALUES),
-            ("observatory", DEFAULT_OBSERVATORY_SETTINGS),
-            ("passband_map", DEFAULT_PASSBAND_MAP),
+            ("observatory", TEST_OBSERVATORY_SETTINGS),
+            ("passband_map", TEST_PASSBAND_MAP),
         ],
     )
     def test_make_new_with_existing_item_resets_value(self, item_type, setting):
@@ -252,10 +252,10 @@ class TestChooseOrMakeNew:
     def test_choosing_different_item_updates_display(self):
         # Should update the display when a different item is chosen
         saved = SavedSettings()
-        observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+        observatory = Observatory(**TEST_OBSERVATORY_SETTINGS)
         saved.add_item(observatory)
 
-        observatory2 = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+        observatory2 = Observatory(**TEST_OBSERVATORY_SETTINGS)
         # Make sure this name sorts lower than the first observatory
         observatory2.name = "zzzz" + observatory2.name
         observatory2.elevation = "-200 m"
@@ -281,7 +281,7 @@ class TestChooseOrMakeNew:
         # When an existing PassbandMap is selected the add/remove buttons
         # for individual rows should not be displayed.
         saved = SavedSettings()
-        passband_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
+        passband_map = PassbandMap(**TEST_PASSBAND_MAP)
         saved.add_item(passband_map)
 
         choose_or_make_new = ChooseOrMakeNew("passband_map")
@@ -310,7 +310,7 @@ class TestChooseOrMakeNew:
     def test_make_passband_map(self):
         # Make a passband map and save it, then check that it is in the dropdown
         saved = SavedSettings()
-        passband_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
+        passband_map = PassbandMap(**TEST_PASSBAND_MAP)
         saved.add_item(passband_map)
 
         # Should create a new passband map
@@ -1025,7 +1025,7 @@ class TestReviewSettings:
             saved = SavedSettings()
             # Make an instance of the class
             snake_name = to_snake(setting_class.__name__)
-            item = DEFAULT_PHOTOMETRY_SETTINGS[snake_name]
+            item = TEST_PHOTOMETRY_SETTINGS[snake_name]
             # Save the instance to saved settings file
             saved.add_item(item)
 
@@ -1050,7 +1050,7 @@ class TestReviewSettings:
     def test_creation_with_saved_working_dir_settings(self):
         # Check that when there is a saved item in the working directory
         # the badge attached to the name is "needs review"
-        photometry_apertures = DEFAULT_PHOTOMETRY_SETTINGS["photometry_apertures"]
+        photometry_apertures = TEST_PHOTOMETRY_SETTINGS["photometry_apertures"]
         wk_dir = PhotometryWorkingDirSettings()
         partial_settings = PartialPhotometrySettings(
             photometry_apertures=photometry_apertures
@@ -1074,7 +1074,7 @@ class TestReviewSettings:
         saved = SavedSettings()
         camera = Camera(**TEST_CAMERA_VALUES)
         saved.add_item(camera)
-        observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+        observatory = Observatory(**TEST_OBSERVATORY_SETTINGS)
         saved.add_item(observatory)
 
         # Create the review widget
@@ -1148,8 +1148,8 @@ class TestReviewSettings:
         # saved user settings.
         wd_settings = PhotometryWorkingDirSettings()
         camera = Camera(**TEST_CAMERA_VALUES)
-        observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
-        passbands = PassbandMap(**DEFAULT_PASSBAND_MAP)
+        observatory = Observatory(**TEST_OBSERVATORY_SETTINGS)
+        passbands = PassbandMap(**TEST_PASSBAND_MAP)
         wd_settings.save(
             PartialPhotometrySettings(
                 camera=camera, observatory=observatory, passband_map=passbands
@@ -1182,8 +1182,8 @@ class TestReviewSettings:
         # saved user settings.
         wd_settings = PhotometryWorkingDirSettings()
         camera = Camera(**TEST_CAMERA_VALUES)
-        observatory = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
-        passbands = PassbandMap(**DEFAULT_PASSBAND_MAP)
+        observatory = Observatory(**TEST_OBSERVATORY_SETTINGS)
+        passbands = PassbandMap(**TEST_PASSBAND_MAP)
         wd_settings.save(
             PartialPhotometrySettings(
                 camera=camera, observatory=observatory, passband_map=passbands

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -27,13 +27,13 @@ from stellarphot.settings.models import (
 TEST_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
 
 TEST_CAMERA_VALUES = dict(
-    data_unit=u.adu,
-    gain=2.0 * u.electron / u.adu,
+    data_unit="adu",
+    gain="2.0 electron / adu",
     name="test camera",
-    read_noise=10 * u.electron,
-    dark_current=0.01 * u.electron / u.second,
-    pixel_scale=0.563 * u.arcsec / u.pix,
-    max_data_value=50000 * u.adu,
+    read_noise="10.0 electron",
+    dark_current="0.01 electron / s",
+    pixel_scale="0.563 arcsec / pix",
+    max_data_value="50000.0 adu",
 )
 
 TEST_EXOPLANET_SETTINGS = dict(
@@ -375,7 +375,8 @@ def test_camera_unitscheck():
     # dimensionless_unscaled. So we need to set the units to something that is
     # invalid.
     camera_dict_bad_unit = {
-        k: "5 cows" if hasattr(v, "value") else v for k, v in TEST_CAMERA_VALUES.items()
+        k: "5 cows" if k not in ["name", "data_unit"] else v
+        for k, v in TEST_CAMERA_VALUES.items()
     }
     # All 5 of the attributes after data_unit will be checked for units
     # and noted in the ValidationError message. Rather than checking
@@ -391,7 +392,9 @@ def test_camera_unitscheck():
 def test_camera_negative_max_adu():
     # Check that a negative maximum data value raises an error
     camera_for_test = TEST_CAMERA_VALUES.copy()
-    camera_for_test["max_data_value"] = -1 * camera_for_test["max_data_value"]
+    camera_for_test["max_data_value"] = -1 * u.Quantity(
+        camera_for_test["max_data_value"]
+    )
 
     # Make sure that a negative max_adu raises an error
     with pytest.raises(ValidationError, match="Input should be greater than 0"):

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -24,7 +24,7 @@ from stellarphot.settings.models import (
     SourceLocationSettings,
 )
 
-DEFAULT_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
+TEST_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
 
 TEST_CAMERA_VALUES = dict(
     data_unit=u.adu,
@@ -36,7 +36,7 @@ TEST_CAMERA_VALUES = dict(
     max_data_value=50000 * u.adu,
 )
 
-DEFAULT_EXOPLANET_SETTINGS = dict(
+TEST_EXOPLANET_SETTINGS = dict(
     epoch=Time(0, format="jd"),
     period=0 * u.min,
     identifier="a planet",
@@ -47,7 +47,7 @@ DEFAULT_EXOPLANET_SETTINGS = dict(
     duration=0 * u.min,
 )
 
-DEFAULT_OBSERVATORY_SETTINGS = dict(
+TEST_OBSERVATORY_SETTINGS = dict(
     name="test observatory",
     longitude=43 * u.deg,
     latitude=45 * u.deg,
@@ -58,7 +58,7 @@ DEFAULT_OBSERVATORY_SETTINGS = dict(
 
 # The first setting here is required, the rest are optional. The optional
 # settings below are different than the defaults in the model definition.
-DEFAULT_PHOTOMETRY_OPTIONS = dict(
+TEST_PHOTOMETRY_OPTIONS = dict(
     include_dig_noise=False,
     reject_too_close=False,
     reject_background_outliers=False,
@@ -66,7 +66,7 @@ DEFAULT_PHOTOMETRY_OPTIONS = dict(
     method="center",
 )
 
-DEFAULT_PASSBAND_MAP = dict(
+TEST_PASSBAND_MAP = dict(
     name="Example map",
     your_filter_names_to_aavso=[
         PassbandMapEntry(
@@ -84,27 +84,25 @@ DEFAULT_PASSBAND_MAP = dict(
     ],
 )
 
-DEFAULT_LOGGING_SETTINGS = dict(
+TEST_LOGGING_SETTINGS = dict(
     logfile="test.log",
     console_log=False,
 )
 
-DEFAULT_SOURCE_LOCATION_SETTINGS = dict(
+TEST_SOURCE_LOCATION_SETTINGS = dict(
     shift_tolerance=5,
     source_list_file="test.ecsv",
     use_coordinates="pixel",
 )
 
-DEFAULT_PHOTOMETRY_SETTINGS = dict(
+TEST_PHOTOMETRY_SETTINGS = dict(
     camera=Camera(**TEST_CAMERA_VALUES),
-    observatory=Observatory(**DEFAULT_OBSERVATORY_SETTINGS),
-    photometry_apertures=PhotometryApertures(**DEFAULT_APERTURE_SETTINGS),
-    source_location_settings=SourceLocationSettings(**DEFAULT_SOURCE_LOCATION_SETTINGS),
-    photometry_optional_settings=PhotometryOptionalSettings(
-        **DEFAULT_PHOTOMETRY_OPTIONS
-    ),
-    passband_map=PassbandMap(**DEFAULT_PASSBAND_MAP),
-    logging_settings=LoggingSettings(**DEFAULT_LOGGING_SETTINGS),
+    observatory=Observatory(**TEST_OBSERVATORY_SETTINGS),
+    photometry_apertures=PhotometryApertures(**TEST_APERTURE_SETTINGS),
+    source_location_settings=SourceLocationSettings(**TEST_SOURCE_LOCATION_SETTINGS),
+    photometry_optional_settings=PhotometryOptionalSettings(**TEST_PHOTOMETRY_OPTIONS),
+    passband_map=PassbandMap(**TEST_PASSBAND_MAP),
+    logging_settings=LoggingSettings(**TEST_LOGGING_SETTINGS),
 )
 
 
@@ -112,14 +110,14 @@ DEFAULT_PHOTOMETRY_SETTINGS = dict(
     "model,settings",
     [
         [Camera, TEST_CAMERA_VALUES],
-        [PhotometryApertures, DEFAULT_APERTURE_SETTINGS],
-        [Exoplanet, DEFAULT_EXOPLANET_SETTINGS],
-        [Observatory, DEFAULT_OBSERVATORY_SETTINGS],
-        [PhotometryOptionalSettings, DEFAULT_PHOTOMETRY_OPTIONS],
-        [PassbandMap, DEFAULT_PASSBAND_MAP],
-        [PhotometrySettings, DEFAULT_PHOTOMETRY_SETTINGS],
-        [LoggingSettings, DEFAULT_LOGGING_SETTINGS],
-        [SourceLocationSettings, DEFAULT_SOURCE_LOCATION_SETTINGS],
+        [PhotometryApertures, TEST_APERTURE_SETTINGS],
+        [Exoplanet, TEST_EXOPLANET_SETTINGS],
+        [Observatory, TEST_OBSERVATORY_SETTINGS],
+        [PhotometryOptionalSettings, TEST_PHOTOMETRY_OPTIONS],
+        [PassbandMap, TEST_PASSBAND_MAP],
+        [PhotometrySettings, TEST_PHOTOMETRY_SETTINGS],
+        [LoggingSettings, TEST_LOGGING_SETTINGS],
+        [SourceLocationSettings, TEST_SOURCE_LOCATION_SETTINGS],
     ],
 )
 class TestModelAgnosticActions:
@@ -232,8 +230,8 @@ class TestModelAgnosticActions:
     "model,settings",
     [
         [Camera, TEST_CAMERA_VALUES.copy()],
-        [Observatory, DEFAULT_OBSERVATORY_SETTINGS.copy()],
-        [PassbandMap, DEFAULT_PASSBAND_MAP.copy()],
+        [Observatory, TEST_OBSERVATORY_SETTINGS.copy()],
+        [PassbandMap, TEST_PASSBAND_MAP.copy()],
     ],
 )
 class TestModelsWithName:
@@ -275,7 +273,7 @@ class TestModelsWithName:
     "model,settings",
     [
         [Camera, TEST_CAMERA_VALUES.copy()],
-        [Observatory, DEFAULT_OBSERVATORY_SETTINGS.copy()],
+        [Observatory, TEST_OBSERVATORY_SETTINGS.copy()],
     ],
 )
 class TestModelExamples:
@@ -355,11 +353,11 @@ def test_partial_photometry_settings():
     # Loop over the individual default photometry settings and make sure we can
     # create a PartialPhotometrySettings object with just that field.
 
-    for k, v in DEFAULT_PHOTOMETRY_SETTINGS.items():
+    for k, v in TEST_PHOTOMETRY_SETTINGS.items():
         pps = PartialPhotometrySettings(**{k: v})
         assert getattr(pps, k) == v
 
-    choices = list(DEFAULT_PHOTOMETRY_SETTINGS.items())
+    choices = list(TEST_PHOTOMETRY_SETTINGS.items())
     for i in range(2, 5):
         # Try a few random subsets of fields
         fields = random.choices(choices, k=i)
@@ -474,24 +472,24 @@ def test_camera_altunitscheck():
 
 
 def test_create_aperture_settings_correctly():
-    ap_set = PhotometryApertures(**DEFAULT_APERTURE_SETTINGS)
-    assert ap_set.radius == DEFAULT_APERTURE_SETTINGS["radius"]
+    ap_set = PhotometryApertures(**TEST_APERTURE_SETTINGS)
+    assert ap_set.radius == TEST_APERTURE_SETTINGS["radius"]
     assert (
         ap_set.inner_annulus
-        == DEFAULT_APERTURE_SETTINGS["radius"] + DEFAULT_APERTURE_SETTINGS["gap"]
+        == TEST_APERTURE_SETTINGS["radius"] + TEST_APERTURE_SETTINGS["gap"]
     )
     assert (
         ap_set.outer_annulus
-        == DEFAULT_APERTURE_SETTINGS["radius"]
-        + DEFAULT_APERTURE_SETTINGS["gap"]
-        + DEFAULT_APERTURE_SETTINGS["annulus_width"]
+        == TEST_APERTURE_SETTINGS["radius"]
+        + TEST_APERTURE_SETTINGS["gap"]
+        + TEST_APERTURE_SETTINGS["annulus_width"]
     )
 
 
 @pytest.mark.parametrize("bad_one", ["radius", "gap", "annulus_width"])
 def test_create_invalid_values(bad_one):
     # Check that individual values that are bad raise an error
-    bad_settings = DEFAULT_APERTURE_SETTINGS.copy()
+    bad_settings = TEST_APERTURE_SETTINGS.copy()
     bad_settings[bad_one] = -1
     with pytest.raises(ValidationError, match=bad_one):
         PhotometryApertures(**bad_settings)
@@ -499,11 +497,11 @@ def test_create_invalid_values(bad_one):
 
 def test_observatory_earth_location():
     # Check that the earth location is correctly set
-    obs = Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+    obs = Observatory(**TEST_OBSERVATORY_SETTINGS)
     earth_loc = EarthLocation(
-        lat=DEFAULT_OBSERVATORY_SETTINGS["latitude"],
-        lon=DEFAULT_OBSERVATORY_SETTINGS["longitude"],
-        height=DEFAULT_OBSERVATORY_SETTINGS["elevation"],
+        lat=TEST_OBSERVATORY_SETTINGS["latitude"],
+        lon=TEST_OBSERVATORY_SETTINGS["longitude"],
+        height=TEST_OBSERVATORY_SETTINGS["elevation"],
     )
     assert obs.earth_location == earth_loc
 
@@ -512,16 +510,16 @@ def test_observatory_lat_long_as_float():
     # To make it easier to enter latitude and longitude in a form (e.g. a GUI),
     # we allow them to be entered as floats with an assumed unit of degrees,
     # not just Quantity objects.
-    settings = dict(DEFAULT_OBSERVATORY_SETTINGS)
+    settings = dict(TEST_OBSERVATORY_SETTINGS)
     settings["latitude"] = settings["latitude"].value
     settings["longitude"] = settings["longitude"].value
     obs = Observatory(**settings)
-    assert obs == Observatory(**DEFAULT_OBSERVATORY_SETTINGS)
+    assert obs == Observatory(**TEST_OBSERVATORY_SETTINGS)
 
 
 def test_source_locations_negative_shift_tolerance():
     # Check that a negative shift tolerance raises an error
-    settings = dict(DEFAULT_SOURCE_LOCATION_SETTINGS)
+    settings = dict(TEST_SOURCE_LOCATION_SETTINGS)
     settings["shift_tolerance"] = -1
     with pytest.raises(
         ValidationError, match="Input should be greater than or equal to 0"
@@ -533,18 +531,17 @@ class TestPassbandMapDictMethods:
     """Test all of the dict methods we implement for the PassbandMap class."""
 
     def create_passband_map(self):
-        return PassbandMap(**DEFAULT_PASSBAND_MAP)
+        return PassbandMap(**TEST_PASSBAND_MAP)
 
     def default_pb_map_keys(self):
         return [
-            v.your_filter_name
-            for v in DEFAULT_PASSBAND_MAP["your_filter_names_to_aavso"]
+            v.your_filter_name for v in TEST_PASSBAND_MAP["your_filter_names_to_aavso"]
         ]
 
     def default_pb_map_values(self):
         return [
             v.aavso_filter_name.value
-            for v in DEFAULT_PASSBAND_MAP["your_filter_names_to_aavso"]
+            for v in TEST_PASSBAND_MAP["your_filter_names_to_aavso"]
         ]
 
     def test_keys(self):
@@ -592,7 +589,7 @@ def test_passband_map_init_with_none():
 
 
 def test_passband_map_init_with_passband_map():
-    pb_map = PassbandMap(**DEFAULT_PASSBAND_MAP)
+    pb_map = PassbandMap(**TEST_PASSBAND_MAP)
     pb_map2 = PassbandMap(name="Example map", your_filter_names_to_aavso=pb_map)
     assert pb_map == pb_map2
 
@@ -605,7 +602,7 @@ def test_passband_map_entry_empty_name_raises_error():
 
 def test_create_invalid_exoplanet():
     # Set some bad values and make sure they raise validation errors
-    values = DEFAULT_EXOPLANET_SETTINGS.copy()
+    values = TEST_EXOPLANET_SETTINGS.copy()
     # Make pediod and duration have invalid units for a time
     values["period"] = values["period"].value * u.m
     values["duration"] = values["duration"].value * u.m

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -49,9 +49,9 @@ TEST_EXOPLANET_SETTINGS = dict(
 
 TEST_OBSERVATORY_SETTINGS = dict(
     name="test observatory",
-    longitude=43 * u.deg,
-    latitude=45 * u.deg,
-    elevation=311 * u.m,
+    longitude="43.0 deg",
+    latitude="45.0 deg",
+    elevation="311.0 m",
     AAVSO_code="test",
     TESS_telescope_code="tess test",
 )
@@ -514,8 +514,8 @@ def test_observatory_lat_long_as_float():
     # we allow them to be entered as floats with an assumed unit of degrees,
     # not just Quantity objects.
     settings = dict(TEST_OBSERVATORY_SETTINGS)
-    settings["latitude"] = settings["latitude"].value
-    settings["longitude"] = settings["longitude"].value
+    settings["latitude"] = u.Quantity(settings["latitude"]).value
+    settings["longitude"] = u.Quantity(settings["longitude"]).value
     obs = Observatory(**settings)
     assert obs == Observatory(**TEST_OBSERVATORY_SETTINGS)
 

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -69,15 +69,15 @@ TEST_PHOTOMETRY_OPTIONS = dict(
 TEST_PASSBAND_MAP = dict(
     name="Example map",
     your_filter_names_to_aavso=[
-        PassbandMapEntry(
+        dict(
             your_filter_name="V",
             aavso_filter_name="V",
         ),
-        PassbandMapEntry(
+        dict(
             your_filter_name="B",
             aavso_filter_name="B",
         ),
-        PassbandMapEntry(
+        dict(
             your_filter_name="rp",
             aavso_filter_name="SR",
         ),
@@ -130,7 +130,11 @@ class TestModelAgnosticActions:
         # Make sure we can create the model and that the settings are correct.
         mod = model(**settings)
         for k, v in settings.items():
-            assert getattr(mod, k) == v
+            if k == "your_filter_names_to_aavso":
+                # This is the only nested model, so we need to check it separately
+                assert getattr(mod, k) == [PassbandMapEntry(**x) for x in v]
+            else:
+                assert getattr(mod, k) == v
 
     def test_model_copy(self, model, settings):
         # Make sure we can create a copy of the model
@@ -182,7 +186,11 @@ class TestModelAgnosticActions:
         ui.value = values_dict_as_strings
         mod = model(**ui.value)
         for k, v in settings.items():
-            assert getattr(mod, k) == v
+            if k == "your_filter_names_to_aavso":
+                # This is the only nested model, so we need to check it separately
+                assert getattr(mod, k) == [PassbandMapEntry(**x) for x in v]
+            else:
+                assert getattr(mod, k) == v
 
         # 3) The UI widgets contains the titles generated from pydantic.
         # Pydantic generically is supposed to generate titles from the field names,
@@ -538,12 +546,13 @@ class TestPassbandMapDictMethods:
 
     def default_pb_map_keys(self):
         return [
-            v.your_filter_name for v in TEST_PASSBAND_MAP["your_filter_names_to_aavso"]
+            v["your_filter_name"]
+            for v in TEST_PASSBAND_MAP["your_filter_names_to_aavso"]
         ]
 
     def default_pb_map_values(self):
         return [
-            v.aavso_filter_name.value
+            v["aavso_filter_name"]
             for v in TEST_PASSBAND_MAP["your_filter_names_to_aavso"]
         ]
 

--- a/stellarphot/settings/tests/test_photometry_runner.py
+++ b/stellarphot/settings/tests/test_photometry_runner.py
@@ -11,7 +11,7 @@ from stellarphot.settings import (
     settings_files,
 )
 from stellarphot.settings.custom_widgets import PhotometryRunner
-from stellarphot.settings.tests.test_models import DEFAULT_PHOTOMETRY_SETTINGS
+from stellarphot.settings.tests.test_models import TEST_PHOTOMETRY_SETTINGS
 
 
 # See test_settings_file.TestSavedSettings for a detailed description of what the
@@ -50,7 +50,7 @@ class TestPhotometryRunner:
         # or the results of the photometry run, except to ensure that the expected
         # files are created.
         # Make a settings
-        phot_settings = PhotometrySettings.model_validate(DEFAULT_PHOTOMETRY_SETTINGS)
+        phot_settings = PhotometrySettings.model_validate(TEST_PHOTOMETRY_SETTINGS)
 
         # Save a copy to the working directory
         wd_settings = PhotometryWorkingDirSettings()

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -15,7 +15,7 @@ from stellarphot.settings import (
     SavedSettings,
     settings_files,  # This import is needed for mocking -- see TestSavedSettings
 )
-from stellarphot.settings.tests.test_models import DEFAULT_PHOTOMETRY_SETTINGS
+from stellarphot.settings.tests.test_models import TEST_PHOTOMETRY_SETTINGS
 
 CAMERA = """
 {
@@ -399,7 +399,7 @@ class TestPhotometryWorkingDirSettings:
     def test_save_complete_settings(self):
         # Test that saving complete settings works.
         settings_file = PhotometryWorkingDirSettings()
-        settings = PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         settings_file.save(settings)
         assert settings_file.settings_file.exists()
         assert not settings_file.partial_settings_file.exists()
@@ -408,7 +408,7 @@ class TestPhotometryWorkingDirSettings:
     def test_save_partial_settings_that_are_full_settings(self):
         # Test that saving partial settings that are actually full settings works.
         settings_file = PhotometryWorkingDirSettings()
-        settings = PartialPhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         settings_file.save(settings)
         assert settings_file.settings_file.exists()
         assert not settings_file.partial_settings_file.exists()
@@ -424,7 +424,7 @@ class TestPhotometryWorkingDirSettings:
         assert not settings_file.settings_file.exists()
         assert settings_file.partial_settings == partial_settings
 
-        full_settings = PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         settings_file.save(full_settings)
         assert settings_file.settings_file.exists()
         assert not settings_file.partial_settings_file.exists()
@@ -436,7 +436,7 @@ class TestPhotometryWorkingDirSettings:
         # Test that saving full settings and then partial settings generates
         # the expected error.
         settings_file = PhotometryWorkingDirSettings()
-        full_settings = PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         settings_file.save(full_settings)
         assert settings_file.settings_file.exists()
         assert not settings_file.partial_settings_file.exists()
@@ -476,7 +476,7 @@ class TestPhotometryWorkingDirSettings:
         with settings_file.partial_settings_file.open("w") as f:
             f.write(partial_settings.model_dump_json())
 
-        full_settings = PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         with settings_file.settings_file.open("w") as f:
             f.write(full_settings.model_dump_json())
 
@@ -491,13 +491,13 @@ class TestPhotometryWorkingDirSettings:
         # a valid full settings file that do not conflict with each other.
         settings_file = PhotometryWorkingDirSettings()
 
-        partial_settings = PartialPhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        partial_settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         # write these settings directly to the directory to avoid any conflict
         # resolution in the save method.
         with settings_file.partial_settings_file.open("w") as f:
             f.write(partial_settings.model_dump_json())
 
-        full_settings = PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         with settings_file.settings_file.open("w") as f:
             f.write(full_settings.model_dump_json())
 
@@ -548,29 +548,29 @@ class TestPhotometryWorkingDirSettings:
 
         # Save a Camera first
         partial_settings_cam = PartialPhotometrySettings(
-            camera=DEFAULT_PHOTOMETRY_SETTINGS["camera"]
+            camera=TEST_PHOTOMETRY_SETTINGS["camera"]
         )
         settings_file.save(partial_settings_cam, update=True)
         from_file = settings_file.load()
         # Make sure the camera is there
-        assert from_file.camera == DEFAULT_PHOTOMETRY_SETTINGS["camera"]
+        assert from_file.camera == TEST_PHOTOMETRY_SETTINGS["camera"]
 
         # Save a different item, like an observatory
         partial_settings_obs = PartialPhotometrySettings(
-            observatory=DEFAULT_PHOTOMETRY_SETTINGS["observatory"]
+            observatory=TEST_PHOTOMETRY_SETTINGS["observatory"]
         )
         settings_file.save(partial_settings_obs, update=True)
         from_file2 = settings_file.load()
         # Make sure the camera is still there
-        assert from_file2.camera == DEFAULT_PHOTOMETRY_SETTINGS["camera"]
+        assert from_file2.camera == TEST_PHOTOMETRY_SETTINGS["camera"]
         # Make sure the observatory is there
-        assert from_file2.observatory == DEFAULT_PHOTOMETRY_SETTINGS["observatory"]
+        assert from_file2.observatory == TEST_PHOTOMETRY_SETTINGS["observatory"]
 
     def test_save_update_completing_partial_makes_full(self):
         # Test that saving a partial settings file and then updating it to a
         # full settings file works.
         settings_file = PhotometryWorkingDirSettings()
-        almost_complete_settings = DEFAULT_PHOTOMETRY_SETTINGS.copy()
+        almost_complete_settings = TEST_PHOTOMETRY_SETTINGS.copy()
         the_observatory = almost_complete_settings.pop("observatory")
 
         # Make and save an object that has all settings except observatory
@@ -585,6 +585,6 @@ class TestPhotometryWorkingDirSettings:
         settings_file.save(the_last_setting, update=True)
         from_file2 = settings_file.load()
         # Make sure we have the full settings
-        assert from_file2 == PhotometrySettings(**DEFAULT_PHOTOMETRY_SETTINGS)
+        assert from_file2 == PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         # Make sure we have no partial settings
         assert settings_file.partial_settings is None

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -553,18 +553,20 @@ class TestPhotometryWorkingDirSettings:
         settings_file.save(partial_settings_cam, update=True)
         from_file = settings_file.load()
         # Make sure the camera is there
-        assert from_file.camera == TEST_PHOTOMETRY_SETTINGS["camera"]
+        assert from_file.camera == Camera(**TEST_PHOTOMETRY_SETTINGS["camera"])
 
         # Save a different item, like an observatory
         partial_settings_obs = PartialPhotometrySettings(
-            observatory=TEST_PHOTOMETRY_SETTINGS["observatory"]
+            observatory=Observatory(**TEST_PHOTOMETRY_SETTINGS["observatory"])
         )
         settings_file.save(partial_settings_obs, update=True)
         from_file2 = settings_file.load()
         # Make sure the camera is still there
-        assert from_file2.camera == TEST_PHOTOMETRY_SETTINGS["camera"]
+        assert from_file2.camera == Camera(**TEST_PHOTOMETRY_SETTINGS["camera"])
         # Make sure the observatory is there
-        assert from_file2.observatory == TEST_PHOTOMETRY_SETTINGS["observatory"]
+        assert from_file2.observatory == Observatory(
+            **TEST_PHOTOMETRY_SETTINGS["observatory"]
+        )
 
     def test_save_update_completing_partial_makes_full(self):
         # Test that saving a partial settings file and then updating it to a


### PR DESCRIPTION
This PR removes from `settings/tests/test_models.py` any code outside of a function or class that did any meaningful execution and fixes #412. That means that we no longer call any stellarphot code outside of a class or function and that we no longer create astropy objects (e.g. a `Time` or `Quantity`) outside of a function or class.

A few different modules used the testing values from `test_models` so a few files were affected. 

While I was doing this I also decided to make the names uniform. Some had started `TEST_...` and others `DEFAULT_...` and now they all start out `TEST_...`

@JuanCab - a fairly quick review on this one would be nice, because a few more coming in soon to remove other executable code in tests depend on this rearrangement, I think.