### PR TITLE
Add method for creating lightcurve for object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,5 +194,7 @@ filterwarnings = [
     # papermill is using deprecated jupyter paths
     'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
     # papermill is also using a deprecated method of getting current time
-    'ignore:.*is deprecated and scheduled for removal.*:DeprecationWarning'
+    'ignore:.*is deprecated and scheduled for removal.*:DeprecationWarning',
+    # lightkurve is using a deprecated numpy interface
+    'ignore:.*numpy.core.einsumfunc is deprecated and has been renamed.*:DeprecationWarning'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ipyfilechooser",
     "ipywidgets",
     "jupyter-app-launcher >=0.3.0",
+    "lightkurve",
     "matplotlib",
     "papermill",
     "pandas",

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -1203,6 +1203,7 @@ def test_to_lightcurve(simple_photometry_data, target_by, target_star_id):
     assert (lc["star_id"] == target_star_id).all()
 
 
+@pytest.mark.remote_data
 def test_to_lightcurve_from_name(simple_photometry_data):
     # Make a few more rows of data, changing only date_obs, then update the BJD
     delta_t = 3 * u.minute


### PR DESCRIPTION
This fixes #462 by adding a `lightcurve_for` method to `PhotometryData`.

A couple items:

1. A better API might be to accept a single required argument, maybe called "target", that can be either a `star_id`, a coordinate or a name. If that is better, then we might need to drop the name option, because star_id is a string so I'm not sure how to distinguish between star_id and name.
2. The term "flux" is a little unfortunate, but we can't change that...it is a lightkiurve thing. 