### PR TITLE
Add an error column for catalogs, even those without error

### DIFF
--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -686,7 +686,7 @@ class CatalogData(BaseEnhancedTable):
             if input_data is not None:
                 # Check whether the colname_map has an entry for mag_error
                 # that is None. If it does, and there is no mag_error column
-                # in the input data, then add a column on NaNs to the input
+                # in the input data, then add a column of NaNs to the input
                 # data for mag_error.
 
                 if (

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -723,6 +723,7 @@ def test_catalog_colname_map():
         catalog_name="VSX",
         catalog_source="Vizier",
         colname_map=vsx_colname_map,
+        no_catalog_error=True,
     )
 
     assert catalog_dat["id"][0] == "ASASSN-V J000052.03+002216.6"
@@ -754,6 +755,7 @@ def test_catalog_bandpassmap():
         catalog_source="Vizier",
         colname_map=vsx_colname_map,
         passband_map=passband_map,
+        no_catalog_error=True,
     )
 
     assert catalog_dat["passband"][0] == "SG"
@@ -778,6 +780,7 @@ def test_catalog_recursive():
         catalog_name="VSX",
         catalog_source="Vizier",
         colname_map=vsx_colname_map,
+        no_catalog_error=True,
     )
 
     # Attempt recursive call
@@ -958,11 +961,15 @@ def test_catalog_from_vizier_search_vsx(location_method):
         clip_by_frame=False,
         colname_map=vsx_map,
         prepare_catalog=prepare_cat,
+        no_catalog_error=True,
     )
 
     assert my_cat["id"][0] == "DQ Psc"
     assert my_cat["passband"][0] == "Hp"
     assert my_cat["Type"][0] == "SRB"
+
+    # Make sure has been set to NaN
+    assert np.isnan(my_cat["mag_error"][0])
 
 
 def test_from_vizier_with_coord_and_frame_clip_fails():
@@ -1025,7 +1032,11 @@ def test_vsx_results(clip, data_file):
     # Turn this into an HDU to get the standard FITS image keywords
     ccd_im = ccd.to_hdu()
 
-    actual = vsx_vizier(ccd_im[0].header, radius=0.5 * u.degree, clip_by_frame=clip)
+    actual = vsx_vizier(
+        ccd_im[0].header,
+        radius=0.5 * u.degree,
+        clip_by_frame=clip,
+    )
     assert set(actual["OID"]) == set(expected["OID"])
 
 


### PR DESCRIPTION
Adds a mandatory magnitude error column for `CatalogData`. Since some catalogs (e.g. VSX) do not supply an error, a new option was added to `__init__` that sets the error column to all `NaNs`.

Fixes #438 

@JuanCab I'm not sure this is the best solution. I coded up a version where to indicate a catalog had no error available by adding an entry `None: "mag_error"` to `colname_map`, but think I prefer this more explicit version now.