### PR TITLE
Variable aperture fixes

### DIFF
--- a/stellarphot/gui_tools/seeing_profile_functions.py
+++ b/stellarphot/gui_tools/seeing_profile_functions.py
@@ -393,8 +393,9 @@ class SeeingProfileWidget:
             self._update_plots()
             ape = PhotometryApertures(**change["new"])
             self.aperture_settings.description = (
-                f"Inner annulus: {ape.inner_annulus}, "
-                f"outer annulus: {ape.outer_annulus}"
+                f"Aperture radius: {ape.radius_pixels(ape.fwhm_estimate):.2f} pix, "
+                f"Inner annulus: {ape.inner_annulus:.2f} pix, "
+                f"outer annulus: {ape.outer_annulus:.2f} pix"
             )
 
         self.aperture_settings.observe(aperture_obs, names="_value")

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -424,7 +424,7 @@ class PhotometryApertures(BaseModelWithTableRep):
         """
         Radius of the inner annulus in pixels.
         """
-        return self.radius + self.gap
+        return self.radius_pixels(self.fwhm_estimate) + self.gap
 
     @property
     def outer_annulus(self):

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -466,34 +466,59 @@ def test_camera_altunitscheck():
     assert c.model_dump() == camera_for_test
 
 
-def test_create_aperture_settings_correctly():
-    ap_set = PhotometryApertures(**TEST_APERTURE_SETTINGS)
-    assert ap_set.radius == TEST_APERTURE_SETTINGS["radius"]
-    assert (
-        ap_set.inner_annulus
-        == TEST_APERTURE_SETTINGS["radius"] + TEST_APERTURE_SETTINGS["gap"]
+class TestPhotometryApertureSettings:
+    """
+    Put tests specific to, and isolated to, `PhotometryAperture` settings here.
+    """
+
+    @pytest.mark.parametrize(
+        "variable_aperture,radius",
+        [
+            (True, 1.5),
+            (False, 5.0),
+        ],
     )
-    assert (
-        ap_set.outer_annulus
-        == TEST_APERTURE_SETTINGS["radius"]
-        + TEST_APERTURE_SETTINGS["gap"]
-        + TEST_APERTURE_SETTINGS["annulus_width"]
-    )
+    def test_create_aperture_settings_correctly(self, variable_aperture, radius):
+        # Check that the inner and outer annulus are set correctly.
+        ap_set = PhotometryApertures(**TEST_APERTURE_SETTINGS)
+        assert ap_set.radius == TEST_APERTURE_SETTINGS["radius"]
 
+        ap_set.variable_aperture = variable_aperture
+        ap_set.radius = radius
+        if variable_aperture:
+            expected_inner = (
+                radius * TEST_APERTURE_SETTINGS["fwhm_estimate"]
+                + TEST_APERTURE_SETTINGS["gap"]
+            )
+            expected_outer = (
+                radius * TEST_APERTURE_SETTINGS["fwhm_estimate"]
+                + TEST_APERTURE_SETTINGS["gap"]
+                + TEST_APERTURE_SETTINGS["annulus_width"]
+            )
+        else:
+            expected_inner = radius + TEST_APERTURE_SETTINGS["gap"]
+            expected_outer = (
+                radius
+                + TEST_APERTURE_SETTINGS["gap"]
+                + TEST_APERTURE_SETTINGS["annulus_width"]
+            )
+        assert ap_set.inner_annulus == expected_inner
+        assert ap_set.outer_annulus == expected_outer
 
-def test_create_aperture_settings_variable_aperture():
-    # Check that the variable aperture flag is set correctly
-    settings = deepcopy(TEST_APERTURE_SETTINGS)
-    settings["variable_aperture"] = True
-    # The radius below is intended as a multiple of the FWHM
-    settings["radius"] = 1.5
-    ap_set = PhotometryApertures(**settings)
-    assert ap_set.variable_aperture is True
+    def test_create_aperture_settings_variable_aperture(self):
+        # Check that the variable aperture flag is set correctly
+        # and that radius_pixles is calculated correctly.
+        settings = deepcopy(TEST_APERTURE_SETTINGS)
+        settings["variable_aperture"] = True
+        # The radius below is intended as a multiple of the FWHM
+        settings["radius"] = 1.5
+        ap_set = PhotometryApertures(**settings)
+        assert ap_set.variable_aperture is True
 
-    # Check that the radius in pixels is correct
-    fwhm = 5.0
-    radius_pix = ap_set.radius_pixels(fwhm)
-    assert radius_pix == pytest.approx(7.5, rel=1e-6)
+        # Check that the radius in pixels is correct
+        fwhm = 5.0
+        radius_pix = ap_set.radius_pixels(fwhm)
+        assert radius_pix == pytest.approx(7.5, rel=1e-6)
 
 
 @pytest.mark.parametrize("bad_one", ["radius", "gap", "annulus_width"])


### PR DESCRIPTION
Every new line of code is an opportunity for a new error, right?

In any event, this fixes up the `PhotometryAperture` class so that  it correctly calculates the inner annulus now. The error is that the inner annulus calculation still used `radius`, which can be in either pixels or a multiple of the FWHM. It shound have been using `radius_pixel`.