### PR TITLE
Fix APASS passband names

### DIFF
--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -760,6 +760,9 @@ def test_catalog_bandpassmap():
     assert catalog_dat.catalog_name == "VSX"
     assert catalog_dat.catalog_source == "Vizier"
 
+    # Also test that we can read the bandpass map
+    assert catalog_dat.passband_map["g"] == "SG"
+
 
 def test_catalog_recursive():
     # Construct good objects

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -1015,6 +1015,11 @@ def test_find_apass():
     # so just check the RAs.
     assert set(ra.value for ra in all_apass["ra"]) == set(expected_all["RAJ2000"])
 
+    # The passbands ought to have been translated to the AAVSO standard names.
+    # This is a regression test for #439.
+    for band in ["B", "V", "SG", "SR", "SI"]:
+        assert band in all_apass["passband"]
+
 
 # Load test apertures
 test_sl_data = ascii.read(

--- a/stellarphot/utils/comparison_utils.py
+++ b/stellarphot/utils/comparison_utils.py
@@ -116,7 +116,7 @@ def crossmatch_APASS2VSX(CCD, RD, vsx):
 
 
 def mag_scale(
-    cmag, apass, v_angle, RD_angle, brighter_dmag=0.44, dimmer_dmag=0.75, passband="r"
+    cmag, apass, v_angle, RD_angle, brighter_dmag=0.44, dimmer_dmag=0.75, passband="SR"
 ):
     """
     Select comparison stars that are 1) not close the VSX stars or to other


### PR DESCRIPTION
This PR ensures that the APASS passband names are the AAVSO standard names.

Fixes #439