### PR TITLE
Remove executable code from `test_profile`

### DIFF
--- a/stellarphot/conftest.py
+++ b/stellarphot/conftest.py
@@ -2,7 +2,11 @@
 # test infrastructure.
 import os
 
+import pytest
+from astropy.table import Table
 from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+# astropy-specific-stuff
 
 
 def pytest_configure(config):
@@ -25,3 +29,21 @@ def pytest_unconfigure():
 
     # Undo IERS auto download setting for testing
     iers_conf.reset("auto_download")
+
+
+# stellarphot fixtures
+
+
+@pytest.fixture
+def profile_stars():
+    # Make a few round stars
+    return Table(
+        dict(
+            amplitude=[1000, 200, 300],
+            x_mean=[30, 100, 150],
+            y_mean=[40, 110, 160],
+            x_stddev=[4, 4, 4],
+            y_stddev=[4, 4, 4],
+            theta=[0, 0, 0],
+        )
+    )

--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -17,7 +17,7 @@ from stellarphot.gui_tools.seeing_profile_functions import (
     AP_SETTING_SAVED,
 )
 from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
-from stellarphot.photometry.tests.test_profiles import RANDOM_SEED, SHAPE, profile_stars
+from stellarphot.photometry.tests.test_profiles import RANDOM_SEED, SHAPE
 from stellarphot.settings import (
     Camera,
     Observatory,
@@ -78,7 +78,7 @@ def fake_settings_dir(mocker, tmp_path):
     )
 
 
-def test_seeing_profile_properties(tmp_path):
+def test_seeing_profile_properties(tmp_path, profile_stars):
     # Here we make a seeing profile then load an image.
     profile_widget = spf.SeeingProfileWidget(
         camera=Camera(**TEST_CAMERA_VALUES), _testing_path=tmp_path

--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -17,7 +17,7 @@ from stellarphot.gui_tools.seeing_profile_functions import (
     AP_SETTING_SAVED,
 )
 from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
-from stellarphot.photometry.tests.test_profiles import RANDOM_SEED, SHAPE, STARS
+from stellarphot.photometry.tests.test_profiles import RANDOM_SEED, SHAPE, profile_stars
 from stellarphot.settings import (
     Camera,
     Observatory,
@@ -85,7 +85,7 @@ def test_seeing_profile_properties(tmp_path):
     )
 
     # Make a fits file
-    image = make_gaussian_sources_image(SHAPE, STARS) + make_noise_image(
+    image = make_gaussian_sources_image(SHAPE, profile_stars) + make_noise_image(
         SHAPE, mean=10, stddev=100, seed=RANDOM_SEED
     )
 
@@ -112,7 +112,7 @@ def test_seeing_profile_properties(tmp_path):
 
     # Make a mock event object
     Event = namedtuple("Event", ["data_x", "data_y"])
-    star_loc_x, star_loc_y = STARS["x_mean"][0], STARS["y_mean"][0]
+    star_loc_x, star_loc_y = profile_stars["x_mean"][0], profile_stars["y_mean"][0]
     # Sending a mock event will generate plots that we don't want to see
     # so set the matplotlib backend to a non-interactive one
     matplotlib.use("agg")

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -14,7 +14,7 @@ from stellarphot.settings import Camera
 from stellarphot.settings.tests.test_models import TEST_CAMERA_VALUES
 
 # Make a few round stars
-STARS = Table(
+profile_stars = Table(
     dict(
         amplitude=[1000, 200, 300],
         x_mean=[30, 100, 150],
@@ -29,14 +29,14 @@ RANDOM_SEED = 1230971
 
 
 def test_find_center_no_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     # Good initial guess, no noise, should converge in one try
     cen1 = find_center(image, (31, 41), max_iters=1)
     np.testing.assert_allclose(cen1, [30, 40])
 
 
 def test_find_center_noise_bad_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     noise = make_noise_image(
         SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
     )
@@ -47,7 +47,7 @@ def test_find_center_noise_bad_guess():
 
 
 def test_find_center_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     noise = make_noise_image(
         SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
     )
@@ -59,7 +59,7 @@ def test_find_center_noise_good_guess():
 
 def test_find_center_no_noise_star_at_edge():
     # Trying to put the star at the edge of the initial guess
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     cen = find_center(image, [45, 65], max_iters=20)
 
     np.testing.assert_allclose(cen, [30, 40], atol=0.02)
@@ -67,7 +67,7 @@ def test_find_center_no_noise_star_at_edge():
 
 def test_find_center_no_star():
     # No star anywhere near the original guess
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     # Offset the mean from zero to avoid nan center
     noise = make_noise_image(
         SHAPE, distribution="gaussian", mean=1000, stddev=5, seed=RANDOM_SEED
@@ -114,8 +114,8 @@ def test_find_center_dim_star():
 def test_radial_profile():
     # Test that both curve of growth and radial profile are correct
 
-    image = make_gaussian_sources_image(SHAPE, STARS)
-    for row in STARS:
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
+    for row in profile_stars:
         cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
 
         # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
@@ -143,7 +143,7 @@ def test_radial_profile():
 
 def test_radial_profile_exposure_is_nan():
     # Check that using an exposure value of NaN returns NaN for the SNR and noise
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
 
     cen = find_center(image, (50, 50), max_iters=10)
 
@@ -158,12 +158,12 @@ def test_radial_profile_exposure_is_nan():
 
 def test_radial_profile_with_background():
     # Regression test for #328 -- image with a background level
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     noise_stdev = 10
     image = image + make_noise_image(
         image.shape, distribution="gaussian", mean=100, stddev=noise_stdev, seed=43917
     )
-    for row in STARS:
+    for row in profile_stars:
         cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
 
         # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
@@ -215,7 +215,7 @@ def test_radial_profile_with_background():
 def test_radial_profile_bigger_profile_than_cutout():
     # Test that the cutout, used for finding the star, can be smaller than
     # the profile radius.
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
 
     # Just look at one star in this test, the last one, which is far from the edges.
     # Prior to a change in CenterAndProfile, this would have raised an error because the
@@ -224,7 +224,7 @@ def test_radial_profile_bigger_profile_than_cutout():
     # outermost annuli.
     profile = CenterAndProfile(
         image,
-        (STARS["x_mean"][-1], STARS["y_mean"][-1]),
+        (profile_stars["x_mean"][-1], profile_stars["y_mean"][-1]),
         centering_cutout_size=20,
         profile_radius=50,
     )
@@ -234,10 +234,10 @@ def test_radial_profile_bigger_profile_than_cutout():
 
 def test_radial_profile_no_profile_size():
     # Test that when we do not provide a profile size it is half the cutout size
-    image = make_gaussian_sources_image(SHAPE, STARS)
+    image = make_gaussian_sources_image(SHAPE, profile_stars)
     profile = CenterAndProfile(
         image,
-        (STARS["x_mean"][-1], STARS["y_mean"][-1]),
+        (profile_stars["x_mean"][-1], profile_stars["y_mean"][-1]),
         centering_cutout_size=50,
     )
 

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -4,7 +4,6 @@ from astropy.coordinates import SkyCoord
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Gaussian1D
 from astropy.nddata import CCDData
-from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from photutils.datasets import make_noise_image
 
@@ -13,233 +12,248 @@ from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
 from stellarphot.settings import Camera
 from stellarphot.settings.tests.test_models import TEST_CAMERA_VALUES
 
-# Make a few round stars
-profile_stars = Table(
-    dict(
-        amplitude=[1000, 200, 300],
-        x_mean=[30, 100, 150],
-        y_mean=[40, 110, 160],
-        x_stddev=[4, 4, 4],
-        y_stddev=[4, 4, 4],
-        theta=[0, 0, 0],
-    )
-)
 SHAPE = (300, 300)
 RANDOM_SEED = 1230971
 
 
-def test_find_center_no_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    # Good initial guess, no noise, should converge in one try
-    cen1 = find_center(image, (31, 41), max_iters=1)
-    np.testing.assert_allclose(cen1, [30, 40])
+class TestCenter:
+    # The scope="function" below is not required (it is the default option) but
+    # being explicit seems good, and we want the scope to be function so that each test
+    # gets its own copy of the table.
+    # Setting autouse=True means that this fixture will be run for every test in this
+    # class. To get the data from the fixture we need to store it somewhere, so we store
+    # it in self.profile_stars.
+    @pytest.fixture(scope="function", autouse=True)
+    def make_star_table(self, profile_stars):
+        self.profile_stars = profile_stars
 
+    def test_find_center_no_noise_good_guess(self):
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        # Good initial guess, no noise, should converge in one try
+        cen1 = find_center(image, (31, 41), max_iters=1)
+        np.testing.assert_allclose(cen1, [30, 40])
+        self.profile_stars = self.profile_stars[:-1]
 
-def test_find_center_noise_bad_guess():
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
-    )
-    cen2 = find_center(image + noise, [40, 50], max_iters=1)
-    # Bad initial guess, noise, should take more than one try...
-    with pytest.raises(AssertionError):
-        np.testing.assert_allclose(cen2, [30, 40])
+    def test_find_center_noise_bad_guess(self):
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        noise = make_noise_image(
+            SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
+        )
+        cen2 = find_center(image + noise, [40, 50], max_iters=1)
+        # Bad initial guess, noise, should take more than one try...
+        with pytest.raises(AssertionError):
+            np.testing.assert_allclose(cen2, [30, 40])
 
+    def test_find_center_noise_good_guess(self):
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        noise = make_noise_image(
+            SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
+        )
+        # Trying again with several iterations should work
+        cen3 = find_center(image + noise, [31, 41], max_iters=20)
+        # Tolerance chosen based on some trial and error
+        np.testing.assert_allclose(cen3, [30, 40], atol=0.02)
 
-def test_find_center_noise_good_guess():
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=0, stddev=5, seed=RANDOM_SEED
-    )
-    # Trying again with several iterations should work
-    cen3 = find_center(image + noise, [31, 41], max_iters=20)
-    # Tolerance chosen based on some trial and error
-    np.testing.assert_allclose(cen3, [30, 40], atol=0.02)
+    def test_find_center_no_noise_star_at_edge(self):
+        # Trying to put the star at the edge of the initial guess
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        cen = find_center(image, [45, 65], max_iters=20)
 
+        np.testing.assert_allclose(cen, [30, 40], atol=0.02)
 
-def test_find_center_no_noise_star_at_edge():
-    # Trying to put the star at the edge of the initial guess
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    cen = find_center(image, [45, 65], max_iters=20)
-
-    np.testing.assert_allclose(cen, [30, 40], atol=0.02)
-
-
-def test_find_center_no_star():
-    # No star anywhere near the original guess
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    # Offset the mean from zero to avoid nan center
-    noise = make_noise_image(
-        SHAPE, distribution="gaussian", mean=1000, stddev=5, seed=RANDOM_SEED
-    )
-
-    with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
-        find_center(image + noise, [50, 200], max_iters=10)
-
-
-def test_find_center_dim_star():
-    # Regression test for #352, in which a dim star is improperly centered.
-    # The cutout loaded below is from an image of the field of WASP-10, and the star
-    # in question has Gaia DR3 ID that is stored in the header. The Gaia position
-    # is also stored in the header, and is what is taken to be the "correct" position
-    # of the star.
-    #
-    # There is only one star in this cutout.
-    #
-    # For the record, the Gaia DR3 ID is 1909763087978475392.
-
-    name = get_pkg_data_filename(data_name="data/center_cutout_1.fits")
-    ccd = CCDData.read(name)
-
-    true_coordinate = SkyCoord(ccd.header["gaia_coord"])
-    true_pixel_center = ccd.wcs.world_to_pixel(true_coordinate)
-
-    # At least with a faint star and large cutout, the
-    # centroid as determined by COM and the centroid determined by the Gaussian fit
-    # are about 20 pixels apart (pre-bug-fix).
-    with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
-        center = find_center(
-            ccd.data,
-            (40, 42),
-            cutout_size=80,
-            max_iters=10,
+    def test_find_center_no_star(self):
+        # No star anywhere near the original guess
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        # Offset the mean from zero to avoid nan center
+        noise = make_noise_image(
+            SHAPE, distribution="gaussian", mean=1000, stddev=5, seed=RANDOM_SEED
         )
 
-    # Now try with a much smaller cutout size
-    center = find_center(ccd.data, (40, 42), cutout_size=20, max_iters=10)
-    # Check that we got a good center...
-    assert np.linalg.norm(center - true_pixel_center) < 2
+        with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
+            find_center(image + noise, [50, 200], max_iters=10)
+
+    def test_find_center_dim_star(self):
+        # Regression test for #352, in which a dim star is improperly centered.
+        # The cutout loaded below is from an image of the field of WASP-10, and the star
+        # in question has Gaia DR3 ID that is stored in the header. The Gaia position
+        # is also stored in the header, and is what is taken to be the "correct"
+        # position of the star.
+        #
+        # There is only one star in this cutout.
+        #
+        # For the record, the Gaia DR3 ID is 1909763087978475392.
+
+        name = get_pkg_data_filename(data_name="data/center_cutout_1.fits")
+        ccd = CCDData.read(name)
+
+        true_coordinate = SkyCoord(ccd.header["gaia_coord"])
+        true_pixel_center = ccd.wcs.world_to_pixel(true_coordinate)
+
+        # At least with a faint star and large cutout, the
+        # centroid as determined by COM and the centroid determined by the Gaussian fit
+        # are about 20 pixels apart (pre-bug-fix).
+        with pytest.raises(RuntimeError, match="Centroid did not converge on a star"):
+            center = find_center(
+                ccd.data,
+                (40, 42),
+                cutout_size=80,
+                max_iters=10,
+            )
+
+        # Now try with a much smaller cutout size
+        center = find_center(ccd.data, (40, 42), cutout_size=20, max_iters=10)
+        # Check that we got a good center...
+        assert np.linalg.norm(center - true_pixel_center) < 2
 
 
-def test_radial_profile():
-    # Test that both curve of growth and radial profile are correct
+class TestRadialProfile:
+    # The scope="function" below is not required (it is the default option) but
+    # being explicit seems good, and we want the scope to be function so that each test
+    # gets its own copy of the table.
+    # Setting autouse=True means that this fixture will be run for every test in this
+    # class. To get the data from the fixture we need to store it somewhere, so we store
+    # it in self.profile_stars.
+    @pytest.fixture(scope="function", autouse=True)
+    def make_star_table(self, profile_stars):
+        self.profile_stars = profile_stars
 
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    for row in profile_stars:
-        cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
+    def test_radial_profile(self):
+        # Test that both curve of growth and radial profile are correct
 
-        # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
-        # stars fairly big -- the bare minimum would be a radius of 3 FWHM, which is a
-        # cutout size around 60.
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        for row in self.profile_stars:
+            cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
+
+            # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
+            # stars fairly big -- the bare minimum would be a radius of 3 FWHM, which is
+            # a cutout size around 60.
+            rad_prof = CenterAndProfile(
+                image, cen, centering_cutout_size=60, profile_radius=30
+            )
+
+            # Test that the curve of growth is correct
+
+            # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
+            expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
+            np.testing.assert_allclose(
+                rad_prof.curve_of_growth.profile[-1], expected_integral, atol=50
+            )
+
+            # Test that the radial profile is correct by comparing pixel values to a
+            # gaussian fit to the profile.
+            data_radii, data_counts = rad_prof.pixel_values_in_profile
+            expected_profile = rad_prof.radial_profile.gaussian_fit(data_radii)
+
+            np.testing.assert_allclose(data_counts, expected_profile, atol=20)
+
+    def test_radial_profile_exposure_is_nan(self):
+        # Check that using an exposure value of NaN returns NaN for the SNR and noise
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+
+        cen = find_center(image, (50, 50), max_iters=10)
+
         rad_prof = CenterAndProfile(
             image, cen, centering_cutout_size=60, profile_radius=30
         )
 
-        # Test that the curve of growth is correct
+        c = Camera(**TEST_CAMERA_VALUES)
+        assert np.isnan(rad_prof.snr(c, np.nan)[-1])
+        assert np.isnan(rad_prof.noise(c, np.nan)[-1])
+        assert all(np.isfinite(rad_prof.curve_of_growth.profile))
+        assert all(np.isfinite(rad_prof.radial_profile.profile))
 
-        # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
-        expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
-        np.testing.assert_allclose(
-            rad_prof.curve_of_growth.profile[-1], expected_integral, atol=50
+    def test_radial_profile_with_background(self):
+        # Regression test for #328 -- image with a background level
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        noise_stdev = 10
+        image = image + make_noise_image(
+            image.shape,
+            distribution="gaussian",
+            mean=100,
+            stddev=noise_stdev,
+            seed=43917,
+        )
+        for row in self.profile_stars:
+            cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
+
+            # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
+            # stars fairly big -- the bare minimum would be a radius of 3 FWHM, which is
+            # a cutout size around 60.
+            rad_prof = CenterAndProfile(
+                image, cen, centering_cutout_size=60, profile_radius=30
+            )
+
+            # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
+            expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
+
+            # The standard deviation in the sum of N gaussian random variables with
+            # standard deviation SD is
+            #    σ = sqrt(N × SD^2)
+            # The curve of growth includes the sum of a bunch of pixels which each have
+            # a standard deviation of 10, so the standard deviation of the sum of those
+            # pixels is given by the formula above, with N being the number of pixels
+            # in the curve.
+
+            expected_stddev = np.sqrt(
+                rad_prof.curve_of_growth.area[-1] * noise_stdev**2
+            )
+            print(
+                expected_stddev,
+                rad_prof.curve_of_growth.profile[-1] - expected_integral,
+            )
+
+            # With the seed above the difference is just under 1.5 standard deviations.
+            np.testing.assert_allclose(
+                rad_prof.curve_of_growth.profile[-1],
+                expected_integral,
+                atol=1.5 * expected_stddev,
+            )
+
+            # Test that the radial profile is correct by comparing pixel values to a
+            # gaussian fit to the profile.
+            data_radii, data_counts = rad_prof.pixel_values_in_profile
+            expected_profile = rad_prof.radial_profile.gaussian_fit(data_radii)
+
+            # The test here is that the difference between the actual profile and the
+            # expected is itself a Gaussian distribution with standard deviation very
+            # roughly equal to the standard deviation of the noise we put in.
+            differences = data_counts - expected_profile
+            counts, bin_edges = np.histogram(differences)
+            bin_centers = (bin_edges[1:] + bin_edges[:-1]) / 2
+            g1d_init = Gaussian1D()
+            fitter = LevMarLSQFitter()
+            g1d = fitter(g1d_init, bin_centers, counts)
+
+            assert np.abs(g1d.stddev.value - noise_stdev) < 1.5
+            assert np.abs(g1d.mean.value) < 1
+
+    def test_radial_profile_bigger_profile_than_cutout(self):
+        # Test that the cutout, used for finding the star, can be smaller than
+        # the profile radius.
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+
+        # Just look at one star in this test, the last one, which is far from the edges.
+        # Prior to a change in CenterAndProfile, this would have raised an error because
+        # the same cutout size was used for the profile and the centering. The result if
+        # the profile size was larger was that the profile eventually had only NaNs in
+        # the outermost annuli.
+        profile = CenterAndProfile(
+            image,
+            (self.profile_stars["x_mean"][-1], self.profile_stars["y_mean"][-1]),
+            centering_cutout_size=20,
+            profile_radius=50,
         )
 
-        # Test that the radial profile is correct by comparing pixel values to a
-        # gaussian fit to the profile.
-        data_radii, data_counts = rad_prof.pixel_values_in_profile
-        expected_profile = rad_prof.radial_profile.gaussian_fit(data_radii)
+        assert profile.profile_cutout.shape == (100, 100)
 
-        np.testing.assert_allclose(data_counts, expected_profile, atol=20)
-
-
-def test_radial_profile_exposure_is_nan():
-    # Check that using an exposure value of NaN returns NaN for the SNR and noise
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-
-    cen = find_center(image, (50, 50), max_iters=10)
-
-    rad_prof = CenterAndProfile(image, cen, centering_cutout_size=60, profile_radius=30)
-
-    c = Camera(**TEST_CAMERA_VALUES)
-    assert np.isnan(rad_prof.snr(c, np.nan)[-1])
-    assert np.isnan(rad_prof.noise(c, np.nan)[-1])
-    assert all(np.isfinite(rad_prof.curve_of_growth.profile))
-    assert all(np.isfinite(rad_prof.radial_profile.profile))
-
-
-def test_radial_profile_with_background():
-    # Regression test for #328 -- image with a background level
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    noise_stdev = 10
-    image = image + make_noise_image(
-        image.shape, distribution="gaussian", mean=100, stddev=noise_stdev, seed=43917
-    )
-    for row in profile_stars:
-        cen = find_center(image, (row["x_mean"], row["y_mean"]), max_iters=10)
-
-        # The "stars" have FWHM around 9.5, so make the cutouts used for finding the
-        # stars fairly big -- the bare minimum would be a radius of 3 FWHM, which is a
-        # cutout size around 60.
-        rad_prof = CenterAndProfile(
-            image, cen, centering_cutout_size=60, profile_radius=30
+    def test_radial_profile_no_profile_size(self):
+        # Test that when we do not provide a profile size it is half the cutout size
+        image = make_gaussian_sources_image(SHAPE, self.profile_stars)
+        profile = CenterAndProfile(
+            image,
+            (self.profile_stars["x_mean"][-1], self.profile_stars["y_mean"][-1]),
+            centering_cutout_size=50,
         )
 
-        # Numerical value below is integral of input 2D gaussian, 2pi A sigma^2
-        expected_integral = 2 * np.pi * row["amplitude"] * row["x_stddev"] ** 2
-
-        # The standard deviation in the sum of N gaussian random variables with
-        # standard deviation SD is
-        #    σ = sqrt(N × SD^2)
-        # The curve of growth includes the sum of a bunch of pixels which each have a
-        # standard deviation of 10, so the standard deviation of the sum of those pixels
-        # is given by the formula above, with N being the number of pixels in the curve.
-
-        expected_stddev = np.sqrt(rad_prof.curve_of_growth.area[-1] * noise_stdev**2)
-        print(expected_stddev, rad_prof.curve_of_growth.profile[-1] - expected_integral)
-
-        # With the seed above the difference is just under 1.5 standard deviations.
-        np.testing.assert_allclose(
-            rad_prof.curve_of_growth.profile[-1],
-            expected_integral,
-            atol=1.5 * expected_stddev,
-        )
-
-        # Test that the radial profile is correct by comparing pixel values to a
-        # gaussian fit to the profile.
-        data_radii, data_counts = rad_prof.pixel_values_in_profile
-        expected_profile = rad_prof.radial_profile.gaussian_fit(data_radii)
-
-        # The test here is that the difference between the actual profile and the
-        # expected is itself a Gaussian distribution with standard deviation very
-        # roughly equal to the standard deviation of the noise we put in.
-        differences = data_counts - expected_profile
-        counts, bin_edges = np.histogram(differences)
-        bin_centers = (bin_edges[1:] + bin_edges[:-1]) / 2
-        g1d_init = Gaussian1D()
-        fitter = LevMarLSQFitter()
-        g1d = fitter(g1d_init, bin_centers, counts)
-
-        assert np.abs(g1d.stddev.value - noise_stdev) < 1.5
-        assert np.abs(g1d.mean.value) < 1
-
-
-def test_radial_profile_bigger_profile_than_cutout():
-    # Test that the cutout, used for finding the star, can be smaller than
-    # the profile radius.
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-
-    # Just look at one star in this test, the last one, which is far from the edges.
-    # Prior to a change in CenterAndProfile, this would have raised an error because the
-    # same cutout size was used for the profile and the centering. The result if the
-    # profile size was larger was that the profile eventually had only NaNs in the
-    # outermost annuli.
-    profile = CenterAndProfile(
-        image,
-        (profile_stars["x_mean"][-1], profile_stars["y_mean"][-1]),
-        centering_cutout_size=20,
-        profile_radius=50,
-    )
-
-    assert profile.profile_cutout.shape == (100, 100)
-
-
-def test_radial_profile_no_profile_size():
-    # Test that when we do not provide a profile size it is half the cutout size
-    image = make_gaussian_sources_image(SHAPE, profile_stars)
-    profile = CenterAndProfile(
-        image,
-        (profile_stars["x_mean"][-1], profile_stars["y_mean"][-1]),
-        centering_cutout_size=50,
-    )
-
-    # Last point should be the average of the last two bin edges, which is 24.5
-    assert profile.radial_profile.radius[-1] == 24.5
+        # Last point should be the average of the last two bin edges, which is 24.5
+        assert profile.radial_profile.radius[-1] == 24.5


### PR DESCRIPTION
This closes #414 by removing the only executable code in `test_profiles` that was outside a function. Since the bit of code was used in another test in `gui_tools`, I made the table a [pytest fixture](https://docs.pytest.org/en/stable/how-to/fixtures.html) in `conftest.py`.