### PR TITLE
Refactor `source_detection` to allow it to run faster

### DIFF
--- a/stellarphot/photometry/source_detection.py
+++ b/stellarphot/photometry/source_detection.py
@@ -31,7 +31,7 @@ def compute_fwhm(
     Parameters
     ----------
 
-    ccd : `astropy.nddata.CCDData`
+    ccd : `astropy.nddata.CCDData` or `numpy.ndarray`
         The CCD Image array.
 
     sources : `astropy.table.Table`
@@ -70,6 +70,8 @@ def compute_fwhm(
         The FWHM of each source in the x and y directions.
 
     """
+    data = ccd.data if isinstance(ccd, CCDData) else ccd
+
     if sky_per_pix_avg is not None and sky_per_pix_column is not None:
         raise ValueError(
             "Cannot specify both `sky_per_pix_avg` and `sky_per_pix_column`."
@@ -104,8 +106,8 @@ def compute_fwhm(
         except AttributeError:
             pass
 
-        # SKY SUBTRACT SHIT!!
-        cutout = Cutout2D(ccd.data - sky, (x, y), 5 * fwhm_estimate)
+        # SKY SUBTRACT STUFF!!
+        cutout = Cutout2D(data - sky, (x, y), 5 * fwhm_estimate)
 
         # Mask any NaNs in the data
         nan_mask = np.isnan(cutout.data)


### PR DESCRIPTION
This makes some relatively minor changes to `source_detection` that allow it to run significantly faster and makes the `print` stuff optional. The changes to the functionality are listed below and occur only if the user sets `stddev` to a value.

+ One change is to allow the user to input a `stddev` that is used to calculate the threshold for source detection (the `threshold` parameter is multiplied by `stddev`). 
+ Another significant change is to use the median image value as the sky background if i) no input sky value has been provided and ii) sigma clipped stats have not been calculated.
+ Finally, if sigma clipped stats have been done, and the user has not input a sky value, then the sigma clipped median is used instead of the mean.
 
It turns out that on Feder images, sigma clipped stats take roughly a second, even though you get a good estimate of the standard deviation just by using the noise level of the camera. I think the standard deviation of the background is really the quadrature sum of the camera noise and the Poisson noise of the background, but the noise alone isn't terrible.

A median estimate of the background is also not terrible.

