### PR TITLE
Exclude notebook files from ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ include = '\.pyi?$|\.ipynb$'
 # )
 # '''
 
+[tool.ruff]
+# ruff 0.6.0 started automatically linting notebooks. We are not ready for that yet.
+extend-exclude = ["*.ipynb"]
+
 [tool.ruff.lint]
 select = [
     "E",    # E and W are the checks done by pycodestyle


### PR DESCRIPTION
It turns out that ruff 0.6.0, released today now [examines notebooks by default](https://astral.sh/blog/ruff-v0.6.0#jupyter-notebooks-are-now-linted-and-formatted-by-default).

We may want to do that at some point but I would really prefer that today not be that day....