### PR TITLE
Update minimum required version of jupyter-app-launcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ipyautoui >=0.7.19",
     "ipyfilechooser",
     "ipywidgets",
-    "jupyter-app-launcher",
+    "jupyter-app-launcher >=0.3.0",
     "matplotlib",
     "papermill",
     "pandas",


### PR DESCRIPTION
This PR requires a recent version of `jupyter-app-launcher` that fixes a bug in which two notebooks opened from the launcher in succession connected to the same kernel instead of different kernels.