### PR TITLE
Remove executable top-level code in `test_photometry`

### DIFF
--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -74,10 +74,17 @@ ZERO_CAMERA = Camera(
     max_data_value=40000 * u.adu,
 )
 
-# Fake observatory location
-FAKE_OBS = Observatory(
-    name="test observatory", latitude=0 * u.deg, longitude=0 * u.deg, elevation=0 * u.m
-)
+
+@pytest.fixture
+def fake_obs():
+    # Fake observatory location
+    return Observatory(
+        name="test observatory",
+        latitude=0 * u.deg,
+        longitude=0 * u.deg,
+        elevation=0 * u.m,
+    )
+
 
 # The fake image used for testing
 FAKE_CCD_IMAGE = FakeCCDImage(seed=SEED)
@@ -107,10 +114,10 @@ def passband_map():
 
 
 @pytest.fixture
-def photometry_settings(photometry_apertures, passband_map):
+def photometry_settings(fake_obs, photometry_apertures, passband_map):
     return PhotometrySettings(
         camera=FAKE_CAMERA,
-        observatory=FAKE_OBS,
+        observatory=fake_obs,
         photometry_apertures=photometry_apertures,
         source_location_settings=DEFAULT_SOURCE_LOCATIONS,
         photometry_optional_settings=PHOTOMETRY_OPTIONS,
@@ -178,7 +185,7 @@ class TestAperturePhotometry:
 
         # Check that the object was created correctly
         assert ap_phot.settings.camera is FAKE_CAMERA
-        assert ap_phot.settings.observatory is FAKE_OBS
+        assert ap_phot.settings.observatory is photometry_settings.observatory
 
     # The True case below is a regression test for #157
     @pytest.mark.parametrize("int_data", [True, False])

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -39,14 +39,13 @@ GAINS = [1.0, 1.5, 2.0]
 SEED = 5432985
 
 
-# The default coordinate system and shift tolerance to use for the tests
-COORDS2USE = "pixel"
-SHIFT_TOLERANCE = 6
-DEFAULT_SOURCE_LOCATIONS = SourceLocationSettings(
-    source_list_file="",
-    shift_tolerance=SHIFT_TOLERANCE,
-    use_coordinates=COORDS2USE,
-)
+@pytest.fixture
+def source_locations():
+    return SourceLocationSettings(
+        source_list_file="",
+        shift_tolerance=6,
+        use_coordinates="pixel",
+    )
 
 
 @pytest.fixture
@@ -128,6 +127,7 @@ def photometry_settings(
     fake_camera,
     fake_obs,
     photometry_apertures,
+    source_locations,
     photometry_optional_settings,
     passband_map,
 ):
@@ -135,7 +135,7 @@ def photometry_settings(
         camera=fake_camera,
         observatory=fake_obs,
         photometry_apertures=photometry_apertures,
-        source_location_settings=DEFAULT_SOURCE_LOCATIONS,
+        source_location_settings=source_locations,
         photometry_optional_settings=photometry_optional_settings,
         passband_map=passband_map,
         logging_settings=LoggingSettings(),
@@ -240,7 +240,7 @@ class TestAperturePhotometry:
         source_list_file = tmp_path / "source_list.ecsv"
         found_sources.write(source_list_file, format="ascii.ecsv", overwrite=True)
 
-        source_locations = DEFAULT_SOURCE_LOCATIONS.model_copy()
+        source_locations = photometry_settings.source_location_settings.model_copy()
         source_locations.source_list_file = str(source_list_file)
 
         image_file = tmp_path / "fake_image.fits"
@@ -690,7 +690,7 @@ class TestAperturePhotometry:
         phot_options.include_dig_noise = True
 
         # Define the source locations settings
-        source_locations = DEFAULT_SOURCE_LOCATIONS.model_copy()
+        source_locations = photometry_settings.source_location_settings.model_copy()
         source_locations.source_list_file = str(source_list_file)
 
         # Define the logging settings
@@ -1049,7 +1049,7 @@ def test_aperture_photometry_no_outlier_rejection(
     source_list_file = tmp_path / "source_list.ecsv"
     found_sources.write(source_list_file, format="ascii.ecsv", overwrite=True)
 
-    source_locations = DEFAULT_SOURCE_LOCATIONS.model_copy()
+    source_locations = photometry_settings.source_location_settings.model_copy()
     source_locations.source_list_file = str(source_list_file)
 
     # Customize a couple options for this test

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -90,25 +90,28 @@ DEFAULT_PHOTOMETRY_APERTURES = PhotometryApertures(
     fwhm=FAKE_CCD_IMAGE.sources["x_stddev"].mean(),
 )
 
+
 # Passband map for the tests
-PASSBAND_MAP = PassbandMap(
-    name="Example Passband Map",
-    your_filter_names_to_aavso={
-        "B": "B",
-        "rp": "SR",
-    },
-)
+@pytest.fixture
+def passband_map():
+    return PassbandMap(
+        name="Example Passband Map",
+        your_filter_names_to_aavso={
+            "B": "B",
+            "rp": "SR",
+        },
+    )
 
 
 @pytest.fixture
-def photometry_settings():
+def photometry_settings(passband_map):
     return PhotometrySettings(
         camera=FAKE_CAMERA,
         observatory=FAKE_OBS,
         photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
         source_location_settings=DEFAULT_SOURCE_LOCATIONS,
         photometry_optional_settings=PHOTOMETRY_OPTIONS,
-        passband_map=PASSBAND_MAP,
+        passband_map=passband_map,
         logging_settings=LoggingSettings(),
     )
 
@@ -671,15 +674,9 @@ class TestAperturePhotometry:
             logging_settings.console_log = console_log
             full_logfile = logging_settings.logfile
 
-        photometry_settings = PhotometrySettings(
-            camera=FAKE_CAMERA,
-            observatory=FAKE_OBS,
-            photometry_apertures=DEFAULT_PHOTOMETRY_APERTURES,
-            source_location_settings=source_locations,
-            photometry_optional_settings=phot_options,
-            passband_map=PASSBAND_MAP,
-            logging_settings=logging_settings,
-        )
+        photometry_settings.source_location_settings = source_locations
+        photometry_settings.photometry_optional_settings = phot_options
+        photometry_settings.logging_settings = logging_settings
 
         # Call the AperturePhotometry class with a single image
         ap_phot = AperturePhotometry(settings=photometry_settings)


### PR DESCRIPTION
The constants in this module that are now fixtures are used only in this test file so I left the fixtures in the file.

Fixes #413 