### PR TITLE
Fix relative flux calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ filterwarnings = [
     'ignore:Using extra keyword arguments on `Field` is deprecated:',
     # ipywidgets is using something deprecated in traitlets
     'ignore:Deprecated in traitlets 4.1, use the instance:DeprecationWarning',
+    # ipyautoui is also using a deprecated traitlets feature
+    'ignore:Traits should be given as instances, not types:DeprecationWarning',
     # Some WCS headers are issuing warnings
     'ignore:RADECSYS=:',
     # papermill is using deprecated jupyter paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,8 @@ filterwarnings = [
     'ignore:[.\n]*Pyarrow will become a required dependency of pandas[.\n]*:DeprecationWarning',
     # ipyautoui is generating this on import because they still have some pydantic changes to make
     'ignore:Using extra keyword arguments on `Field` is deprecated:',
+    # ipyautoui is generating another new traitlets warning
+    'ignore:.*deprecated in traitlets 5.0.*:DeprecationWarning',
     # ipywidgets is using something deprecated in traitlets
     'ignore:Deprecated in traitlets 4.1, use the instance:DeprecationWarning',
     # ipyautoui is also using a deprecated traitlets feature

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -105,6 +105,17 @@ def calc_aij_relative_flux(
 
     bad_comps = set(is_all_good["star_id"][~is_all_good["good"]])
 
+    # Check for comps that are only in some of the images
+    # Make a small table with just star IDs and date-obs
+    check_for_missing = Table(
+        data=[star_data[star_id_column], star_data["date-obs"]],
+        names=["star_id", "date-obs"],
+    ).group_by("date-obs")
+    star_id_sets = check_for_missing.groups.aggregate(set)["star_id"]
+    good_ids = set.intersection(*star_id_sets)
+    bad_comps_missing = set(is_all_good["star_id"]) - good_ids
+    bad_comps = bad_comps | bad_comps_missing
+
     # Check whether any of the comp stars have NaN values and,
     # if they do, exclude them from the comp set.
     check_for_nan = Table(


### PR DESCRIPTION
The relative flux can only be calculated if the same set of stars is used in each image as the comparison. This adds a calculation of the star IDs that are present in every image and uses those as the comparison set.