### PR TITLE
Add test and fix for PhotometryData initialization

### DIFF
--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -438,6 +438,9 @@ class PhotometryData(BaseEnhancedTable):
                 **kwargs,
             )
 
+            # From this point forwarsd we should be using self to get at any data
+            # columns, because that is where BaseEnhancedTable has put the data.
+
             # Perform input validation
             if not isinstance(self.observatory, Observatory):
                 raise TypeError(
@@ -465,24 +468,24 @@ class PhotometryData(BaseEnhancedTable):
             ]
             cnts_unit = self[counts_columns[0]].unit
             for this_col in counts_columns[1:]:
-                if input_data[this_col].unit != cnts_unit:
+                if self[this_col].unit != cnts_unit:
                     raise ValueError(
                         f"input_data['{this_col}'] has inconsistent units "
                         f"with input_data['{counts_columns[0]}'] (should "
                         f"be {cnts_unit} but it's "
-                        f"{input_data[this_col].unit})."
+                        f"{self[this_col].unit})."
                     )
             for this_col in counts_per_pixel_columns:
                 if cnts_unit is None:
                     perpixel = u.pixel**-1
                 else:
                     perpixel = cnts_unit * u.pixel**-1
-                if input_data[this_col].unit != perpixel:
+                if self[this_col].unit != perpixel:
                     raise ValueError(
                         f"input_data['{this_col}'] has inconsistent units "
                         f"with input_data['{counts_columns[0]}'] (should "
                         f"be {perpixel} but it's "
-                        f"{input_data[this_col].unit})."
+                        f"{self[this_col].unit})."
                     )
 
             # Compute additional columns

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -438,7 +438,7 @@ class PhotometryData(BaseEnhancedTable):
                 **kwargs,
             )
 
-            # From this point forwarsd we should be using self to get at any data
+            # From this point forward we should be using self to get at any data
             # columns, because that is where BaseEnhancedTable has put the data.
 
             # Perform input validation

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -491,6 +491,23 @@ def test_photometry_blank():
     assert test_base.observatory is None
 
 
+def test_photometry_with_colname_map(feder_cg_16m, feder_passbands, feder_obs):
+    # Rename one of the columns in the test data to something else
+    # and provide a colname_map that should fix it.
+    # Regression test for #469
+    this_phot_data = testphot_clean.copy()
+    this_phot_data.rename_column("aperture_net_cnts", "bad_column")
+    colname_map = {"bad_column": "aperture_net_cnts"}
+    pd = PhotometryData(
+        input_data=this_phot_data,
+        colname_map=colname_map,
+        observatory=feder_obs,
+        camera=feder_cg_16m,
+        passband_map=feder_passbands,
+    )
+    assert "bad_column" not in pd.columns
+
+
 @pytest.mark.parametrize("bjd_coordinates", [None, "custom"])
 def test_photometry_data(feder_cg_16m, feder_passbands, feder_obs, bjd_coordinates):
     # Create photometry data instance


### PR DESCRIPTION
Fixes #469 by using `self` to get at the data instead of `input_data` after `BaseEnhancedTable` has fixed up column names.