### PR TITLE
Fix representation of table attributes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
 # Per the ruff documentation, this should be before black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
       # Run the linter.
       - id: ruff

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -290,7 +290,7 @@ class BaseEnhancedTable(QTable):
         else:
             # If we got here, we can assume the table is a new one and has
             # models as dictionaries in the metadata.
-            deserialize_models_in_table_meta(table)
+            deserialize_models_in_table_meta(table.meta)
         return cls(table)
 
     def write(self, *args, **kwargs):

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -4,7 +4,7 @@ import re
 from copy import deepcopy
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional, TypeVar
+from typing import Annotated, Any, Literal, TypeVar
 
 from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.time import Time
@@ -1146,7 +1146,7 @@ def _make_partial_model(model: type[BaseModelT], default=None) -> type[BaseModel
     for field_name, field_info in model.model_fields.items():
         new = deepcopy(field_info)
         new.default = default
-        new.annotation = Optional[field_info.annotation]  # type: ignore  # noqa: UP007
+        new.annotation = field_info.annotation | None  # type: ignore  # noqa: UP007
         new_fields[field_name] = (new.annotation, new)
     return create_model(  # type: ignore
         f"Partial{model.__name__}",

--- a/stellarphot/table_representations.py
+++ b/stellarphot/table_representations.py
@@ -89,7 +89,10 @@ def deserialize_models_in_table_meta(table_meta):
 
     1. Directly in the table metadata.
     2. As a TableAttribute, which ends up in the table's meta under
-       the "``__attribute__``" key.
+       the "``__attributes__``" key.
+
+    This function checks subdictionaries recursively to properly handle this
+    case.
 
     Parameters
     ----------


### PR DESCRIPTION
It turns out there was a bug in #519: stellarphot objects stored as `dict`s in the metadata were not properly turned back into onjects on reading if they were table attributes instead of being stored directly in the table metadata dictionary.

This PR adds a test for that and fixes the issue.