### PR TITLE
Move dictionaries needed for testing to new file

### DIFF
--- a/stellarphot/gui_tools/tests/test_seeing_profile.py
+++ b/stellarphot/gui_tools/tests/test_seeing_profile.py
@@ -25,7 +25,7 @@ from stellarphot.settings import (
     PhotometryWorkingDirSettings,
     settings_files,  # This import is needed for mocking
 )
-from stellarphot.settings.tests.test_models import (
+from stellarphot.settings.constants import (
     TEST_CAMERA_VALUES,
 )
 

--- a/stellarphot/photometry/tests/test_profiles.py
+++ b/stellarphot/photometry/tests/test_profiles.py
@@ -10,7 +10,7 @@ from photutils.datasets import make_noise_image
 from stellarphot.photometry import CenterAndProfile, find_center
 from stellarphot.photometry.tests.fake_image import make_gaussian_sources_image
 from stellarphot.settings import Camera
-from stellarphot.settings.tests.test_models import TEST_CAMERA_VALUES
+from stellarphot.settings.constants import TEST_CAMERA_VALUES
 
 SHAPE = (300, 300)
 RANDOM_SEED = 1230971

--- a/stellarphot/settings/__init__.py
+++ b/stellarphot/settings/__init__.py
@@ -5,7 +5,7 @@ from .views import *
 # For conveniences, provide the JSON schema and an example of PhotometrySettings.
 photometry_settings_schema = PhotometrySettings.model_json_schema()  # noqa: F405
 
-from .tests.test_models import TEST_PHOTOMETRY_SETTINGS
+from .constants import TEST_PHOTOMETRY_SETTINGS
 
 photometry_settings_example = PhotometrySettings(  # noqa: F405
     **TEST_PHOTOMETRY_SETTINGS

--- a/stellarphot/settings/constants.py
+++ b/stellarphot/settings/constants.py
@@ -1,0 +1,95 @@
+# Though these constants are used in the tests they are needed in a few
+# non-test places too. Putting them here ensures they can be imported
+# without needing test dependencies.
+
+TEST_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
+
+TEST_CAMERA_VALUES = dict(
+    data_unit="adu",
+    gain="2.0 electron / adu",
+    name="test camera",
+    read_noise="10.0 electron",
+    dark_current="0.01 electron / s",
+    pixel_scale="0.563 arcsec / pix",
+    max_data_value="50000.0 adu",
+)
+
+TEST_EXOPLANET_SETTINGS = dict(
+    epoch={
+        "jd1": 0.0,
+        "jd2": 0.0,
+        "format": "jd",
+        "scale": "utc",
+        "precision": 3,
+        "in_subfmt": "*",
+        "out_subfmt": "*",
+    },
+    period="0.0 min",
+    identifier="a planet",
+    coordinate={
+        "ra": "0d00m00s",
+        "dec": "0d00m00s",
+        "representation_type": "spherical",
+        "frame": "icrs",
+    },
+    depth=0,
+    duration="0.0 min",
+)
+
+TEST_OBSERVATORY_SETTINGS = dict(
+    name="test observatory",
+    longitude="43d00m00s",
+    latitude="45d00m00s",
+    elevation="311.0 m",
+    AAVSO_code="test",
+    TESS_telescope_code="tess test",
+)
+
+# The first setting here is required, the rest are optional. The optional
+# settings below are different than the defaults in the model definition.
+TEST_PHOTOMETRY_OPTIONS = dict(
+    include_dig_noise=False,
+    reject_too_close=False,
+    reject_background_outliers=False,
+    fwhm_by_fit=False,
+    method="center",
+)
+
+TEST_PASSBAND_MAP = dict(
+    name="Example map",
+    your_filter_names_to_aavso=[
+        dict(
+            your_filter_name="V",
+            aavso_filter_name="V",
+        ),
+        dict(
+            your_filter_name="B",
+            aavso_filter_name="B",
+        ),
+        dict(
+            your_filter_name="rp",
+            aavso_filter_name="SR",
+        ),
+    ],
+)
+
+TEST_LOGGING_SETTINGS = dict(
+    logfile="test.log",
+    console_log=False,
+)
+
+TEST_SOURCE_LOCATION_SETTINGS = dict(
+    shift_tolerance=5,
+    source_list_file="test.ecsv",
+    use_coordinates="pixel",
+)
+
+TEST_PHOTOMETRY_SETTINGS = dict(
+    camera=TEST_CAMERA_VALUES,
+    observatory=TEST_OBSERVATORY_SETTINGS,
+    photometry_apertures=TEST_APERTURE_SETTINGS,
+    source_location_settings=TEST_SOURCE_LOCATION_SETTINGS,
+    photometry_optional_settings=TEST_PHOTOMETRY_OPTIONS,
+    passband_map=TEST_PASSBAND_MAP,
+    logging_settings=TEST_LOGGING_SETTINGS,
+)

--- a/stellarphot/settings/tests/test_custom_widgets.py
+++ b/stellarphot/settings/tests/test_custom_widgets.py
@@ -22,6 +22,12 @@ from stellarphot.settings import (
     settings_files,
     ui_generator,
 )
+from stellarphot.settings.constants import (
+    TEST_CAMERA_VALUES,
+    TEST_OBSERVATORY_SETTINGS,
+    TEST_PASSBAND_MAP,
+    TEST_PHOTOMETRY_SETTINGS,
+)
 from stellarphot.settings.custom_widgets import (
     ChooseOrMakeNew,
     Confirm,
@@ -30,12 +36,6 @@ from stellarphot.settings.custom_widgets import (
     SettingWithTitle,
     Spinner,
     _add_saving_to_widget,
-)
-from stellarphot.settings.tests.test_models import (
-    TEST_CAMERA_VALUES,
-    TEST_OBSERVATORY_SETTINGS,
-    TEST_PASSBAND_MAP,
-    TEST_PHOTOMETRY_SETTINGS,
 )
 
 

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -9,6 +9,17 @@ from astropy.table import Table
 from pydantic import ValidationError
 
 from stellarphot.settings import ui_generator
+from stellarphot.settings.constants import (
+    TEST_APERTURE_SETTINGS,
+    TEST_CAMERA_VALUES,
+    TEST_EXOPLANET_SETTINGS,
+    TEST_LOGGING_SETTINGS,
+    TEST_OBSERVATORY_SETTINGS,
+    TEST_PASSBAND_MAP,
+    TEST_PHOTOMETRY_OPTIONS,
+    TEST_PHOTOMETRY_SETTINGS,
+    TEST_SOURCE_LOCATION_SETTINGS,
+)
 from stellarphot.settings.models import (
     Camera,
     Exoplanet,
@@ -21,98 +32,6 @@ from stellarphot.settings.models import (
     PhotometryOptionalSettings,
     PhotometrySettings,
     SourceLocationSettings,
-)
-
-TEST_APERTURE_SETTINGS = dict(radius=5, gap=10, annulus_width=15, fwhm=3.2)
-
-TEST_CAMERA_VALUES = dict(
-    data_unit="adu",
-    gain="2.0 electron / adu",
-    name="test camera",
-    read_noise="10.0 electron",
-    dark_current="0.01 electron / s",
-    pixel_scale="0.563 arcsec / pix",
-    max_data_value="50000.0 adu",
-)
-
-TEST_EXOPLANET_SETTINGS = dict(
-    epoch={
-        "jd1": 0.0,
-        "jd2": 0.0,
-        "format": "jd",
-        "scale": "utc",
-        "precision": 3,
-        "in_subfmt": "*",
-        "out_subfmt": "*",
-    },
-    period="0.0 min",
-    identifier="a planet",
-    coordinate={
-        "ra": "0d00m00s",
-        "dec": "0d00m00s",
-        "representation_type": "spherical",
-        "frame": "icrs",
-    },
-    depth=0,
-    duration="0.0 min",
-)
-
-TEST_OBSERVATORY_SETTINGS = dict(
-    name="test observatory",
-    longitude="43d00m00s",
-    latitude="45d00m00s",
-    elevation="311.0 m",
-    AAVSO_code="test",
-    TESS_telescope_code="tess test",
-)
-
-# The first setting here is required, the rest are optional. The optional
-# settings below are different than the defaults in the model definition.
-TEST_PHOTOMETRY_OPTIONS = dict(
-    include_dig_noise=False,
-    reject_too_close=False,
-    reject_background_outliers=False,
-    fwhm_by_fit=False,
-    method="center",
-)
-
-TEST_PASSBAND_MAP = dict(
-    name="Example map",
-    your_filter_names_to_aavso=[
-        dict(
-            your_filter_name="V",
-            aavso_filter_name="V",
-        ),
-        dict(
-            your_filter_name="B",
-            aavso_filter_name="B",
-        ),
-        dict(
-            your_filter_name="rp",
-            aavso_filter_name="SR",
-        ),
-    ],
-)
-
-TEST_LOGGING_SETTINGS = dict(
-    logfile="test.log",
-    console_log=False,
-)
-
-TEST_SOURCE_LOCATION_SETTINGS = dict(
-    shift_tolerance=5,
-    source_list_file="test.ecsv",
-    use_coordinates="pixel",
-)
-
-TEST_PHOTOMETRY_SETTINGS = dict(
-    camera=TEST_CAMERA_VALUES,
-    observatory=TEST_OBSERVATORY_SETTINGS,
-    photometry_apertures=TEST_APERTURE_SETTINGS,
-    source_location_settings=TEST_SOURCE_LOCATION_SETTINGS,
-    photometry_optional_settings=TEST_PHOTOMETRY_OPTIONS,
-    passband_map=TEST_PASSBAND_MAP,
-    logging_settings=TEST_LOGGING_SETTINGS,
 )
 
 

--- a/stellarphot/settings/tests/test_photometry_runner.py
+++ b/stellarphot/settings/tests/test_photometry_runner.py
@@ -10,8 +10,8 @@ from stellarphot.settings import (
     PhotometryWorkingDirSettings,
     settings_files,
 )
+from stellarphot.settings.constants import TEST_PHOTOMETRY_SETTINGS
 from stellarphot.settings.custom_widgets import PhotometryRunner
-from stellarphot.settings.tests.test_models import TEST_PHOTOMETRY_SETTINGS
 
 
 # See test_settings_file.TestSavedSettings for a detailed description of what the

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -15,7 +15,7 @@ from stellarphot.settings import (
     SavedSettings,
     settings_files,  # This import is needed for mocking -- see TestSavedSettings
 )
-from stellarphot.settings.tests.test_models import TEST_PHOTOMETRY_SETTINGS
+from stellarphot.settings.constants import TEST_PHOTOMETRY_SETTINGS
 
 CAMERA = """
 {

--- a/stellarphot/settings/tests/test_views.py
+++ b/stellarphot/settings/tests/test_views.py
@@ -1,5 +1,5 @@
 from stellarphot.settings import Camera, SourceLocationSettings, ui_generator
-from stellarphot.settings.tests.test_models import TEST_CAMERA_VALUES
+from stellarphot.settings.constants import TEST_CAMERA_VALUES
 
 
 class TestUiGenerator:


### PR DESCRIPTION
This ensures that we can get at those constants without having to have test dependencies (e.g. pytest) installed.

Fixes #465 