### PR TITLE
Redo table I/O

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,5 +200,8 @@ filterwarnings = [
     # lightkurve issues a warning about an optional import
     'ignore:.*the tpfmodel submodule is not available without oktopus.*:UserWarning',
     # Sometimes gaussian fits are not great
-    'ignore:The fit may be unsuccessful; check fit_info:astropy.utils.exceptions.AstropyUserWarning'
+    'ignore:The fit may be unsuccessful; check fit_info:astropy.utils.exceptions.AstropyUserWarning',
+    # Apparently some change in pytest or coverage or pytest-cov exposes warnings
+    # that were previously ignored.
+    'ignore:.*:coverage.exceptions.CoverageWarning'
 ]

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -103,7 +103,7 @@ class TestModelAgnosticActions:
 
     def test_model_table_round_trip(self, model, settings, tmp_path):
         # Make sure that we can write the model to a table metadata and read it back in
-        # as long as we are use BaseEnhancedTable or a subclass.
+        # as long as we are using BaseEnhancedTable or a subclass.
         mod = model(**settings)
         table = BaseEnhancedTable({"data": [1, 2, 3]})
         table.meta["model"] = mod

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -6,9 +6,9 @@ from copy import deepcopy
 import astropy.units as u
 import pytest
 from astropy.coordinates import EarthLocation, Latitude, Longitude
-from astropy.table import Table
 from pydantic import ValidationError
 
+from stellarphot import BaseEnhancedTable
 from stellarphot.settings import ui_generator
 from stellarphot.settings.constants import (
     TEST_APERTURE_SETTINGS,
@@ -102,13 +102,14 @@ class TestModelAgnosticActions:
 
     def test_model_table_round_trip(self, model, settings, tmp_path):
         # Make sure that we can write the model to a table metadata and read it back in
+        # as long as we are use BaseEnhancedTable or a subclass.
         mod = model(**settings)
-        table = Table({"data": [1, 2, 3]})
+        table = BaseEnhancedTable({"data": [1, 2, 3]})
         table.meta["model"] = mod
         table_path = tmp_path / "test_table.ecsv"
         print(f"{mod=}")
         table.write(table_path)
-        new_table = Table.read(table_path)
+        new_table = BaseEnhancedTable.read(table_path)
         assert new_table.meta["model"] == mod
 
     def test_settings_ui_generation(self, model, settings):

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import astropy.units as u
 import pytest
 from astropy.coordinates import EarthLocation, Latitude, Longitude
+from astropy.table import Table
 from pydantic import ValidationError
 
 from stellarphot import BaseEnhancedTable
@@ -107,10 +108,21 @@ class TestModelAgnosticActions:
         table = BaseEnhancedTable({"data": [1, 2, 3]})
         table.meta["model"] = mod
         table_path = tmp_path / "test_table.ecsv"
-        print(f"{mod=}")
         table.write(table_path)
         new_table = BaseEnhancedTable.read(table_path)
         assert new_table.meta["model"] == mod
+
+    def test_plain_table_readability(self, model, settings, tmp_path):
+        # Make sure that we can write the model to a table metadata and read it back in
+        # as long as we are use BaseEnhancedTable or a subclass.
+        mod = model(**settings)
+        table = BaseEnhancedTable({"data": [1, 2, 3]})
+        table.meta["model"] = mod
+        table_path = tmp_path / "test_table.ecsv"
+        print(f"{mod=}")
+        table.write(table_path)
+        new_table = Table.read(table_path)
+        assert mod.__class__.__name__ == new_table.meta["model"]["_model_name"]
 
     def test_settings_ui_generation(self, model, settings):
         # Check a few things about the UI generation:

--- a/stellarphot/table_representations.py
+++ b/stellarphot/table_representations.py
@@ -1,3 +1,5 @@
+import json
+
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader
 
 from stellarphot.settings import models
@@ -35,8 +37,83 @@ def generate_table_representers(cls):
     AstropyLoader.add_constructor(class_string, _constructor)
 
 
-# This code is deliberately executable so that it can be executed on import, which
-# should assure that Table representations are generated for all models.
-for model_name in models.__all__:
-    model_class = getattr(models, model_name)
-    generate_table_representers(model_class)
+def serialize_models_in_table_meta(table_meta):
+    """
+    Serialize the models in the table metadata **IN PLACE**.
+    This is used to ensure that the models are represented as simple
+    dictionaries when written to disk.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        The table whose metadata will be serialized.
+    """
+    model_classes = tuple(getattr(models, model_name) for model_name in models.__all__)
+
+    for key, value in table_meta.items():
+        # If the value is a model instance, serialize it
+        if isinstance(value, model_classes):
+            model_instance = value
+            # So, funny story. model_dump gives you a nice dictionary, in which
+            # things like Longitude are turned into strings. However, writing them
+            # to ECSV fails, because ECSV doesn't understand np.str_, and - guess what -
+            # a Longitude returns a np.str_ when you do str(some_longitude).
+            # The upshot is that the workaround here, i.e. using model_dump to get
+            # simple objects into the header, does not work unless all string values
+            # are converted to str.
+            #
+            # The issue has been reported in
+            # https://github.com/astropy/astropy/issues/18235
+            #
+
+            # Dumping to json ensures that all the objects are converted to
+            # very basic types, which is easy enough to convert to a dictionary.
+
+            # Use model_dump_json to get a simple dictionary representation
+            model_json = model_instance.model_dump_json()
+            model_dict = json.loads(model_json)
+            table_meta[key] = model_dict
+            table_meta[key]["_model_name"] = model_instance.__class__.__name__
+        # If the value is a dict, recurse
+        elif isinstance(value, dict):
+            serialize_models_in_table_meta(value)
+
+
+def deserialize_models_in_table_meta(table_meta):
+    """
+    Deserialize the models in the table metadata **IN PLACE**.
+    This is used to ensure that the models are restored from simple
+    dictionaries when read from disk.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        The table whose metadata will be deserialized.
+    """
+    known_models = {
+        model_name: getattr(models, model_name) for model_name in models.__all__
+    }
+
+    model_keys_in_meta = []
+    for key, value in table_meta.meta.items():
+        # Check if the value is a dictionary and has a "_model_name" key
+        if isinstance(value, dict) and "_model_name" in value:
+            # Check if the model name is in the known models
+            if value["_model_name"] in known_models.keys():
+                model_keys_in_meta.append(key)
+
+    for key in model_keys_in_meta:
+        model_name = table_meta.meta[key].pop("_model_name")
+        table_meta.meta[key] = known_models[model_name].model_validate(
+            table_meta.meta[key]
+        )
+
+
+def _generate_old_table_representers():
+    """
+    This provides what is needed to read the "old-style" data tables in
+    which the models were stored as objects in the table metadata.
+    """
+    for model_name in models.__all__:
+        model_class = getattr(models, model_name)
+        generate_table_representers(model_class)

--- a/stellarphot/table_representations.py
+++ b/stellarphot/table_representations.py
@@ -45,8 +45,8 @@ def serialize_models_in_table_meta(table_meta):
 
     Parameters
     ----------
-    table : `~astropy.table.Table`
-        The table whose metadata will be serialized.
+    table_meta : dict
+        The metadata dictionary of the table.
     """
     model_classes = tuple(getattr(models, model_name) for model_name in models.__all__)
 
@@ -87,8 +87,8 @@ def deserialize_models_in_table_meta(table_meta):
 
     Parameters
     ----------
-    table : `~astropy.table.Table`
-        The table whose metadata will be deserialized.
+    table_meta : dict
+        The metadata dictionary of the table.
     """
     known_models = {
         model_name: getattr(models, model_name) for model_name in models.__all__


### PR DESCRIPTION
This pull request changes how stellarphot objects (e.g. `Camera`) are represented when one of our tables (e.g. `PhotometryData`) is saved to `ecsv`. 

Prior to this pull request, special "representers" were added to astropy's Table I/O. That worked fine within stellarphot, but it means that if you write a file and send it to someone else they would not be able to read it with plain astropy. 

Now, stellarphot models are saved as plain dictionaries in the table metadata. If a stellarphot-written file is read in with a stellarphot data table then the objects in the metadata are stellarphot objects. If read in with plain astropy Table, then the objects remain as dictionaries in the table metadata.

Fixes #489 