### PR TITLE
Use `to_snake` from `pydantic`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "astroquery",
     "astrowidgets",
     "bottleneck",
-    "camel-converter",
     "ccdproc",
     "ginga",
     "ipyautoui >=0.7.19",

--- a/stellarphot/settings/custom_widgets.py
+++ b/stellarphot/settings/custom_widgets.py
@@ -17,10 +17,10 @@ import ipywidgets as ipw
 import papermill as pm
 import traitlets as tr
 from astropy.utils.data import get_pkg_data_filename
-from camel_converter import to_snake
 from ipyautoui.autoobject import AutoObject
 from ipyautoui.custom.iterable import ItemBox
 from pydantic import ValidationError
+from pydantic.alias_generators import to_snake
 
 from stellarphot.io import tess_photometry_setup
 from stellarphot.io.tess import TIC_regex

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import ipywidgets as ipw
 import pytest
 from astropy.units import Quantity
-from camel_converter import to_snake
 from ipyautoui.custom.iterable import ItemBox, ItemControl
 from pydantic import ValidationError
+from pydantic.alias_generators import to_snake
 
 from stellarphot.settings import (
     Camera,


### PR DESCRIPTION
The dependency `camel-converter` was added for its `to_snake` function. It turns out that `pydantic` supplies a function that does that, so we just use the one from `pydantic` and drop the dependency on `camel-converter`.

(planning to self-merge this once tests pass)