### PR TITLE
 Use the modern importlib.metadata

### DIFF
--- a/stellarphot/version.py
+++ b/stellarphot/version.py
@@ -1,15 +1,8 @@
 version = "unknown.dev"
 try:
-    from importlib_metadata import PackageNotFoundError
-    from importlib_metadata import version as _version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _version
 
     version = _version("stellarphot")
-except ImportError:
-    from pkg_resources import DistributionNotFound, get_distribution
-
-    try:
-        version = get_distribution("stellarphot").version
-    except DistributionNotFound:
-        pass
 except PackageNotFoundError:
     pass


### PR DESCRIPTION
 `importlib.metadata` was introduced in python 3.8 [according to the documentation](https://docs.python.org/3/library/importlib.metadata.html). The previous [`importlib_metadata`](https://importlib-metadata.readthedocs.io/en/latest/index.html) is a
 backport of new `importlib` features to earlier python versions. `pkg_resources` has been
 [deprecated for a long time](https://setuptools.pypa.io/en/latest/pkg_resources.html) and may be gone from setuptools now.

The alternative, I suppose, is to declare `importlib_metadata` as a dependency.