### PR TITLE
Check for NaNs in errors in mag transforms

### DIFF
--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -657,6 +657,7 @@ def transform_to_catalog(
             (one_image[obs_mag_col] < -3)
             & (one_image[obs_mag_col] > -20)
             & ~np.isnan(one_image[obs_mag_col])
+            & ~np.isnan(one_image[obs_error_column])
         )
 
         if not (any(good_dat) or any(good_cat)):
@@ -676,6 +677,8 @@ def transform_to_catalog(
             continue
 
         mag_diff_mask = getattr(mag_diff, "mask", np.array([False]))
+        # WHAT DOES THIS DO? I THINK IT REMOVES OUTLIER THAT ARE MORE
+        # THAN 1 MAG OFF MEDIAN
         good_data = good_dat & (
             np.abs(mag_diff - np.nanmedian(mag_diff[good_dat & ~mag_diff_mask])) < 1
         )


### PR DESCRIPTION
Fixes #529 by filtering out `NaN` values in mag errors.