### PR TITLE
Change default value for reject_unmatched and fix description

### DIFF
--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -1163,6 +1163,10 @@ class PhotometryRunSettings(BaseModel):
     directory_with_images: Path = "."
     photometry_settings_file: Path = "photometry_settings.json"
     reject_unmatched: Annotated[
-        bool, Field(description="Blah blah", tooltip="WOMA")
-    ] = True
+        bool,
+        Field(
+            description="Drop any stars that do not appear in all images",
+            tooltip="Reject unmatched stars",
+        ),
+    ] = False
     object_of_interest: str | None = None


### PR DESCRIPTION
The description fix here is pretty straightforward. We are preparing to do some notebook-based photometry on several nights and want to keep all the stars we can so I changed the default for that case.