### PR TITLE
Add AAVSO Extended File Format export for ensemble photometry

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -21,6 +21,5 @@ dependencies:
     - reproject
     - sphinx
     - sphinx-astropy
-    - sphinx-automodapi=0.16
     - pip:
         - ipyautoui

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ useful photometry, with a focus on variable star and exoplanet transit observati
   - calculate relative flux (like [AstroImageJ](https://www.astro.louisville.edu/software/astroimagej/)),
   - calculate calibrated magnitudes by transforming to a catalog (e.g. APASS DR9), and/or
   - calculate calibrated magnitudes with a user-provided set of comparison stars (as is done in AAVSO submissions).
+  - export ensemble photometry results in the AAVSO Extended File Format for direct upload to WebObs.
 - If you are working with exoplanet transit observations, `stellarphot` can turns the photometry into exoplanet transit light curves (see installation notes below).
 
 ## Installation

--- a/docs/stellarphot/user_guide/calibrating_photometry.rst
+++ b/docs/stellarphot/user_guide/calibrating_photometry.rst
@@ -1,2 +1,57 @@
 Calibrating Photometry
 ######################
+
+Exporting to AAVSO
+==================
+
+Once you have calibrated magnitudes for your target and a check star, you can
+write a file in the `AAVSO Extended File Format
+<https://www.aavso.org/aavso-extended-file-format>`_ that the AAVSO WebObs
+loader accepts. Stellarphot's writer produces an *ensemble* submission
+(``CNAME=ENSEMBLE``, ``CMAG=na``) with one target star and one check star,
+paired observation-by-observation by ``(file, passband)``.
+
+The writer expects the ``passband`` column to already contain valid AAVSO
+filter names. If you started from instrumental filter names, use a
+:class:`~stellarphot.settings.PassbandMap` when constructing
+:class:`~stellarphot.PhotometryData` and the column will be remapped in place.
+
+Example
+-------
+
+.. code-block:: python
+
+    from stellarphot.settings import AAVSOSubmissionHeader
+
+    header = AAVSOSubmissionHeader(
+        type="EXTENDED",
+        obscode="ABC",
+        software="stellarphot 1.4",
+        delim="comma",
+        date_format="JD",
+    )
+
+    phot_data.write_aavso_extended(
+        "submission.csv",
+        header=header,
+        target_star_id=1,
+        target_name="V0533 Her",
+        check_star_id=6,
+        check_name="000-BLS-123",
+        chart="X12345",
+        mag_column="mag_inst_cal",
+        mag_error_column="mag_inst_cal_error",
+        trans=False,
+    )
+
+The ``mag_column`` and ``mag_error_column`` arguments name the calibrated
+magnitude columns to read; the
+:class:`~stellarphot.photometry.transform.TransformApplier` workflow produces
+``mag_inst_cal`` and ``mag_inst_cal_error``.
+
+.. note::
+
+   This release supports ``DATE=JD`` only. The AAVSO spec also allows ``HJD``
+   and ``EXCEL`` dates; using either currently raises ``NotImplementedError``.
+   The writer always emits ``#OBSTYPE=CCD`` and ``MTYPE=STD`` (consistent with
+   ensemble photometry using standardized magnitudes).

--- a/docs/stellarphot/user_guide/calibrating_photometry.rst
+++ b/docs/stellarphot/user_guide/calibrating_photometry.rst
@@ -9,7 +9,7 @@ write a file in the `AAVSO Extended File Format
 <https://www.aavso.org/aavso-extended-file-format>`_ that the AAVSO WebObs
 loader accepts. Stellarphot's writer produces an *ensemble* submission
 (``CNAME=ENSEMBLE``, ``CMAG=na``) with one target star and one check star,
-paired observation-by-observation by ``(file, passband)``.
+paired observation-by-observation by ``(date-obs, passband)``.
 
 The writer expects the ``passband`` column to already contain valid AAVSO
 filter names. If you started from instrumental filter names, use a
@@ -45,9 +45,8 @@ Example
     )
 
 The ``mag_column`` and ``mag_error_column`` arguments name the calibrated
-magnitude columns to read; the
-:class:`~stellarphot.photometry.transform.TransformApplier` workflow produces
-``mag_inst_cal`` and ``mag_inst_cal_error``.
+magnitude column and its uncertainty column to read for the target and the
+check star.
 
 .. note::
 

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -782,6 +782,18 @@ class PhotometryData(BaseEnhancedTable):
 
         return lk.LightCurve(star_data)
 
+    def write_aavso_extended(self, path, **kwargs):
+        """Write this photometry table in the AAVSO Extended File Format.
+
+        See `stellarphot.io.write_aavso_extended` for the full signature and
+        behavior. All keyword arguments are forwarded to that function.
+        """
+        # Lazy import to avoid a circular dependency: stellarphot.io imports
+        # from stellarphot.settings, which is loaded before core.
+        from .io.aavso import write_aavso_extended
+
+        return write_aavso_extended(self, path, **kwargs)
+
 
 class CatalogData(BaseEnhancedTable):
     """

--- a/stellarphot/io/__init__.py
+++ b/stellarphot/io/__init__.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from .aavso import *
 from .aij import *
 from .tess import *

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -1,0 +1,286 @@
+"""Writer for the AAVSO Extended File Format used by WebObs.
+
+Implements ensemble photometry submissions (CNAME=ENSEMBLE, CMAG=na) with one
+target star and one check star. The data layout follows the spec mirrored in
+``stellarphot/io/aavso_submission_schema.yml``.
+
+v1 limitations:
+- ``DATE=JD`` only. ``HJD`` and ``EXCEL`` are valid in the header model but
+  raise ``NotImplementedError`` from the writer.
+- ``MTYPE`` is hardcoded to ``STD`` (calibrated/standardized magnitudes), which
+  is the correct value when CNAME=ENSEMBLE.
+- ``OBSTYPE`` is hardcoded to ``CCD``.
+"""
+
+import math
+from pathlib import Path
+
+from astropy.time import Time
+
+from stellarphot.settings.aavso_models import AAVSOFilters
+from stellarphot.settings.aavso_submission import AAVSOSubmissionHeader
+
+__all__ = ["write_aavso_extended"]
+
+
+ALLOWED_EXTENSIONS = frozenset({".txt", ".csv", ".tsv"})
+
+# AAVSO data column order, in the sequence the spec requires.
+DATA_COLUMNS = (
+    "STARID",
+    "DATE",
+    "MAGNITUDE",
+    "MAGERR",
+    "FILTER",
+    "TRANS",
+    "MTYPE",
+    "CNAME",
+    "CMAG",
+    "KNAME",
+    "KMAG",
+    "AIRMASS",
+    "GROUP",
+    "CHART",
+    "NOTES",
+)
+
+# Per-field maximum character counts pulled from the spec. Fields not listed
+# (FILTER, TRANS, MTYPE, NOTES) have no length limit. AIRMASS is special: the
+# spec says it should be truncated rather than rejected.
+FIELD_LIMITS = {
+    "STARID": 30,
+    "DATE": 16,
+    "MAGNITUDE": 8,
+    "MAGERR": 6,
+    "CNAME": 20,
+    "CMAG": 8,
+    "KNAME": 20,
+    "KMAG": 8,
+    "AIRMASS": 7,
+    "GROUP": 5,
+    "CHART": 20,
+}
+
+
+def _is_valid_filter(value):
+    try:
+        AAVSOFilters(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _enforce_limit(name, value):
+    """Validate that the stringified field does not exceed its limit.
+
+    AIRMASS truncates; every other limited field raises.
+    """
+    limit = FIELD_LIMITS.get(name)
+    if limit is None or len(value) <= limit:
+        return value
+    if name == "AIRMASS":
+        return value[:limit]
+    raise ValueError(
+        f"AAVSO field {name}={value!r} exceeds the {limit}-character limit "
+        f"(got {len(value)} characters)."
+    )
+
+
+def _format_jd(date_obs, exposure):
+    """JD at mid-exposure in UT. ``exposure`` carries seconds units."""
+    midpoint = Time(date_obs) + exposure / 2
+    return f"{midpoint.jd:.5f}"
+
+
+def _to_float(value):
+    """Coerce a table cell (possibly an astropy ``Quantity``) to a plain float.
+
+    Columns in ``PhotometryData`` may carry units (e.g. ``mag_error`` has
+    ``1/adu`` in the test fixture, ``exposure`` has seconds). For string
+    formatting we only need the numeric magnitude, so strip the unit.
+    """
+    try:
+        return float(value.value)
+    except AttributeError:
+        return float(value)
+
+
+def _format_float(value, decimals):
+    return f"{_to_float(value):.{decimals}f}"
+
+
+def write_aavso_extended(
+    phot_data,
+    path,
+    *,
+    header,
+    target_star_id,
+    target_name,
+    check_star_id,
+    check_name,
+    chart,
+    mag_column,
+    mag_error_column,
+    trans=False,
+    group=None,
+    notes="na",
+):
+    """Write an AAVSO Extended File Format submission for ensemble photometry.
+
+    Parameters
+    ----------
+    phot_data : `stellarphot.PhotometryData`
+        Table of photometry results. Must contain at least the target star
+        and the check star, paired by ``(file, passband)``.
+
+    path : str or `pathlib.Path`
+        Destination file. Must have a ``.txt``, ``.csv`` or ``.tsv`` suffix.
+
+    header : `stellarphot.settings.AAVSOSubmissionHeader`
+        Header parameters. Only ``date_format="JD"`` is supported in v1.
+
+    target_star_id : str or int
+        The ``star_id`` value identifying the target rows in ``phot_data``.
+
+    target_name : str
+        The string written into the ``STARID`` column for every target row.
+
+    check_star_id : str or int
+        The ``star_id`` value identifying the check-star rows.
+
+    check_name : str
+        The string written into the ``KNAME`` column.
+
+    chart : str
+        The AAVSO chart sequence ID written into the ``CHART`` column.
+
+    mag_column : str
+        Name of the column in ``phot_data`` containing the calibrated magnitude
+        for the target. The same column is read for the check-star rows.
+
+    mag_error_column : str
+        Name of the column in ``phot_data`` containing the magnitude error.
+
+    trans : bool, optional
+        ``True`` to emit ``TRANS=YES``, ``False`` (default) for ``TRANS=NO``.
+
+    group : int or None, optional
+        Optional grouping identifier. ``None`` (default) emits ``GROUP=na``.
+
+    notes : str, optional
+        Text written into the ``NOTES`` column. Defaults to ``"na"``.
+    """
+    if not isinstance(header, AAVSOSubmissionHeader):
+        raise TypeError(
+            "header must be an AAVSOSubmissionHeader instance; "
+            f"got {type(header).__name__}."
+        )
+
+    if header.date_format != "JD":
+        raise NotImplementedError(
+            f"AAVSO writer only supports DATE=JD in this release; "
+            f"got date_format={header.date_format!r}."
+        )
+
+    path = Path(path)
+    if path.suffix.lower() not in ALLOWED_EXTENSIONS:
+        raise ValueError(
+            f"AAVSO submission file must have one of {sorted(ALLOWED_EXTENSIONS)} "
+            f"extensions; got {path.suffix!r}."
+        )
+
+    delimiter = header.data_delimiter()
+
+    # Split the table into target and check-star rows.
+    target_mask = phot_data["star_id"] == target_star_id
+    check_mask = phot_data["star_id"] == check_star_id
+
+    if not target_mask.any():
+        raise ValueError(f"No rows in phot_data have star_id={target_star_id!r}.")
+    if not check_mask.any():
+        raise ValueError(f"No rows in phot_data have star_id={check_star_id!r}.")
+
+    target_rows = phot_data[target_mask]
+    check_rows = phot_data[check_mask]
+
+    # Index check star rows by (file, passband) for fast lookup.
+    check_index = {}
+    for row in check_rows:
+        key = (row["file"], row["passband"])
+        check_index[key] = row
+
+    group_field = "na" if group is None else str(group)
+    trans_field = "YES" if trans else "NO"
+
+    data_lines = []
+    for row in target_rows:
+        passband = row["passband"]
+        if not _is_valid_filter(passband):
+            raise ValueError(
+                f"Row passband {passband!r} is not a valid AAVSO filter. "
+                "Apply a PassbandMap so the column uses AAVSO filter names "
+                "before exporting."
+            )
+
+        key = (row["file"], passband)
+        if key not in check_index:
+            raise ValueError(
+                "No check-star row found for "
+                f"(file={row['file']!r}, passband={passband!r}); "
+                f"check_star_id={check_star_id!r} must have a matching "
+                "observation for every target observation."
+            )
+        check_row = check_index[key]
+
+        starid = _enforce_limit("STARID", str(target_name))
+        date = _enforce_limit("DATE", _format_jd(row["date-obs"], row["exposure"]))
+        magnitude = _enforce_limit("MAGNITUDE", _format_float(row[mag_column], 4))
+
+        err_value = row[mag_error_column]
+        if err_value is None:
+            magerr = "na"
+        else:
+            err_float = _to_float(err_value)
+            if math.isnan(err_float):
+                magerr = "na"
+            else:
+                magerr = _enforce_limit("MAGERR", _format_float(err_float, 3))
+
+        filter_field = _enforce_limit("FILTER", str(passband))
+        cname = _enforce_limit("CNAME", "ENSEMBLE")
+        cmag = _enforce_limit("CMAG", "na")
+        kname = _enforce_limit("KNAME", str(check_name))
+        kmag = _enforce_limit("KMAG", _format_float(check_row[mag_column], 4))
+        airmass = _enforce_limit("AIRMASS", f"{_to_float(row['airmass']):.4f}")
+        group_value = _enforce_limit("GROUP", group_field)
+        chart_field = _enforce_limit("CHART", str(chart))
+        notes_field = str(notes) if notes is not None else "na"
+        if not notes_field:
+            notes_field = "na"
+
+        fields = [
+            starid,
+            date,
+            magnitude,
+            magerr,
+            filter_field,
+            trans_field,
+            "STD",
+            cname,
+            cmag,
+            kname,
+            kmag,
+            airmass,
+            group_value,
+            chart_field,
+            notes_field,
+        ]
+        data_lines.append(delimiter.join(fields))
+
+    with open(path, "w") as f:
+        for line in header.header_lines():
+            f.write(line + "\n")
+        for line in data_lines:
+            f.write(line + "\n")
+
+    return path

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -13,9 +13,9 @@ v1 limitations:
 """
 
 import io
-import math
 from pathlib import Path
 
+import numpy as np
 from astropy.table import Column, QTable, Table, join
 from astropy.time import Time
 
@@ -89,6 +89,31 @@ def _enforce_limit(name, value):
     )
 
 
+def _require_nonblank(name, value):
+    """Strip ``value`` and reject empty/whitespace-only required identifiers."""
+    if value is None:
+        raise ValueError(f"AAVSO field {name} is required; got None.")
+    stripped = str(value).strip()
+    if not stripped:
+        raise ValueError(
+            f"AAVSO field {name} is required; got an empty/whitespace value."
+        )
+    return stripped
+
+
+def _reject_delimiter_or_newline(name, value, delimiter):
+    if delimiter in value:
+        raise ValueError(
+            f"AAVSO field {name}={value!r} contains the configured delimiter "
+            f"{delimiter!r}; choose a delimiter that does not appear in the data."
+        )
+    if "\n" in value or "\r" in value:
+        raise ValueError(
+            f"AAVSO field {name}={value!r} contains a newline; "
+            "AAVSO rows must be a single line."
+        )
+
+
 def _to_float(value):
     """Coerce a value (possibly an astropy ``Quantity``) to a plain float."""
     try:
@@ -97,21 +122,33 @@ def _to_float(value):
         return float(value)
 
 
-def _format_mag(value):
-    return f"{_to_float(value):.4f}"
+def _format_mag(value, field_name):
+    """Format a required magnitude field. Non-finite values raise."""
+    f = _to_float(value)
+    if not np.isfinite(f):
+        raise ValueError(
+            f"AAVSO field {field_name} is required but the value is "
+            f"non-finite ({value!r}). Drop these rows before exporting."
+        )
+    return f"{f:.4f}"
 
 
 def _format_magerr(value):
     if value is None:
         return "na"
     f = _to_float(value)
-    if math.isnan(f):
+    if not np.isfinite(f):
         return "na"
     return f"{f:.3f}"
 
 
 def _format_airmass(value):
-    return f"{_to_float(value):.4f}"
+    if value is None:
+        return "na"
+    f = _to_float(value)
+    if not np.isfinite(f):
+        return "na"
+    return f"{f:.4f}"
 
 
 def write_aavso_extended(
@@ -187,6 +224,12 @@ def write_aavso_extended(
             f"got date_format={header.date_format!r}."
         )
 
+    if target_star_id == check_star_id:
+        raise ValueError(
+            "target_star_id and check_star_id must be different; "
+            f"got {target_star_id!r} for both."
+        )
+
     path = Path(path)
     if path.suffix.lower() not in ALLOWED_EXTENSIONS:
         raise ValueError(
@@ -195,6 +238,29 @@ def write_aavso_extended(
         )
 
     delimiter = header.data_delimiter()
+
+    # Required identifier fields supplied by the caller. The AAVSO spec
+    # forbids leading/trailing whitespace and empty values; we strip and
+    # then refuse to write a row with a blank required field.
+    target_name = _require_nonblank("target_name", target_name)
+    check_name = _require_nonblank("check_name", check_name)
+    chart = _require_nonblank("chart", chart)
+
+    # NOTES is optional; "na" is the spec's missing value. Strip then fall
+    # back to "na" so users can pass " " without producing a blank field.
+    notes = str(notes).strip() if notes is not None else ""
+    if not notes:
+        notes = "na"
+
+    # Reject values that would collide with the delimiter or break the row
+    # structure. Applies to every user-controlled string field.
+    for field_name, field_value in (
+        ("target_name", target_name),
+        ("check_name", check_name),
+        ("chart", chart),
+        ("notes", notes),
+    ):
+        _reject_delimiter_or_newline(field_name, field_value, delimiter)
 
     target_mask = phot_data["star_id"] == target_star_id
     check_mask = phot_data["star_id"] == check_star_id
@@ -258,8 +324,10 @@ def write_aavso_extended(
     paired.sort(["date-obs", "passband"])
 
     group_field = "na" if group is None else str(group)
+    if group is not None:
+        _reject_delimiter_or_newline("group", group_field, delimiter)
     trans_field = "YES" if trans else "NO"
-    notes_field = str(notes) if notes else "na"
+    notes_field = notes
 
     n = len(paired)
     target_mag_col = f"{mag_column}_target"
@@ -268,9 +336,9 @@ def write_aavso_extended(
     date_values = [
         f"{(Time(row['date-obs']) + row['exposure'] / 2).jd:.5f}" for row in paired
     ]
-    mag_values = [_format_mag(v) for v in paired[target_mag_col]]
+    mag_values = [_format_mag(v, "MAGNITUDE") for v in paired[target_mag_col]]
     err_values = [_format_magerr(v) for v in paired[mag_error_column]]
-    kmag_values = [_format_mag(v) for v in paired[check_mag_col]]
+    kmag_values = [_format_mag(v, "KMAG") for v in paired[check_mag_col]]
     airmass_values = [_format_airmass(v) for v in paired["airmass"]]
     filter_values = [str(p) for p in paired["passband"]]
 

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -214,27 +214,29 @@ def write_aavso_extended(
             )
 
     # Pull just the columns we need from each side so the join result is small
-    # and the renamed columns are unambiguous.
+    # and the renamed columns are unambiguous. Pairing is on (date-obs,
+    # passband) rather than (file, passband) so that submissions covering
+    # multiple nights still pair correctly when filenames are reused across
+    # nights.
     target_cols = [
-        "file",
-        "passband",
         "date-obs",
+        "passband",
         "exposure",
         "airmass",
         mag_column,
         mag_error_column,
     ]
-    check_cols = ["file", "passband", mag_column]
+    check_cols = ["date-obs", "passband", mag_column]
 
     target_subset = QTable(phot_data[target_mask][target_cols], copy=True)
     check_subset = QTable(phot_data[check_mask][check_cols], copy=True)
 
-    # Join on (file, passband) — this replaces the manual lookup dictionary
+    # Join on (date-obs, passband) — this replaces the manual lookup dictionary
     # and naturally drops target rows that have no matching check observation.
     paired = join(
         target_subset,
         check_subset,
-        keys=["file", "passband"],
+        keys=["date-obs", "passband"],
         table_names=["target", "check"],
         join_type="left",
     )
@@ -243,18 +245,17 @@ def write_aavso_extended(
     # join those rows have the check magnitude masked.
     check_mag_col = f"{mag_column}_check"
     if hasattr(paired[check_mag_col], "mask") and paired[check_mag_col].mask.any():
-        missing = paired[paired[check_mag_col].mask][["file", "passband"]]
+        missing = paired[paired[check_mag_col].mask][["date-obs", "passband"]]
         first = missing[0]
         raise ValueError(
             "No check-star row found for "
-            f"(file={first['file']!r}, passband={first['passband']!r}); "
+            f"(date-obs={first['date-obs']!r}, passband={first['passband']!r}); "
             f"check_star_id={check_star_id!r} must have a matching "
             "observation for every target observation."
         )
 
-    # Preserve the original target row order so the output is stable and easy
-    # to compare against the input table.
-    paired.sort(["file", "passband"])
+    # Preserve a stable, easy-to-compare row order.
+    paired.sort(["date-obs", "passband"])
 
     group_field = "na" if group is None else str(group)
     trans_field = "YES" if trans else "NO"

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -142,6 +142,39 @@ def _format_magerr(value):
     return f"{f:.3f}"
 
 
+def _validate_trans(value):
+    """``trans`` controls a required YES/NO field; truthiness would silently
+    flip a caller's intent (e.g. the string ``"False"`` is truthy)."""
+    if not isinstance(value, bool):
+        raise TypeError(
+            f"trans must be a bool (True or False); got "
+            f"{type(value).__name__} ({value!r})."
+        )
+    return value
+
+
+def _coerce_group(value):
+    """Coerce ``value`` to a non-bool ``int`` or ``None`` for the GROUP field.
+
+    Accepts Python ints, numpy integers, integer-valued floats (``5.0``) and
+    numeric strings (``"5"``). Rejects ``bool``, non-integer floats, and
+    anything that doesn't convert cleanly to a number.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"group must be an int or None; got bool ({value!r}).")
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"group must be an int or None; got {type(value).__name__} ({value!r})."
+        ) from exc
+    if not np.isfinite(as_float) or as_float != int(as_float):
+        raise ValueError(f"group must be an integer value; got {value!r}.")
+    return int(as_float)
+
+
 def _format_airmass(value):
     if value is None:
         return "na"
@@ -229,6 +262,9 @@ def write_aavso_extended(
             "target_star_id and check_star_id must be different; "
             f"got {target_star_id!r} for both."
         )
+
+    _validate_trans(trans)
+    group = _coerce_group(group)
 
     path = Path(path)
     if path.suffix.lower() not in ALLOWED_EXTENSIONS:

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -431,11 +431,18 @@ def write_aavso_extended(
     # column-name row prefixed with "#".
     buf = io.StringIO()
     out_table.write(buf, format="ascii.no_header", delimiter=delimiter)
-    data_text = buf.getvalue()
+    # astropy's ascii writer can emit os.linesep into the StringIO on
+    # Windows, mixing with the LF terminators we use for the header lines.
+    # Normalize to LF here so the open() below sees a uniform "\n" stream
+    # and translates the whole file to the platform's native terminator.
+    data_text = buf.getvalue().replace("\r\n", "\n").replace("\r", "\n")
 
     column_header = "#" + delimiter.join(DATA_COLUMNS)
 
-    with open(path, "w") as f:
+    # utf-8 because user-supplied notes/software fields can contain
+    # non-ASCII characters; default newline=None translates "\n" → os.linesep
+    # so the file uses native line endings (LF on Unix, CRLF on Windows).
+    with open(path, "w", encoding="utf-8") as f:
         for line in header.header_lines():
             f.write(line + "\n")
         f.write(column_header + "\n")

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -243,6 +243,13 @@ def write_aavso_extended(
             f"got {target_star_id!r} for both."
         )
 
+    for col in (mag_column, mag_error_column):
+        if col not in phot_data.colnames:
+            raise ValueError(
+                f"Column {col!r} is not in phot_data; "
+                f"available columns: {phot_data.colnames}"
+            )
+
     _validate_trans(trans)
     group = _coerce_group(group)
 

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -27,34 +27,19 @@ __all__ = ["write_aavso_extended"]
 
 ALLOWED_EXTENSIONS = frozenset({".txt", ".csv", ".tsv"})
 
-# AAVSO data column order, in the sequence the spec requires. The AAVSO
-# sample files prepend a row of these names with "#" before the data.
-DATA_COLUMNS = (
-    "STARID",
-    "DATE",
-    "MAGNITUDE",
-    "MAGERR",
-    "FILTER",
-    "TRANS",
-    "MTYPE",
-    "CNAME",
-    "CMAG",
-    "KNAME",
-    "KMAG",
-    "AIRMASS",
-    "GROUP",
-    "CHART",
-    "NOTES",
-)
-
-# Per-field maximum character counts pulled from the spec. Fields not listed
-# (FILTER, TRANS, MTYPE, NOTES) have no length limit. AIRMASS is special: the
-# spec says it should be truncated rather than rejected.
+# AAVSO data columns in spec order with their max character counts. ``None``
+# means the field has no length limit. The AAVSO sample files prepend a row
+# of these names with "#" before the data. AIRMASS is special: the spec says
+# it should be truncated rather than rejected; ``_enforce_limit`` handles
+# that.
 FIELD_LIMITS = {
     "STARID": 30,
     "DATE": 16,
     "MAGNITUDE": 8,
     "MAGERR": 6,
+    "FILTER": None,
+    "TRANS": None,
+    "MTYPE": None,
     "CNAME": 20,
     "CMAG": 8,
     "KNAME": 20,
@@ -62,6 +47,7 @@ FIELD_LIMITS = {
     "AIRMASS": 7,
     "GROUP": 5,
     "CHART": 20,
+    "NOTES": None,
 }
 
 
@@ -131,6 +117,7 @@ def _format_mag(value, field_name):
 
 
 def _format_magerr(value):
+    """Format magnitude error as a 3-decimal float; 'na' for non-finite values."""
     f = _to_float(value)
     if not np.isfinite(f):
         return "na"
@@ -170,6 +157,7 @@ def _coerce_group(value):
 
 
 def _format_airmass(value):
+    """Format an airmass as a 4-decimal float; return 'na' for non-finite values."""
     f = _to_float(value)
     if not np.isfinite(f):
         return "na"
@@ -265,7 +253,7 @@ def write_aavso_extended(
             f"extensions; got {path.suffix!r}."
         )
 
-    delimiter = header.data_delimiter()
+    delimiter = header.data_delimiter
 
     # Required identifier fields supplied by the caller. The AAVSO spec
     # forbids leading/trailing whitespace and empty values; we strip and
@@ -379,7 +367,7 @@ def write_aavso_extended(
         "CMAG": ["na"] * n,
         "KNAME": [str(check_name)] * n,
         "KMAG": kmag_values,
-        "AIRMASS": [_enforce_limit("AIRMASS", v) for v in airmass_values],
+        "AIRMASS": airmass_values,
         "GROUP": [group_field] * n,
         "CHART": [str(chart)] * n,
         "NOTES": [notes_field] * n,
@@ -388,9 +376,9 @@ def write_aavso_extended(
     # Enforce length limits on every column that has one (AIRMASS already
     # truncated above). Validation fires before any I/O.
     out_table = Table()
-    for name in DATA_COLUMNS:
+    for name, limit in FIELD_LIMITS.items():
         values = columns[name]
-        if name in FIELD_LIMITS and name != "AIRMASS":
+        if limit is not None:
             values = [_enforce_limit(name, v) for v in values]
         out_table[name] = Column(values, dtype=str)
 
@@ -402,7 +390,7 @@ def write_aavso_extended(
     # validation and the per-field user-input checks above (which only
     # cover string fields supplied by the caller) but would produce a
     # mis-parseable file.
-    for col_name in DATA_COLUMNS:
+    for col_name in FIELD_LIMITS:
         if delimiter in col_name:
             raise ValueError(
                 f"AAVSO column name {col_name!r} contains the configured "
@@ -426,7 +414,7 @@ def write_aavso_extended(
     # and translates the whole file to the platform's native terminator.
     data_text = buf.getvalue().replace("\r\n", "\n").replace("\r", "\n")
 
-    column_header = "#" + delimiter.join(DATA_COLUMNS)
+    column_header = "#" + delimiter.join(FIELD_LIMITS)
 
     # utf-8 because user-supplied notes/software fields can contain
     # non-ASCII characters; default newline=None translates "\n" → os.linesep

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -206,7 +206,7 @@ def write_aavso_extended(
     ----------
     phot_data : `stellarphot.PhotometryData`
         Table of photometry results. Must contain at least the target star
-        and the check star, paired by ``(file, passband)``.
+        and the check star, paired by ``(date-obs, passband)``.
 
     path : str or `pathlib.Path`
         Destination file. Must have a ``.txt``, ``.csv`` or ``.tsv`` suffix.
@@ -404,6 +404,27 @@ def write_aavso_extended(
         if name in FIELD_LIMITS and name != "AIRMASS":
             values = [_enforce_limit(name, v) for v in values]
         out_table[name] = Column(values, dtype=str)
+
+    # Final sweep: the configured delimiter must not appear anywhere in the
+    # rendered data table or in the AAVSO column names. The header model
+    # permits any printable ASCII except |/#/space, but values like "."
+    # collide with every formatted numeric field and an uppercase letter
+    # such as "A" appears in the AAVSO column names — both pass header
+    # validation and the per-field user-input checks above (which only
+    # cover string fields supplied by the caller) but would produce a
+    # mis-parseable file.
+    for col_name in DATA_COLUMNS:
+        if delimiter in col_name:
+            raise ValueError(
+                f"AAVSO column name {col_name!r} contains the configured "
+                f"delimiter {delimiter!r}; choose a different delimiter."
+            )
+        for value in out_table[col_name]:
+            if delimiter in value:
+                raise ValueError(
+                    f"AAVSO field {col_name}={value!r} contains the configured "
+                    f"delimiter {delimiter!r}; choose a different delimiter."
+                )
 
     # Write the data rows to a string buffer via astropy's ascii writer, then
     # assemble the final file with the parameter header and the

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -180,6 +180,7 @@ def write_aavso_extended(
     trans=False,
     group=None,
     notes="na",
+    drop_missing_check=True,
 ):
     """Write an AAVSO Extended File Format submission for ensemble photometry.
 
@@ -225,6 +226,12 @@ def write_aavso_extended(
 
     notes : str, optional
         Text written into the ``NOTES`` column. Defaults to ``"na"``.
+
+    drop_missing_check : bool, optional
+        How to handle target rows that have no check-star observation at the
+        same ``(date-obs, passband)``. ``True`` (default) silently drops
+        those target rows; ``False`` raises ``ValueError``. If dropping
+        leaves no rows to write, ``ValueError`` is raised regardless.
     """
     if not isinstance(header, AAVSOSubmissionHeader):
         raise TypeError(
@@ -334,15 +341,27 @@ def write_aavso_extended(
     # Detect target rows without a matching check observation. After a left
     # join those rows have the check magnitude masked.
     check_mag_col = f"{mag_column}_check"
-    if hasattr(paired[check_mag_col], "mask") and paired[check_mag_col].mask.any():
-        missing = paired[paired[check_mag_col].mask][["date-obs", "passband"]]
-        first = missing[0]
-        raise ValueError(
-            "No check-star row found for "
-            f"(date-obs={first['date-obs']!r}, passband={first['passband']!r}); "
-            f"check_star_id={check_star_id!r} must have a matching "
-            "observation for every target observation."
-        )
+    has_mask = hasattr(paired[check_mag_col], "mask")
+    if has_mask and paired[check_mag_col].mask.any():
+        unmatched = paired[check_mag_col].mask
+        if drop_missing_check:
+            paired = paired[~unmatched]
+            if len(paired) == 0:
+                raise ValueError(
+                    f"drop_missing_check=True removed every target row; no "
+                    f"target observations have a matching check-star "
+                    f"observation for check_star_id={check_star_id!r}."
+                )
+        else:
+            missing = paired[unmatched][["date-obs", "passband"]]
+            first = missing[0]
+            raise ValueError(
+                "No check-star row found for "
+                f"(date-obs={first['date-obs']!r}, passband={first['passband']!r}); "
+                f"check_star_id={check_star_id!r} must have a matching "
+                "observation for every target observation. Pass "
+                "drop_missing_check=True to drop unmatched target rows."
+            )
 
     # Preserve a stable, easy-to-compare row order.
     paired.sort(["date-obs", "passband"])

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -88,6 +88,7 @@ def _require_nonblank(name, value):
 
 
 def _reject_delimiter_or_newline(name, value, delimiter):
+    """Reject string fields that contain the configured delimiter or a newline."""
     if delimiter in value:
         raise ValueError(
             f"AAVSO field {name}={value!r} contains the configured delimiter "
@@ -294,7 +295,7 @@ def write_aavso_extended(
         raise ValueError(f"No rows in phot_data have star_id={check_star_id!r}.")
 
     # Reject invalid filters before doing any heavier work.
-    for passband in phot_data["passband"][target_mask]:
+    for passband in set(phot_data["passband"][target_mask]):
         if not _is_valid_filter(passband):
             raise ValueError(
                 f"Row passband {passband!r} is not a valid AAVSO filter. "
@@ -380,8 +381,7 @@ def write_aavso_extended(
         "NOTES": [notes_field] * n,
     }
 
-    # Enforce length limits on every column that has one (AIRMASS already
-    # truncated above). Validation fires before any I/O.
+    # Enforce length limits on every column that has one. Validation fires before I/O.
     out_table = Table()
     for name, limit in FIELD_LIMITS.items():
         values = columns[name]

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -12,9 +12,11 @@ v1 limitations:
 - ``OBSTYPE`` is hardcoded to ``CCD``.
 """
 
+import io
 import math
 from pathlib import Path
 
+from astropy.table import Column, QTable, Table, join
 from astropy.time import Time
 
 from stellarphot.settings.aavso_models import AAVSOFilters
@@ -25,7 +27,8 @@ __all__ = ["write_aavso_extended"]
 
 ALLOWED_EXTENSIONS = frozenset({".txt", ".csv", ".tsv"})
 
-# AAVSO data column order, in the sequence the spec requires.
+# AAVSO data column order, in the sequence the spec requires. The AAVSO
+# sample files prepend a row of these names with "#" before the data.
 DATA_COLUMNS = (
     "STARID",
     "DATE",
@@ -86,27 +89,29 @@ def _enforce_limit(name, value):
     )
 
 
-def _format_jd(date_obs, exposure):
-    """JD at mid-exposure in UT. ``exposure`` carries seconds units."""
-    midpoint = Time(date_obs) + exposure / 2
-    return f"{midpoint.jd:.5f}"
-
-
 def _to_float(value):
-    """Coerce a table cell (possibly an astropy ``Quantity``) to a plain float.
-
-    Columns in ``PhotometryData`` may carry units (e.g. ``mag_error`` has
-    ``1/adu`` in the test fixture, ``exposure`` has seconds). For string
-    formatting we only need the numeric magnitude, so strip the unit.
-    """
+    """Coerce a value (possibly an astropy ``Quantity``) to a plain float."""
     try:
         return float(value.value)
     except AttributeError:
         return float(value)
 
 
-def _format_float(value, decimals):
-    return f"{_to_float(value):.{decimals}f}"
+def _format_mag(value):
+    return f"{_to_float(value):.4f}"
+
+
+def _format_magerr(value):
+    if value is None:
+        return "na"
+    f = _to_float(value)
+    if math.isnan(f):
+        return "na"
+    return f"{f:.3f}"
+
+
+def _format_airmass(value):
+    return f"{_to_float(value):.4f}"
 
 
 def write_aavso_extended(
@@ -191,7 +196,6 @@ def write_aavso_extended(
 
     delimiter = header.data_delimiter()
 
-    # Split the table into target and check-star rows.
     target_mask = phot_data["star_id"] == target_star_id
     check_mask = phot_data["star_id"] == check_star_id
 
@@ -200,21 +204,8 @@ def write_aavso_extended(
     if not check_mask.any():
         raise ValueError(f"No rows in phot_data have star_id={check_star_id!r}.")
 
-    target_rows = phot_data[target_mask]
-    check_rows = phot_data[check_mask]
-
-    # Index check star rows by (file, passband) for fast lookup.
-    check_index = {}
-    for row in check_rows:
-        key = (row["file"], row["passband"])
-        check_index[key] = row
-
-    group_field = "na" if group is None else str(group)
-    trans_field = "YES" if trans else "NO"
-
-    data_lines = []
-    for row in target_rows:
-        passband = row["passband"]
+    # Reject invalid filters before doing any heavier work.
+    for passband in phot_data["passband"][target_mask]:
         if not _is_valid_filter(passband):
             raise ValueError(
                 f"Row passband {passband!r} is not a valid AAVSO filter. "
@@ -222,65 +213,108 @@ def write_aavso_extended(
                 "before exporting."
             )
 
-        key = (row["file"], passband)
-        if key not in check_index:
-            raise ValueError(
-                "No check-star row found for "
-                f"(file={row['file']!r}, passband={passband!r}); "
-                f"check_star_id={check_star_id!r} must have a matching "
-                "observation for every target observation."
-            )
-        check_row = check_index[key]
+    # Pull just the columns we need from each side so the join result is small
+    # and the renamed columns are unambiguous.
+    target_cols = [
+        "file",
+        "passband",
+        "date-obs",
+        "exposure",
+        "airmass",
+        mag_column,
+        mag_error_column,
+    ]
+    check_cols = ["file", "passband", mag_column]
 
-        starid = _enforce_limit("STARID", str(target_name))
-        date = _enforce_limit("DATE", _format_jd(row["date-obs"], row["exposure"]))
-        magnitude = _enforce_limit("MAGNITUDE", _format_float(row[mag_column], 4))
+    target_subset = QTable(phot_data[target_mask][target_cols], copy=True)
+    check_subset = QTable(phot_data[check_mask][check_cols], copy=True)
 
-        err_value = row[mag_error_column]
-        if err_value is None:
-            magerr = "na"
-        else:
-            err_float = _to_float(err_value)
-            if math.isnan(err_float):
-                magerr = "na"
-            else:
-                magerr = _enforce_limit("MAGERR", _format_float(err_float, 3))
+    # Join on (file, passband) — this replaces the manual lookup dictionary
+    # and naturally drops target rows that have no matching check observation.
+    paired = join(
+        target_subset,
+        check_subset,
+        keys=["file", "passband"],
+        table_names=["target", "check"],
+        join_type="left",
+    )
 
-        filter_field = _enforce_limit("FILTER", str(passband))
-        cname = _enforce_limit("CNAME", "ENSEMBLE")
-        cmag = _enforce_limit("CMAG", "na")
-        kname = _enforce_limit("KNAME", str(check_name))
-        kmag = _enforce_limit("KMAG", _format_float(check_row[mag_column], 4))
-        airmass = _enforce_limit("AIRMASS", f"{_to_float(row['airmass']):.4f}")
-        group_value = _enforce_limit("GROUP", group_field)
-        chart_field = _enforce_limit("CHART", str(chart))
-        notes_field = str(notes) if notes is not None else "na"
-        if not notes_field:
-            notes_field = "na"
+    # Detect target rows without a matching check observation. After a left
+    # join those rows have the check magnitude masked.
+    check_mag_col = f"{mag_column}_check"
+    if hasattr(paired[check_mag_col], "mask") and paired[check_mag_col].mask.any():
+        missing = paired[paired[check_mag_col].mask][["file", "passband"]]
+        first = missing[0]
+        raise ValueError(
+            "No check-star row found for "
+            f"(file={first['file']!r}, passband={first['passband']!r}); "
+            f"check_star_id={check_star_id!r} must have a matching "
+            "observation for every target observation."
+        )
 
-        fields = [
-            starid,
-            date,
-            magnitude,
-            magerr,
-            filter_field,
-            trans_field,
-            "STD",
-            cname,
-            cmag,
-            kname,
-            kmag,
-            airmass,
-            group_value,
-            chart_field,
-            notes_field,
-        ]
-        data_lines.append(delimiter.join(fields))
+    # Preserve the original target row order so the output is stable and easy
+    # to compare against the input table.
+    paired.sort(["file", "passband"])
+
+    group_field = "na" if group is None else str(group)
+    trans_field = "YES" if trans else "NO"
+    notes_field = str(notes) if notes else "na"
+
+    n = len(paired)
+    target_mag_col = f"{mag_column}_target"
+
+    # Build per-row string columns in AAVSO order.
+    date_values = [
+        f"{(Time(row['date-obs']) + row['exposure'] / 2).jd:.5f}" for row in paired
+    ]
+    mag_values = [_format_mag(v) for v in paired[target_mag_col]]
+    err_values = [_format_magerr(v) for v in paired[mag_error_column]]
+    kmag_values = [_format_mag(v) for v in paired[check_mag_col]]
+    airmass_values = [_format_airmass(v) for v in paired["airmass"]]
+    filter_values = [str(p) for p in paired["passband"]]
+
+    columns = {
+        "STARID": [str(target_name)] * n,
+        "DATE": date_values,
+        "MAGNITUDE": mag_values,
+        "MAGERR": err_values,
+        "FILTER": filter_values,
+        "TRANS": [trans_field] * n,
+        "MTYPE": ["STD"] * n,
+        "CNAME": ["ENSEMBLE"] * n,
+        "CMAG": ["na"] * n,
+        "KNAME": [str(check_name)] * n,
+        "KMAG": kmag_values,
+        "AIRMASS": [_enforce_limit("AIRMASS", v) for v in airmass_values],
+        "GROUP": [group_field] * n,
+        "CHART": [str(chart)] * n,
+        "NOTES": [notes_field] * n,
+    }
+
+    # Enforce length limits on every column that has one (AIRMASS already
+    # truncated above). Validation fires before any I/O.
+    out_table = Table()
+    for name in DATA_COLUMNS:
+        values = columns[name]
+        if name in FIELD_LIMITS and name != "AIRMASS":
+            values = [_enforce_limit(name, v) for v in values]
+        out_table[name] = Column(values, dtype=str)
+
+    # Write the data rows to a string buffer via astropy's ascii writer, then
+    # assemble the final file with the parameter header and the
+    # column-name row prefixed with "#".
+    buf = io.StringIO()
+    out_table.write(buf, format="ascii.no_header", delimiter=delimiter)
+    data_text = buf.getvalue()
+
+    column_header = "#" + delimiter.join(DATA_COLUMNS)
 
     with open(path, "w") as f:
         for line in header.header_lines():
             f.write(line + "\n")
-        for line in data_lines:
-            f.write(line + "\n")
+        f.write(column_header + "\n")
+        f.write(data_text)
+        if not data_text.endswith("\n"):
+            f.write("\n")
 
     return path

--- a/stellarphot/io/aavso.py
+++ b/stellarphot/io/aavso.py
@@ -116,10 +116,7 @@ def _reject_delimiter_or_newline(name, value, delimiter):
 
 def _to_float(value):
     """Coerce a value (possibly an astropy ``Quantity``) to a plain float."""
-    try:
-        return float(value.value)
-    except AttributeError:
-        return float(value)
+    return float(getattr(value, "value", value))
 
 
 def _format_mag(value, field_name):
@@ -134,8 +131,6 @@ def _format_mag(value, field_name):
 
 
 def _format_magerr(value):
-    if value is None:
-        return "na"
     f = _to_float(value)
     if not np.isfinite(f):
         return "na"
@@ -150,7 +145,6 @@ def _validate_trans(value):
             f"trans must be a bool (True or False); got "
             f"{type(value).__name__} ({value!r})."
         )
-    return value
 
 
 def _coerce_group(value):
@@ -176,8 +170,6 @@ def _coerce_group(value):
 
 
 def _format_airmass(value):
-    if value is None:
-        return "na"
     f = _to_float(value)
     if not np.isfinite(f):
         return "na"
@@ -360,8 +352,6 @@ def write_aavso_extended(
     paired.sort(["date-obs", "passband"])
 
     group_field = "na" if group is None else str(group)
-    if group is not None:
-        _reject_delimiter_or_newline("group", group_field, delimiter)
     trans_field = "YES" if trans else "NO"
     notes_field = notes
 
@@ -369,9 +359,8 @@ def write_aavso_extended(
     target_mag_col = f"{mag_column}_target"
 
     # Build per-row string columns in AAVSO order.
-    date_values = [
-        f"{(Time(row['date-obs']) + row['exposure'] / 2).jd:.5f}" for row in paired
-    ]
+    mid_jd = (Time(paired["date-obs"]) + paired["exposure"] / 2).jd
+    date_values = [f"{jd:.5f}" for jd in mid_jd]
     mag_values = [_format_mag(v, "MAGNITUDE") for v in paired[target_mag_col]]
     err_values = [_format_magerr(v) for v in paired[mag_error_column]]
     kmag_values = [_format_mag(v, "KMAG") for v in paired[check_mag_col]]

--- a/stellarphot/io/aavso_submission_schema.yml
+++ b/stellarphot/io/aavso_submission_schema.yml
@@ -1,3 +1,24 @@
+file_format:
+  case_sensitive: false
+  allowed_extensions:
+    - .txt
+    - .csv
+    - .tsv
+  parameter_prefix: |
+    Header parameters must begin with a "#" at the start of the line.
+    Personal comments may also be added after a "#"; they are ignored by
+    the AAVSO loader but retained in the permanent archive. Blank lines
+    between header and data are not allowed unless commented with "#".
+  field_whitespace: |
+    Do not put a space at the beginning or end of a field.
+  missing_value: |
+    Optional fields with no value must be written as the literal string "na".
+  notes:
+    - The format has two components: parameters (header) and data.
+    - One observation per line; fields separated by the DELIM character.
+    - OBSCODE and DATE may also appear inline within the data; subsequent
+      observations are then attributed to the new value.
+
 comments:
   TYPE:
     summary: |
@@ -201,7 +222,7 @@ data:
   AIRMASS:
     summary: |
       Airmass of observation Limit 7 characters - entry will be truncated
-      if longer than that. If not present, use "na".\
+      if longer than that. If not present, use "na".
     limit: 7
   GROUP:
     summary: |

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -305,8 +305,8 @@ class TestCheckStarPairing:
         bad = phot_table[
             ~mask_check | (np.arange(len(phot_table)) != np.where(mask_check)[0][0])
         ]
-        # Sanity: target still has 2 files, but check star is now missing
-        # one (file, passband) pair.
+        # Sanity: target still has 2 observations, but check star is now
+        # missing one (date-obs, passband) pair.
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match="No check-star row"):
             write_aavso_extended(bad, out, **writer_kwargs)

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -80,13 +80,22 @@ class TestHeaderAndFileFormat:
         # Hardcoded OBSTYPE
         assert lines[5] == "#OBSTYPE=CCD"
 
+    def test_column_header_row_follows_parameter_header(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        lines = out.read_text().splitlines()
+        assert lines[6] == "#" + ",".join(DATA_COLUMNS)
+
     def test_data_uses_configured_delimiter(self, tmp_path, phot_table, writer_kwargs):
         # Default delim=","
         out = tmp_path / "sub.csv"
         write_aavso_extended(phot_table, out, **writer_kwargs)
         lines = out.read_text().splitlines()
-        # First data row should have 14 commas (15 fields)
-        assert lines[6].count(",") == len(DATA_COLUMNS) - 1
+        # First data row (line 7, after 6 parameter lines + column header) has
+        # 14 commas (15 fields).
+        assert lines[7].count(",") == len(DATA_COLUMNS) - 1
 
     def test_delim_comma_writes_comma_in_header_but_separates_with_commas(
         self, tmp_path, phot_table, writer_kwargs
@@ -103,7 +112,7 @@ class TestHeaderAndFileFormat:
         lines = out.read_text().splitlines()
         assert lines[3] == "#DELIM=comma"
         # Data row still uses literal commas as separators
-        assert lines[6].count(",") == len(DATA_COLUMNS) - 1
+        assert lines[7].count(",") == len(DATA_COLUMNS) - 1
 
     def test_delim_tab_writes_tab_in_data(self, tmp_path, phot_table, writer_kwargs):
         writer_kwargs["header"] = AAVSOSubmissionHeader(
@@ -117,7 +126,7 @@ class TestHeaderAndFileFormat:
         write_aavso_extended(phot_table, out, **writer_kwargs)
         lines = out.read_text().splitlines()
         assert lines[3] == "#DELIM=tab"
-        assert lines[6].count("\t") == len(DATA_COLUMNS) - 1
+        assert lines[7].count("\t") == len(DATA_COLUMNS) - 1
 
     def test_non_jd_date_format_raises(self, tmp_path, phot_table, writer_kwargs):
         writer_kwargs["header"] = AAVSOSubmissionHeader(

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -128,16 +128,27 @@ class TestHeaderAndFileFormat:
         assert lines[3] == "#DELIM=tab"
         assert lines[7].count("\t") == len(DATA_COLUMNS) - 1
 
-    def test_non_jd_date_format_raises(self, tmp_path, phot_table, writer_kwargs):
+    @pytest.mark.parametrize("date_format", ["HJD", "EXCEL"])
+    def test_non_jd_date_format_raises(
+        self, tmp_path, phot_table, writer_kwargs, date_format
+    ):
         writer_kwargs["header"] = AAVSOSubmissionHeader(
             type="EXTENDED",
             obscode="ABC",
             software="stellarphot test",
             delim=",",
-            date_format="HJD",
+            date_format=date_format,
         )
         out = tmp_path / "sub.csv"
         with pytest.raises(NotImplementedError, match="JD"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    def test_header_must_be_submission_header_instance(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        writer_kwargs["header"] = {"obscode": "ABC", "delim": ","}
+        out = tmp_path / "sub.csv"
+        with pytest.raises(TypeError, match="header"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
 
@@ -254,19 +265,38 @@ class TestTargetRows:
         assert set(rows["GROUP"]) == {7}
 
     def test_airmass_truncates(self, tmp_path, phot_table, writer_kwargs):
-        # Force a very long airmass value
+        # Format is {f:.4f}; 1234.56789 → "1234.5679" (9 chars), truncated to 7.
         long_data = phot_table.copy()
-        long_data["airmass"] = 1.123456789
+        long_data["airmass"] = 1234.56789
         out = tmp_path / "sub.csv"
         write_aavso_extended(long_data, out, **writer_kwargs)
-        rows = _read_data_rows(out)
-        for value in rows["AIRMASS"]:
-            assert len(str(value)) <= 7
+        lines = out.read_text().splitlines()
+        airmass_idx = DATA_COLUMNS.index("AIRMASS")
+        # Data rows begin after 6 parameter lines + 1 column-header line.
+        for line in lines[7:]:
+            fields = line.split(",")
+            assert fields[airmass_idx] == "1234.56"
 
     def test_field_too_long_raises(self, tmp_path, phot_table, writer_kwargs):
         writer_kwargs["target_name"] = "x" * 31  # exceeds STARID limit of 30
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match="STARID"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize(
+        "field,value,column",
+        [
+            ("check_name", "x" * 21, "KNAME"),  # KNAME limit 20
+            ("chart", "x" * 21, "CHART"),  # CHART limit 20
+            ("group", 123456, "GROUP"),  # GROUP limit 5
+        ],
+    )
+    def test_field_too_long_raises_other_fields(
+        self, tmp_path, phot_table, writer_kwargs, field, value, column
+    ):
+        writer_kwargs[field] = value
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match=column):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
 
@@ -320,6 +350,12 @@ class TestCheckStarPairing:
         with pytest.raises(ValueError, match="No rows in phot_data"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
+    def test_missing_check_star_raises(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["check_star_id"] = 9999
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="No rows in phot_data"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
 
 # ---- Step 5: PhotometryData convenience method -----------------------------
 
@@ -343,11 +379,12 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="must be different"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
+    @pytest.mark.parametrize("value", ["   ", None])
     @pytest.mark.parametrize("field", ["target_name", "check_name", "chart"])
     def test_blank_required_identifier_rejected(
-        self, tmp_path, phot_table, writer_kwargs, field
+        self, tmp_path, phot_table, writer_kwargs, field, value
     ):
-        writer_kwargs[field] = "   "
+        writer_kwargs[field] = value
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match=field):
             write_aavso_extended(phot_table, out, **writer_kwargs)
@@ -380,6 +417,22 @@ class TestInputValidation:
         writer_kwargs["notes"] = "line1\nline2"
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match="newline"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    def test_delim_in_group_field_rejected(self, tmp_path, phot_table, writer_kwargs):
+        # "-" is a legal AAVSO delim but appears in str(-7). The default
+        # target/check/chart/notes strings contain no "-", so the writer
+        # reaches the group-field check before the per-column sweep.
+        writer_kwargs["header"] = AAVSOSubmissionHeader(
+            type="EXTENDED",
+            obscode="ABC",
+            software="stellarphot test",
+            delim="-",
+            date_format="JD",
+        )
+        writer_kwargs["group"] = -7
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="group"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
     @pytest.mark.parametrize("delim", [".", "n", "a", "A"])
@@ -524,3 +577,23 @@ class TestKwargTypeValidation:
         out = tmp_path / "sub.csv"
         with pytest.raises(TypeError, match="group"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
+
+
+# ---- Private helper coverage ----------------------------------------------
+
+
+class TestPrivateHelpers:
+    """The None branches in these helpers aren't reachable from typical
+    PhotometryData inputs (astropy columns yield masked sentinels, not None),
+    but the writer keeps them as a defensive fallback. Cover them directly so
+    the contract is asserted."""
+
+    def test_format_magerr_none_returns_na(self):
+        from stellarphot.io.aavso import _format_magerr
+
+        assert _format_magerr(None) == "na"
+
+    def test_format_airmass_none_returns_na(self):
+        from stellarphot.io.aavso import _format_airmass
+
+        assert _format_airmass(None) == "na"

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -328,3 +328,107 @@ class TestPhotometryDataMethod:
         write_aavso_extended(phot_table, func_out, **writer_kwargs)
         phot_table.write_aavso_extended(meth_out, **writer_kwargs)
         assert func_out.read_bytes() == meth_out.read_bytes()
+
+
+# ---- Input validation ------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_target_and_check_must_differ(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["check_star_id"] = writer_kwargs["target_star_id"]
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="must be different"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("field", ["target_name", "check_name", "chart"])
+    def test_blank_required_identifier_rejected(
+        self, tmp_path, phot_table, writer_kwargs, field
+    ):
+        writer_kwargs[field] = "   "
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match=field):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    def test_identifiers_are_stripped(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["target_name"] = "  V0533 Her  "
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["STARID"]) == {"V0533 Her"}
+
+    def test_blank_notes_becomes_na(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["notes"] = "   "
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["NOTES"]) == {"na"}
+
+    @pytest.mark.parametrize("field", ["target_name", "check_name", "chart", "notes"])
+    def test_delimiter_in_field_rejected(
+        self, tmp_path, phot_table, writer_kwargs, field
+    ):
+        # Default delim is comma; injecting one would create an extra column.
+        writer_kwargs[field] = "bad,value"
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="delimiter"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    def test_newline_in_field_rejected(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["notes"] = "line1\nline2"
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="newline"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+
+# ---- Non-finite numeric handling -------------------------------------------
+
+
+class TestNonFiniteValues:
+    def test_nan_target_magnitude_raises(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        target_mask = bad["star_id"] == writer_kwargs["target_star_id"]
+        idx = np.where(target_mask)[0][0]
+        bad["mag_inst"][idx] = float("nan")
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="MAGNITUDE"):
+            write_aavso_extended(bad, out, **writer_kwargs)
+
+    def test_nan_check_magnitude_raises(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        check_mask = bad["star_id"] == writer_kwargs["check_star_id"]
+        idx = np.where(check_mask)[0][0]
+        bad["mag_inst"][idx] = float("nan")
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="KMAG"):
+            write_aavso_extended(bad, out, **writer_kwargs)
+
+    def test_nan_magerr_becomes_na(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        target_mask = bad["star_id"] == writer_kwargs["target_star_id"]
+        idx = np.where(target_mask)[0][0]
+        bad["mag_error"][idx] = float("nan")
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(bad, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        # At least one MAGERR cell should read "na"; the rest are numeric.
+        assert "na" in {str(v) for v in rows["MAGERR"]}
+
+    def test_inf_magerr_becomes_na(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        target_mask = bad["star_id"] == writer_kwargs["target_star_id"]
+        idx = np.where(target_mask)[0][0]
+        bad["mag_error"][idx] = float("inf")
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(bad, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert "na" in {str(v) for v in rows["MAGERR"]}
+
+    def test_nan_airmass_becomes_na(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        target_mask = bad["star_id"] == writer_kwargs["target_star_id"]
+        idx = np.where(target_mask)[0][0]
+        bad["airmass"][idx] = float("nan")
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(bad, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert "na" in {str(v) for v in rows["AIRMASS"]}

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -97,6 +97,22 @@ class TestHeaderAndFileFormat:
         # 14 commas (15 fields).
         assert lines[7].count(",") == len(DATA_COLUMNS) - 1
 
+    def test_line_endings_are_uniform(self, tmp_path, phot_table, writer_kwargs):
+        # The writer uses native line endings (LF on Unix, CRLF on Windows),
+        # but they must be uniform across the whole file. The earlier bug
+        # mixed LF (from our explicit f.write(line + "\n")) with CRLF (from
+        # astropy's ascii writer on Windows), and the double text-mode
+        # translation produced "\r\r\n" — splitlines() then saw spurious
+        # empty rows.
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        raw = out.read_bytes()
+        assert b"\r\r" not in raw
+        n_cr = raw.count(b"\r")
+        n_lf = raw.count(b"\n")
+        # Either LF-only or every CR pairs with an LF (uniform CRLF).
+        assert n_cr == 0 or n_cr == n_lf
+
     def test_delim_comma_writes_comma_in_header_but_separates_with_commas(
         self, tmp_path, phot_table, writer_kwargs
     ):
@@ -265,17 +281,15 @@ class TestTargetRows:
         assert set(rows["GROUP"]) == {7}
 
     def test_airmass_truncates(self, tmp_path, phot_table, writer_kwargs):
-        # Format is {f:.4f}; 1234.56789 → "1234.5679" (9 chars), truncated to 7.
+        # Format is {f:.4f}; 1234.56789 → "1234.5679" (9 chars). The AIRMASS
+        # limit is 7 chars, so the writer must truncate to "1234.56".
         long_data = phot_table.copy()
         long_data["airmass"] = 1234.56789
         out = tmp_path / "sub.csv"
         write_aavso_extended(long_data, out, **writer_kwargs)
-        lines = out.read_text().splitlines()
-        airmass_idx = DATA_COLUMNS.index("AIRMASS")
-        # Data rows begin after 6 parameter lines + 1 column-header line.
-        for line in lines[7:]:
-            fields = line.split(",")
-            assert fields[airmass_idx] == "1234.56"
+        text = out.read_text()
+        assert "1234.5679" not in text
+        assert "1234.56" in text
 
     def test_field_too_long_raises(self, tmp_path, phot_table, writer_kwargs):
         writer_kwargs["target_name"] = "x" * 31  # exceeds STARID limit of 30

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -432,3 +432,72 @@ class TestNonFiniteValues:
         write_aavso_extended(bad, out, **writer_kwargs)
         rows = _read_data_rows(out)
         assert "na" in {str(v) for v in rows["AIRMASS"]}
+
+
+# ---- Kwarg type validation -------------------------------------------------
+
+
+class TestKwargTypeValidation:
+    @pytest.mark.parametrize("value", ["False", "NO", "YES", "yes", "", 0, 1])
+    def test_trans_rejects_non_bool(self, tmp_path, phot_table, writer_kwargs, value):
+        writer_kwargs["trans"] = value
+        out = tmp_path / "sub.csv"
+        with pytest.raises(TypeError, match="trans"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_trans_accepts_bool(self, tmp_path, phot_table, writer_kwargs, value):
+        writer_kwargs["trans"] = value
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["TRANS"]) == {"YES" if value else "NO"}
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (7, 7),
+            ("5", 5),
+            (5.0, 5),
+        ],
+    )
+    def test_group_accepts_int_like(
+        self, tmp_path, phot_table, writer_kwargs, value, expected
+    ):
+        writer_kwargs["group"] = value
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["GROUP"]) == {expected}
+
+    def test_group_accepts_numpy_int(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["group"] = np.int64(42)
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["GROUP"]) == {42}
+
+    @pytest.mark.parametrize("value", ["abc", "5.5", [], {}, object()])
+    def test_group_rejects_non_int_like(
+        self, tmp_path, phot_table, writer_kwargs, value
+    ):
+        writer_kwargs["group"] = value
+        out = tmp_path / "sub.csv"
+        with pytest.raises((TypeError, ValueError), match="group"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("value", [5.5, 0.1, float("inf"), float("nan")])
+    def test_group_rejects_non_integer_float(
+        self, tmp_path, phot_table, writer_kwargs, value
+    ):
+        writer_kwargs["group"] = value
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="group"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_group_rejects_bool(self, tmp_path, phot_table, writer_kwargs, value):
+        writer_kwargs["group"] = value
+        out = tmp_path / "sub.csv"
+        with pytest.raises(TypeError, match="group"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -279,17 +279,20 @@ class TestCheckStarPairing:
         write_aavso_extended(phot_table, out, **writer_kwargs)
         rows = _read_data_rows(out)
 
-        # Build lookup of (file, passband) -> check mag
+        # Build lookup of (date-obs, passband) -> check mag, matching the
+        # writer's join key. Using (file, passband) would silently pass even
+        # if the writer regressed for fixtures with reused filenames.
         check_rows = phot_table[phot_table["star_id"] == writer_kwargs["check_star_id"]]
         check_lookup = {
-            (r["file"], r["passband"]): float(r["mag_inst"]) for r in check_rows
+            (str(r["date-obs"]), r["passband"]): float(r["mag_inst"])
+            for r in check_rows
         }
 
         target_rows = phot_table[
             phot_table["star_id"] == writer_kwargs["target_star_id"]
         ]
         for written_kmag, src in zip(rows["KMAG"], target_rows, strict=True):
-            expected = check_lookup[(src["file"], src["passband"])]
+            expected = check_lookup[(str(src["date-obs"]), src["passband"])]
             assert abs(float(written_kmag) - expected) < 1e-4
 
     def test_kname_is_check_name_kwarg(self, tmp_path, phot_table, writer_kwargs):
@@ -377,6 +380,26 @@ class TestInputValidation:
         writer_kwargs["notes"] = "line1\nline2"
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match="newline"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("delim", [".", "n", "a", "A"])
+    def test_delimiter_collides_with_rendered_field(
+        self, tmp_path, phot_table, writer_kwargs, delim
+    ):
+        # "." appears in every formatted numeric field (DATE, MAGNITUDE,
+        # MAGERR, KMAG, AIRMASS); "n"/"a" appear in the literal missing value
+        # "na"; "A" appears in AAVSO column names (STARID, DATE, ...). All
+        # pass the header model's character check but produce mis-parseable
+        # output and must be rejected before any I/O.
+        writer_kwargs["header"] = AAVSOSubmissionHeader(
+            type="EXTENDED",
+            obscode="ABC",
+            software="stellarphot test",
+            delim=delim,
+            date_format="JD",
+        )
+        out = tmp_path / "sub.txt"
+        with pytest.raises(ValueError, match="delimiter"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
 

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -6,7 +6,7 @@ from astropy.utils.data import get_pkg_data_filename
 
 from stellarphot import PhotometryData
 from stellarphot.io.aavso import (
-    DATA_COLUMNS,
+    FIELD_LIMITS,
     write_aavso_extended,
 )
 from stellarphot.settings.aavso_submission import AAVSOSubmissionHeader
@@ -81,12 +81,12 @@ class TestHeaderAndFileFormat:
         assert lines[5] == "#OBSTYPE=CCD"
 
     def test_column_header_row_follows_parameter_header(
-        self, tmp_path, phot_table, writer_kwargs
+        self, tmp_path, phot_table, writer_kwargs, header
     ):
         out = tmp_path / "sub.csv"
         write_aavso_extended(phot_table, out, **writer_kwargs)
         lines = out.read_text().splitlines()
-        assert lines[6] == "#" + ",".join(DATA_COLUMNS)
+        assert lines[6] == "#" + header.data_delimiter.join(FIELD_LIMITS)
 
     def test_data_uses_configured_delimiter(self, tmp_path, phot_table, writer_kwargs):
         # Default delim=","
@@ -95,7 +95,7 @@ class TestHeaderAndFileFormat:
         lines = out.read_text().splitlines()
         # First data row (line 7, after 6 parameter lines + column header) has
         # 14 commas (15 fields).
-        assert lines[7].count(",") == len(DATA_COLUMNS) - 1
+        assert lines[7].count(",") == len(FIELD_LIMITS) - 1
 
     def test_line_endings_are_uniform(self, tmp_path, phot_table, writer_kwargs):
         # The writer uses native line endings (LF on Unix, CRLF on Windows),
@@ -128,7 +128,7 @@ class TestHeaderAndFileFormat:
         lines = out.read_text().splitlines()
         assert lines[3] == "#DELIM=comma"
         # Data row still uses literal commas as separators
-        assert lines[7].count(",") == len(DATA_COLUMNS) - 1
+        assert lines[7].count(",") == len(FIELD_LIMITS) - 1
 
     def test_delim_tab_writes_tab_in_data(self, tmp_path, phot_table, writer_kwargs):
         writer_kwargs["header"] = AAVSOSubmissionHeader(
@@ -142,7 +142,7 @@ class TestHeaderAndFileFormat:
         write_aavso_extended(phot_table, out, **writer_kwargs)
         lines = out.read_text().splitlines()
         assert lines[3] == "#DELIM=tab"
-        assert lines[7].count("\t") == len(DATA_COLUMNS) - 1
+        assert lines[7].count("\t") == len(FIELD_LIMITS) - 1
 
     @pytest.mark.parametrize("date_format", ["HJD", "EXCEL"])
     def test_non_jd_date_format_raises(
@@ -178,7 +178,7 @@ def _read_data_rows(path):
         format="no_header",
         delimiter=",",
         comment="#",
-        names=list(DATA_COLUMNS),
+        names=list(FIELD_LIMITS),
     )
 
 

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -1,0 +1,321 @@
+import numpy as np
+import pytest
+from astropy.io import ascii as ap_ascii
+from astropy.time import Time
+from astropy.utils.data import get_pkg_data_filename
+
+from stellarphot import PhotometryData
+from stellarphot.io.aavso import (
+    DATA_COLUMNS,
+    write_aavso_extended,
+)
+from stellarphot.settings.aavso_submission import AAVSOSubmissionHeader
+
+# ---- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def header():
+    return AAVSOSubmissionHeader(
+        type="EXTENDED",
+        obscode="ABC",
+        software="stellarphot test",
+        delim=",",
+        date_format="JD",
+    )
+
+
+@pytest.fixture
+def phot_table():
+    """The test photometry fixture, with no further modification.
+
+    The fixture has 8 stars, two files, passband ``SR`` (a valid AAVSO filter).
+    """
+    data_file = get_pkg_data_filename(
+        "data/test_photometry_data.ecsv", package="stellarphot.tests"
+    )
+    return PhotometryData.read(data_file)
+
+
+@pytest.fixture
+def writer_kwargs(header):
+    """Default kwargs for write_aavso_extended built against ``phot_table``.
+
+    Star 1 is the target, star 6 is the check star.
+    """
+    return dict(
+        header=header,
+        target_star_id=1,
+        target_name="V0533 Her",
+        check_star_id=6,
+        check_name="check1",
+        chart="X12345",
+        mag_column="mag_inst",
+        mag_error_column="mag_error",
+    )
+
+
+# ---- Step 2: skeleton + header --------------------------------------------
+
+
+class TestHeaderAndFileFormat:
+    def test_rejects_unknown_extensions(self, tmp_path, phot_table, writer_kwargs):
+        bad = tmp_path / "bad.foo"
+        with pytest.raises(ValueError, match="must have one of"):
+            write_aavso_extended(phot_table, bad, **writer_kwargs)
+
+    @pytest.mark.parametrize("ext", [".txt", ".csv", ".tsv"])
+    def test_accepts_allowed_extensions(self, tmp_path, phot_table, writer_kwargs, ext):
+        out = tmp_path / f"sub{ext}"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        assert out.exists()
+
+    def test_first_six_lines_are_header(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        lines = out.read_text().splitlines()
+        assert len(lines) >= 6
+        for line in lines[:6]:
+            assert line.startswith("#")
+        # Hardcoded OBSTYPE
+        assert lines[5] == "#OBSTYPE=CCD"
+
+    def test_data_uses_configured_delimiter(self, tmp_path, phot_table, writer_kwargs):
+        # Default delim=","
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        lines = out.read_text().splitlines()
+        # First data row should have 14 commas (15 fields)
+        assert lines[6].count(",") == len(DATA_COLUMNS) - 1
+
+    def test_delim_comma_writes_comma_in_header_but_separates_with_commas(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        writer_kwargs["header"] = AAVSOSubmissionHeader(
+            type="EXTENDED",
+            obscode="ABC",
+            software="stellarphot test",
+            delim="comma",
+            date_format="JD",
+        )
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        lines = out.read_text().splitlines()
+        assert lines[3] == "#DELIM=comma"
+        # Data row still uses literal commas as separators
+        assert lines[6].count(",") == len(DATA_COLUMNS) - 1
+
+    def test_delim_tab_writes_tab_in_data(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["header"] = AAVSOSubmissionHeader(
+            type="EXTENDED",
+            obscode="ABC",
+            software="stellarphot test",
+            delim="tab",
+            date_format="JD",
+        )
+        out = tmp_path / "sub.tsv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        lines = out.read_text().splitlines()
+        assert lines[3] == "#DELIM=tab"
+        assert lines[6].count("\t") == len(DATA_COLUMNS) - 1
+
+    def test_non_jd_date_format_raises(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["header"] = AAVSOSubmissionHeader(
+            type="EXTENDED",
+            obscode="ABC",
+            software="stellarphot test",
+            delim=",",
+            date_format="HJD",
+        )
+        out = tmp_path / "sub.csv"
+        with pytest.raises(NotImplementedError, match="JD"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+
+# ---- Step 3: target-star row construction ----------------------------------
+
+
+def _read_data_rows(path):
+    """Read the file and return the data rows as an astropy Table."""
+    return ap_ascii.read(
+        str(path),
+        format="no_header",
+        delimiter=",",
+        comment="#",
+        names=list(DATA_COLUMNS),
+    )
+
+
+class TestTargetRows:
+    def test_one_row_per_target_observation(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        expected = (phot_table["star_id"] == writer_kwargs["target_star_id"]).sum()
+        assert len(rows) == expected
+
+    def test_starid_is_target_name(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["STARID"]) == {writer_kwargs["target_name"]}
+
+    def test_cname_and_cmag_are_ensemble_constants(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["CNAME"]) == {"ENSEMBLE"}
+        assert set(rows["CMAG"]) == {"na"}
+
+    def test_chart_and_mtype(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["CHART"]) == {writer_kwargs["chart"]}
+        assert set(rows["MTYPE"]) == {"STD"}
+
+    def test_date_is_jd_at_mid_exposure(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+
+        target_rows = phot_table[
+            phot_table["star_id"] == writer_kwargs["target_star_id"]
+        ]
+        for written_jd, src in zip(rows["DATE"], target_rows, strict=True):
+            expected = (Time(src["date-obs"]) + src["exposure"] / 2).jd
+            assert abs(float(written_jd) - expected) < 1e-5
+
+    def test_magnitude_and_magerr_columns_used(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+
+        target_rows = phot_table[
+            phot_table["star_id"] == writer_kwargs["target_star_id"]
+        ]
+        for mag_str, err_str, src in zip(
+            rows["MAGNITUDE"], rows["MAGERR"], target_rows, strict=True
+        ):
+            assert abs(float(mag_str) - float(src["mag_inst"])) < 1e-4
+            # mag_error in the fixture carries 1/adu units; .value strips them.
+            assert abs(float(err_str) - float(src["mag_error"].value)) < 1e-3
+
+    def test_filter_is_row_passband(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        # All rows in fixture are SR
+        assert set(rows["FILTER"]) == {"SR"}
+
+    def test_invalid_filter_raises(self, tmp_path, phot_table, writer_kwargs):
+        bad = phot_table.copy()
+        # "XX" is not in AAVSOFilters; same width as the existing column so the
+        # assignment does not need a dtype change.
+        bad["passband"][:] = "XX"
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="not a valid AAVSO filter"):
+            write_aavso_extended(bad, out, **writer_kwargs)
+
+    @pytest.mark.parametrize("trans,expected", [(False, "NO"), (True, "YES")])
+    def test_trans_reflects_kwarg(
+        self, tmp_path, phot_table, writer_kwargs, trans, expected
+    ):
+        writer_kwargs["trans"] = trans
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["TRANS"]) == {expected}
+
+    def test_group_default_is_na(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["GROUP"]) == {"na"}
+
+    def test_group_integer(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["group"] = 7
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["GROUP"]) == {7}
+
+    def test_airmass_truncates(self, tmp_path, phot_table, writer_kwargs):
+        # Force a very long airmass value
+        long_data = phot_table.copy()
+        long_data["airmass"] = 1.123456789
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(long_data, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        for value in rows["AIRMASS"]:
+            assert len(str(value)) <= 7
+
+    def test_field_too_long_raises(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["target_name"] = "x" * 31  # exceeds STARID limit of 30
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="STARID"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+
+# ---- Step 4: check-star pairing -------------------------------------------
+
+
+class TestCheckStarPairing:
+    def test_kmag_comes_from_check_star_row(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+
+        # Build lookup of (file, passband) -> check mag
+        check_rows = phot_table[phot_table["star_id"] == writer_kwargs["check_star_id"]]
+        check_lookup = {
+            (r["file"], r["passband"]): float(r["mag_inst"]) for r in check_rows
+        }
+
+        target_rows = phot_table[
+            phot_table["star_id"] == writer_kwargs["target_star_id"]
+        ]
+        for written_kmag, src in zip(rows["KMAG"], target_rows, strict=True):
+            expected = check_lookup[(src["file"], src["passband"])]
+            assert abs(float(written_kmag) - expected) < 1e-4
+
+    def test_kname_is_check_name_kwarg(self, tmp_path, phot_table, writer_kwargs):
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(phot_table, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        assert set(rows["KNAME"]) == {writer_kwargs["check_name"]}
+
+    def test_missing_check_row_raises(self, tmp_path, phot_table, writer_kwargs):
+        # Drop one of the check-star observations to break pairing.
+        check_id = writer_kwargs["check_star_id"]
+        mask_check = phot_table["star_id"] == check_id
+        bad = phot_table[
+            ~mask_check | (np.arange(len(phot_table)) != np.where(mask_check)[0][0])
+        ]
+        # Sanity: target still has 2 files, but check star is now missing
+        # one (file, passband) pair.
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="No check-star row"):
+            write_aavso_extended(bad, out, **writer_kwargs)
+
+    def test_missing_target_raises(self, tmp_path, phot_table, writer_kwargs):
+        writer_kwargs["target_star_id"] = 9999
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="No rows in phot_data"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
+
+# ---- Step 5: PhotometryData convenience method -----------------------------
+
+
+class TestPhotometryDataMethod:
+    def test_method_matches_function(self, tmp_path, phot_table, writer_kwargs):
+        func_out = tmp_path / "func.csv"
+        meth_out = tmp_path / "meth.csv"
+        write_aavso_extended(phot_table, func_out, **writer_kwargs)
+        phot_table.write_aavso_extended(meth_out, **writer_kwargs)
+        assert func_out.read_bytes() == meth_out.read_bytes()

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -393,6 +393,15 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="must be different"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
+    @pytest.mark.parametrize("kwarg", ["mag_column", "mag_error_column"])
+    def test_missing_mag_column_raises(
+        self, tmp_path, phot_table, writer_kwargs, kwarg
+    ):
+        writer_kwargs[kwarg] = "no_such_column"
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="no_such_column"):
+            write_aavso_extended(phot_table, out, **writer_kwargs)
+
     @pytest.mark.parametrize("value", ["   ", None])
     @pytest.mark.parametrize("field", ["target_name", "check_name", "chart"])
     def test_blank_required_identifier_rejected(

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -434,9 +434,9 @@ class TestInputValidation:
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
     def test_delim_in_group_field_rejected(self, tmp_path, phot_table, writer_kwargs):
-        # "-" is a legal AAVSO delim but appears in str(-7). The default
-        # target/check/chart/notes strings contain no "-", so the writer
-        # reaches the group-field check before the per-column sweep.
+        # "-" is a legal AAVSO delim but appears in str(-7) (and in any
+        # negative rendered numeric field). The per-column sweep catches the
+        # collision before any I/O.
         writer_kwargs["header"] = AAVSOSubmissionHeader(
             type="EXTENDED",
             obscode="ABC",
@@ -446,7 +446,7 @@ class TestInputValidation:
         )
         writer_kwargs["group"] = -7
         out = tmp_path / "sub.csv"
-        with pytest.raises(ValueError, match="group"):
+        with pytest.raises(ValueError, match="delimiter"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
 
     @pytest.mark.parametrize("delim", [".", "n", "a", "A"])
@@ -591,23 +591,3 @@ class TestKwargTypeValidation:
         out = tmp_path / "sub.csv"
         with pytest.raises(TypeError, match="group"):
             write_aavso_extended(phot_table, out, **writer_kwargs)
-
-
-# ---- Private helper coverage ----------------------------------------------
-
-
-class TestPrivateHelpers:
-    """The None branches in these helpers aren't reachable from typical
-    PhotometryData inputs (astropy columns yield masked sentinels, not None),
-    but the writer keeps them as a defensive fallback. Cover them directly so
-    the contract is asserted."""
-
-    def test_format_magerr_none_returns_na(self):
-        from stellarphot.io.aavso import _format_magerr
-
-        assert _format_magerr(None) == "na"
-
-    def test_format_airmass_none_returns_na(self):
-        from stellarphot.io.aavso import _format_airmass
-
-        assert _format_airmass(None) == "na"

--- a/stellarphot/io/tests/test_aavso.py
+++ b/stellarphot/io/tests/test_aavso.py
@@ -356,6 +356,55 @@ class TestCheckStarPairing:
         # missing one (date-obs, passband) pair.
         out = tmp_path / "sub.csv"
         with pytest.raises(ValueError, match="No check-star row"):
+            write_aavso_extended(bad, out, drop_missing_check=False, **writer_kwargs)
+
+    def test_drop_missing_check_is_default_and_keeps_matched_rows(
+        self, tmp_path, phot_table, writer_kwargs
+    ):
+        # Same setup as test_missing_check_row_raises, but rely on the default
+        # drop_missing_check=True: the unmatched target row is dropped silently
+        # and the remaining matched row is written.
+        check_id = writer_kwargs["check_star_id"]
+        target_id = writer_kwargs["target_star_id"]
+        mask_check = phot_table["star_id"] == check_id
+        # Index of the first check-star row, plus its (date-obs, passband).
+        first_check_idx = int(np.where(mask_check)[0][0])
+        dropped_date = phot_table["date-obs"][first_check_idx]
+        dropped_passband = phot_table["passband"][first_check_idx]
+        bad = phot_table[~mask_check | (np.arange(len(phot_table)) != first_check_idx)]
+        out = tmp_path / "sub.csv"
+        write_aavso_extended(bad, out, **writer_kwargs)
+        rows = _read_data_rows(out)
+        # The number of target observations that still have a matching check
+        # observation in `bad`.
+        target_rows = bad[bad["star_id"] == target_id]
+        check_rows = bad[bad["star_id"] == check_id]
+        check_keys = {(str(r["date-obs"]), r["passband"]) for r in check_rows}
+        expected_kept = sum(
+            (str(r["date-obs"]), r["passband"]) in check_keys for r in target_rows
+        )
+        assert len(rows) == expected_kept
+        # The (date-obs, passband) we dropped from the check star should not
+        # appear in the output's DATE column as a written JD. Sanity-check
+        # that the kept rows do not correspond to the dropped check row.
+        dropped_jd = (Time(dropped_date) + target_rows["exposure"][0] / 2).jd
+        assert all(
+            abs(float(written) - dropped_jd) > 1e-5 for written in rows["DATE"]
+        ) or dropped_passband not in set(rows["FILTER"])
+
+    def test_drop_missing_check_empty_raises(self, tmp_path, phot_table, writer_kwargs):
+        # Break pairing for every target row by moving all check-star rows
+        # to a passband no target row uses. The check star still has rows
+        # (so the early "no check rows" guard does not fire), and target
+        # passband validation (which runs only on target rows) is unaffected,
+        # so the join produces zero matches.
+        check_id = writer_kwargs["check_star_id"]
+        bad = phot_table.copy()
+        mask_check = bad["star_id"] == check_id
+        # Target fixture is "SR"; "B" is a valid AAVSO filter that differs.
+        bad["passband"][mask_check] = "B"
+        out = tmp_path / "sub.csv"
+        with pytest.raises(ValueError, match="removed every target row"):
             write_aavso_extended(bad, out, **writer_kwargs)
 
     def test_missing_target_raises(self, tmp_path, phot_table, writer_kwargs):

--- a/stellarphot/settings/__init__.py
+++ b/stellarphot/settings/__init__.py
@@ -1,3 +1,4 @@
+from .aavso_submission import *
 from .models import *
 from .settings_files import *
 from .views import *

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -1,17 +1,16 @@
 """Pydantic model for the AAVSO Extended File Format submission header.
 
 The structure mirrors ``stellarphot/io/aavso_submission_schema.yml``, which
-is a snapshot of the AAVSO specification. The yaml is loaded once at
-import time and used to check that the constants below stay in sync with
-the spec — the type annotations themselves use ``Literal`` so the
-allowed values are visible to static analysis and to the pydantic-
-generated JSON schema.
+is a snapshot of the AAVSO specification. The allowed values for ``TYPE``
+and ``DATE`` are encoded directly as ``Literal`` annotations so they are
+visible to static analysis and to the pydantic-generated JSON schema, and
+``SOFTWARE_LIMIT`` is hardcoded below. The YAML is not read at runtime;
+consistency with the spec snapshot is verified by
+``test_schema_matches_hardcoded_constants`` in the tests for this module.
 """
 
-from pathlib import Path
 from typing import Annotated, Literal
 
-import yaml
 from pydantic import AfterValidator, Field
 
 from .models import MODEL_DEFAULT_CONFIGURATION, BaseModelWithTableRep, NonEmptyStr
@@ -19,29 +18,9 @@ from .models import MODEL_DEFAULT_CONFIGURATION, BaseModelWithTableRep, NonEmpty
 __all__ = ["AAVSOSubmissionHeader"]
 
 
-_SCHEMA_PATH = (
-    Path(__file__).resolve().parent.parent / "io" / "aavso_submission_schema.yml"
-)
-_SCHEMA = yaml.safe_load(_SCHEMA_PATH.read_text())
-_COMMENTS = _SCHEMA["comments"]
-
-# Values pulled from the schema and checked against the Literal annotations
-# below so the two cannot silently drift apart.
-_TYPE_OPTIONS = tuple(_COMMENTS["TYPE"]["options"])
-_DATE_OPTIONS = tuple(_COMMENTS["DATE"]["options"])
-SOFTWARE_LIMIT = int(_COMMENTS["SOFTWARE"]["limit"])
-
-# These are drift guards between the schema YAML and the Literal annotations
-# below. They must run even under ``python -O`` (where ``assert`` is stripped),
-# so use explicit ``raise`` instead.
-if _TYPE_OPTIONS != ("EXTENDED",):
-    raise RuntimeError(
-        f"TYPE options drift: schema={_TYPE_OPTIONS!r} model=('EXTENDED',)"
-    )
-if _DATE_OPTIONS != ("JD", "HJD", "EXCEL"):
-    raise RuntimeError(
-        f"DATE options drift: schema={_DATE_OPTIONS!r} model=('JD','HJD','EXCEL')"
-    )
+# Mirrors ``comments.SOFTWARE.limit`` in aavso_submission_schema.yml;
+# drift-checked in the tests for this module.
+SOFTWARE_LIMIT = 255
 
 # DELIM rules from the schema: cannot use pipe, hash, or space; the literal
 # words "comma" and "tab" are allowed as escapes for Excel users and tab

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -1,0 +1,132 @@
+"""Pydantic model for the AAVSO Extended File Format submission header.
+
+The structure is driven by ``stellarphot/io/aavso_submission_schema.yml``,
+which mirrors the AAVSO specification. The yaml is loaded once at import
+time and used to derive the allowed values, length limits and forbidden
+characters.
+"""
+
+from pathlib import Path
+
+import yaml
+from pydantic import Field, field_validator
+
+from .models import MODEL_DEFAULT_CONFIGURATION, BaseModelWithTableRep, NonEmptyStr
+
+__all__ = ["AAVSOSubmissionHeader"]
+
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent / "io" / "aavso_submission_schema.yml"
+)
+_SCHEMA = yaml.safe_load(_SCHEMA_PATH.read_text())
+_COMMENTS = _SCHEMA["comments"]
+
+# Allowed values pulled from the schema so they stay in sync with the spec.
+TYPE_OPTIONS = tuple(_COMMENTS["TYPE"]["options"])
+DATE_OPTIONS = tuple(_COMMENTS["DATE"]["options"])
+SOFTWARE_LIMIT = int(_COMMENTS["SOFTWARE"]["limit"])
+
+# DELIM rules from the schema: cannot use pipe, hash, or space; the literal
+# words "comma" and "tab" are allowed as escapes for Excel users and tab
+# delimiters respectively.
+DELIM_FORBIDDEN_CHARS = frozenset({"|", "#", " "})
+DELIM_KEYWORDS = frozenset({"comma", "tab"})
+
+# The writer always emits OBSTYPE=CCD; it is not user-settable.
+OBSTYPE = "CCD"
+
+
+class AAVSOSubmissionHeader(BaseModelWithTableRep):
+    """Header parameters for an AAVSO Extended File Format submission.
+
+    Five fields map 1:1 to the ``#``-prefixed parameter lines required by the
+    AAVSO loader (TYPE, OBSCODE, SOFTWARE, DELIM, DATE). The sixth header
+    line, ``#OBSTYPE=CCD``, is always emitted by the writer and is not a
+    field on this model.
+    """
+
+    model_config = MODEL_DEFAULT_CONFIGURATION
+
+    type: str = Field(
+        default="EXTENDED", description="Always EXTENDED for this format."
+    )
+    obscode: NonEmptyStr = Field(description="Official AAVSO observer code.")
+    software: NonEmptyStr = Field(description="Name and version of the software used.")
+    delim: str = Field(
+        description="Field delimiter character or the word 'comma'/'tab'."
+    )
+    date_format: str = Field(
+        default="JD",
+        description="Date format: JD, HJD, or EXCEL.",
+    )
+
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, v):
+        if v not in TYPE_OPTIONS:
+            raise ValueError(f"type must be one of {TYPE_OPTIONS}; got {v!r}")
+        return v
+
+    @field_validator("date_format")
+    @classmethod
+    def _validate_date_format(cls, v):
+        if v not in DATE_OPTIONS:
+            raise ValueError(f"date_format must be one of {DATE_OPTIONS}; got {v!r}")
+        return v
+
+    @field_validator("software")
+    @classmethod
+    def _validate_software(cls, v):
+        if len(v) > SOFTWARE_LIMIT:
+            raise ValueError(
+                f"software must be at most {SOFTWARE_LIMIT} characters; got {len(v)}"
+            )
+        return v
+
+    @field_validator("delim")
+    @classmethod
+    def _validate_delim(cls, v):
+        if v in DELIM_KEYWORDS:
+            return v
+        if len(v) != 1:
+            raise ValueError(
+                "delim must be a single character or one of 'comma'/'tab'; "
+                f"got {v!r}"
+            )
+        if v in DELIM_FORBIDDEN_CHARS:
+            raise ValueError(
+                f"delim cannot be one of {sorted(DELIM_FORBIDDEN_CHARS)}; got {v!r}"
+            )
+        if not (32 <= ord(v) <= 126):
+            raise ValueError(
+                f"delim must be an ASCII character with code 32-126; got {v!r}"
+            )
+        return v
+
+    def header_lines(self) -> list[str]:
+        """Return the six AAVSO ``#`` header lines in spec order.
+
+        OBSTYPE is hardcoded to ``CCD``; the other five values come from the
+        model fields. No trailing newlines.
+        """
+        return [
+            f"#TYPE={self.type}",
+            f"#OBSCODE={self.obscode}",
+            f"#SOFTWARE={self.software}",
+            f"#DELIM={self.delim}",
+            f"#DATE={self.date_format}",
+            f"#OBSTYPE={OBSTYPE}",
+        ]
+
+    def data_delimiter(self) -> str:
+        """Return the actual character used to separate data fields.
+
+        The header writes ``comma`` and ``tab`` literally, but the data rows
+        use ``,`` and ``\\t`` respectively.
+        """
+        if self.delim == "comma":
+            return ","
+        if self.delim == "tab":
+            return "\t"
+        return self.delim

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -16,7 +16,7 @@ from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
 try:
     from stellarphot.version import version as __version__
 except ImportError:
-    __version__ = ""
+    __version__ = "unknown"
 
 from .models import MODEL_DEFAULT_CONFIGURATION, NonEmptyStr
 

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -31,14 +31,17 @@ _TYPE_OPTIONS = tuple(_COMMENTS["TYPE"]["options"])
 _DATE_OPTIONS = tuple(_COMMENTS["DATE"]["options"])
 SOFTWARE_LIMIT = int(_COMMENTS["SOFTWARE"]["limit"])
 
-assert _TYPE_OPTIONS == (
-    "EXTENDED",
-), f"TYPE options drift: schema={_TYPE_OPTIONS!r} model=('EXTENDED',)"
-assert _DATE_OPTIONS == (
-    "JD",
-    "HJD",
-    "EXCEL",
-), f"DATE options drift: schema={_DATE_OPTIONS!r} model=('JD','HJD','EXCEL')"
+# These are drift guards between the schema YAML and the Literal annotations
+# below. They must run even under ``python -O`` (where ``assert`` is stripped),
+# so use explicit ``raise`` instead.
+if _TYPE_OPTIONS != ("EXTENDED",):
+    raise RuntimeError(
+        f"TYPE options drift: schema={_TYPE_OPTIONS!r} model=('EXTENDED',)"
+    )
+if _DATE_OPTIONS != ("JD", "HJD", "EXCEL"):
+    raise RuntimeError(
+        f"DATE options drift: schema={_DATE_OPTIONS!r} model=('JD','HJD','EXCEL')"
+    )
 
 # DELIM rules from the schema: cannot use pipe, hash, or space; the literal
 # words "comma" and "tab" are allowed as escapes for Excel users and tab

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -1,15 +1,18 @@
 """Pydantic model for the AAVSO Extended File Format submission header.
 
-The structure is driven by ``stellarphot/io/aavso_submission_schema.yml``,
-which mirrors the AAVSO specification. The yaml is loaded once at import
-time and used to derive the allowed values, length limits and forbidden
-characters.
+The structure mirrors ``stellarphot/io/aavso_submission_schema.yml``, which
+is a snapshot of the AAVSO specification. The yaml is loaded once at
+import time and used to check that the constants below stay in sync with
+the spec — the type annotations themselves use ``Literal`` so the
+allowed values are visible to static analysis and to the pydantic-
+generated JSON schema.
 """
 
 from pathlib import Path
+from typing import Annotated, Literal
 
 import yaml
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field
 
 from .models import MODEL_DEFAULT_CONFIGURATION, BaseModelWithTableRep, NonEmptyStr
 
@@ -22,10 +25,20 @@ _SCHEMA_PATH = (
 _SCHEMA = yaml.safe_load(_SCHEMA_PATH.read_text())
 _COMMENTS = _SCHEMA["comments"]
 
-# Allowed values pulled from the schema so they stay in sync with the spec.
-TYPE_OPTIONS = tuple(_COMMENTS["TYPE"]["options"])
-DATE_OPTIONS = tuple(_COMMENTS["DATE"]["options"])
+# Values pulled from the schema and checked against the Literal annotations
+# below so the two cannot silently drift apart.
+_TYPE_OPTIONS = tuple(_COMMENTS["TYPE"]["options"])
+_DATE_OPTIONS = tuple(_COMMENTS["DATE"]["options"])
 SOFTWARE_LIMIT = int(_COMMENTS["SOFTWARE"]["limit"])
+
+assert _TYPE_OPTIONS == (
+    "EXTENDED",
+), f"TYPE options drift: schema={_TYPE_OPTIONS!r} model=('EXTENDED',)"
+assert _DATE_OPTIONS == (
+    "JD",
+    "HJD",
+    "EXCEL",
+), f"DATE options drift: schema={_DATE_OPTIONS!r} model=('JD','HJD','EXCEL')"
 
 # DELIM rules from the schema: cannot use pipe, hash, or space; the literal
 # words "comma" and "tab" are allowed as escapes for Excel users and tab
@@ -35,6 +48,25 @@ DELIM_KEYWORDS = frozenset({"comma", "tab"})
 
 # The writer always emits OBSTYPE=CCD; it is not user-settable.
 OBSTYPE = "CCD"
+
+
+def _validate_delim(value: str) -> str:
+    if value in DELIM_KEYWORDS:
+        return value
+    if len(value) != 1:
+        raise ValueError(
+            "delim must be a single character or one of 'comma'/'tab'; "
+            f"got {value!r}"
+        )
+    if value in DELIM_FORBIDDEN_CHARS:
+        raise ValueError(
+            f"delim cannot be one of {sorted(DELIM_FORBIDDEN_CHARS)}; got {value!r}"
+        )
+    if not (32 <= ord(value) <= 126):
+        raise ValueError(
+            f"delim must be an ASCII character with code 32-126; got {value!r}"
+        )
+    return value
 
 
 class AAVSOSubmissionHeader(BaseModelWithTableRep):
@@ -48,61 +80,30 @@ class AAVSOSubmissionHeader(BaseModelWithTableRep):
 
     model_config = MODEL_DEFAULT_CONFIGURATION
 
-    type: str = Field(
-        default="EXTENDED", description="Always EXTENDED for this format."
-    )
-    obscode: NonEmptyStr = Field(description="Official AAVSO observer code.")
-    software: NonEmptyStr = Field(description="Name and version of the software used.")
-    delim: str = Field(
-        description="Field delimiter character or the word 'comma'/'tab'."
-    )
-    date_format: str = Field(
-        default="JD",
-        description="Date format: JD, HJD, or EXCEL.",
-    )
-
-    @field_validator("type")
-    @classmethod
-    def _validate_type(cls, v):
-        if v not in TYPE_OPTIONS:
-            raise ValueError(f"type must be one of {TYPE_OPTIONS}; got {v!r}")
-        return v
-
-    @field_validator("date_format")
-    @classmethod
-    def _validate_date_format(cls, v):
-        if v not in DATE_OPTIONS:
-            raise ValueError(f"date_format must be one of {DATE_OPTIONS}; got {v!r}")
-        return v
-
-    @field_validator("software")
-    @classmethod
-    def _validate_software(cls, v):
-        if len(v) > SOFTWARE_LIMIT:
-            raise ValueError(
-                f"software must be at most {SOFTWARE_LIMIT} characters; got {len(v)}"
-            )
-        return v
-
-    @field_validator("delim")
-    @classmethod
-    def _validate_delim(cls, v):
-        if v in DELIM_KEYWORDS:
-            return v
-        if len(v) != 1:
-            raise ValueError(
-                "delim must be a single character or one of 'comma'/'tab'; "
-                f"got {v!r}"
-            )
-        if v in DELIM_FORBIDDEN_CHARS:
-            raise ValueError(
-                f"delim cannot be one of {sorted(DELIM_FORBIDDEN_CHARS)}; got {v!r}"
-            )
-        if not (32 <= ord(v) <= 126):
-            raise ValueError(
-                f"delim must be an ASCII character with code 32-126; got {v!r}"
-            )
-        return v
+    type: Annotated[
+        Literal["EXTENDED"],
+        Field(description="Always EXTENDED for this format."),
+    ] = "EXTENDED"
+    obscode: Annotated[
+        NonEmptyStr,
+        Field(description="Official AAVSO observer code."),
+    ]
+    software: Annotated[
+        NonEmptyStr,
+        Field(
+            description="Name and version of the software used.",
+            max_length=SOFTWARE_LIMIT,
+        ),
+    ]
+    delim: Annotated[
+        str,
+        AfterValidator(_validate_delim),
+        Field(description="Field delimiter character or the word 'comma'/'tab'."),
+    ]
+    date_format: Annotated[
+        Literal["JD", "HJD", "EXCEL"],
+        Field(description="Date format: JD, HJD, or EXCEL."),
+    ] = "JD"
 
     def header_lines(self) -> list[str]:
         """Return the six AAVSO ``#`` header lines in spec order.

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -45,8 +45,10 @@ def _upper_if_str(value):
 
 
 def _validate_delim(value: str) -> str:
-    if value in DELIM_KEYWORDS:
-        return value
+    # The "comma"/"tab" keywords are case-insensitive per the schema; normalize
+    # to lowercase so the header line always emits the canonical form.
+    if value.lower() in DELIM_KEYWORDS:
+        return value.lower()
     if len(value) != 1:
         raise ValueError(
             "delim must be a single character or one of 'comma'/'tab'; "

--- a/stellarphot/settings/aavso_submission.py
+++ b/stellarphot/settings/aavso_submission.py
@@ -11,9 +11,14 @@ consistency with the spec snapshot is verified by
 
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, Field
+from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
 
-from .models import MODEL_DEFAULT_CONFIGURATION, BaseModelWithTableRep, NonEmptyStr
+try:
+    from stellarphot.version import version as __version__
+except ImportError:
+    __version__ = ""
+
+from .models import MODEL_DEFAULT_CONFIGURATION, NonEmptyStr
 
 __all__ = ["AAVSOSubmissionHeader"]
 
@@ -30,6 +35,13 @@ DELIM_KEYWORDS = frozenset({"comma", "tab"})
 
 # The writer always emits OBSTYPE=CCD; it is not user-settable.
 OBSTYPE = "CCD"
+
+# Map header DELIM keywords to the literal character used between data fields.
+_DELIM_CHAR_MAP = {"comma": ",", "tab": "\t"}
+
+
+def _upper_if_str(value):
+    return value.upper() if isinstance(value, str) else value
 
 
 def _validate_delim(value: str) -> str:
@@ -51,7 +63,7 @@ def _validate_delim(value: str) -> str:
     return value
 
 
-class AAVSOSubmissionHeader(BaseModelWithTableRep):
+class AAVSOSubmissionHeader(BaseModel):
     """Header parameters for an AAVSO Extended File Format submission.
 
     Five fields map 1:1 to the ``#``-prefixed parameter lines required by the
@@ -64,6 +76,7 @@ class AAVSOSubmissionHeader(BaseModelWithTableRep):
 
     type: Annotated[
         Literal["EXTENDED"],
+        BeforeValidator(_upper_if_str),
         Field(description="Always EXTENDED for this format."),
     ] = "EXTENDED"
     obscode: Annotated[
@@ -76,14 +89,15 @@ class AAVSOSubmissionHeader(BaseModelWithTableRep):
             description="Name and version of the software used.",
             max_length=SOFTWARE_LIMIT,
         ),
-    ]
+    ] = f"stellarphot {__version__}"
     delim: Annotated[
         str,
         AfterValidator(_validate_delim),
         Field(description="Field delimiter character or the word 'comma'/'tab'."),
-    ]
+    ] = ","
     date_format: Annotated[
         Literal["JD", "HJD", "EXCEL"],
+        BeforeValidator(_upper_if_str),
         Field(description="Date format: JD, HJD, or EXCEL."),
     ] = "JD"
 
@@ -102,14 +116,11 @@ class AAVSOSubmissionHeader(BaseModelWithTableRep):
             f"#OBSTYPE={OBSTYPE}",
         ]
 
+    @property
     def data_delimiter(self) -> str:
         """Return the actual character used to separate data fields.
 
         The header writes ``comma`` and ``tab`` literally, but the data rows
         use ``,`` and ``\\t`` respectively.
         """
-        if self.delim == "comma":
-            return ","
-        if self.delim == "tab":
-            return "\t"
-        return self.delim
+        return _DELIM_CHAR_MAP.get(self.delim, self.delim)

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -1,9 +1,31 @@
 import json
+from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
-from stellarphot.settings.aavso_submission import AAVSOSubmissionHeader
+from stellarphot.settings.aavso_submission import (
+    SOFTWARE_LIMIT,
+    AAVSOSubmissionHeader,
+)
+
+
+def test_schema_matches_hardcoded_constants():
+    # The YAML in stellarphot/io/ is the canonical AAVSO spec snapshot. The
+    # Literal annotations on AAVSOSubmissionHeader and SOFTWARE_LIMIT are
+    # hardcoded copies; this test fails if the two ever drift apart.
+    schema_path = (
+        Path(__file__).resolve().parents[3]
+        / "stellarphot"
+        / "io"
+        / "aavso_submission_schema.yml"
+    )
+    comments = yaml.safe_load(schema_path.read_text())["comments"]
+
+    assert tuple(comments["TYPE"]["options"]) == ("EXTENDED",)
+    assert tuple(comments["DATE"]["options"]) == ("JD", "HJD", "EXCEL")
+    assert int(comments["SOFTWARE"]["limit"]) == SOFTWARE_LIMIT
 
 
 def _good_kwargs(**overrides):

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -28,6 +28,29 @@ def test_schema_matches_hardcoded_constants():
     assert int(comments["SOFTWARE"]["limit"]) == SOFTWARE_LIMIT
 
 
+def test_default_software_valid_when_version_import_fails(monkeypatch):
+    # The ImportError fallback for __version__ must still yield a default
+    # `software` value that passes NonEmptyStr validation; otherwise simply
+    # constructing AAVSOSubmissionHeader(obscode=...) raises in environments
+    # where stellarphot.version cannot be imported.
+    import importlib
+    import sys
+
+    import stellarphot.settings.aavso_submission as aavso_mod
+
+    # Setting sys.modules[name] = None makes `from name import ...` raise
+    # ModuleNotFoundError (subclass of ImportError).
+    monkeypatch.setitem(sys.modules, "stellarphot.version", None)
+    try:
+        reloaded = importlib.reload(aavso_mod)
+        h = reloaded.AAVSOSubmissionHeader(obscode="ABC")
+        assert h.software
+        assert h.software.strip() == h.software
+    finally:
+        monkeypatch.undo()
+        importlib.reload(aavso_mod)
+
+
 def _good_kwargs(**overrides):
     base = dict(
         type="EXTENDED",

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -91,6 +91,14 @@ class TestAAVSOSubmissionHeader:
         assert h.delim == delim
 
     @pytest.mark.parametrize(
+        "given,expected",
+        [("COMMA", "comma"), ("Comma", "comma"), ("TAB", "tab"), ("Tab", "tab")],
+    )
+    def test_delim_keyword_normalizes_case(self, given, expected):
+        h = AAVSOSubmissionHeader(**_good_kwargs(delim=given))
+        assert h.delim == expected
+
+    @pytest.mark.parametrize(
         "bad", ["|", "#", " ", "", ",,", "\x00", "\x1f", "\x7f", "\xff"]
     )
     def test_delim_rejects_forbidden_values(self, bad):

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from stellarphot.settings.aavso_submission import AAVSOSubmissionHeader
+
+
+def _good_kwargs(**overrides):
+    base = dict(
+        type="EXTENDED",
+        obscode="ABC",
+        software="stellarphot test",
+        delim=",",
+        date_format="JD",
+    )
+    base.update(overrides)
+    return base
+
+
+class TestAAVSOSubmissionHeader:
+    def test_create_and_round_trip(self):
+        h = AAVSOSubmissionHeader(**_good_kwargs())
+        as_json = h.model_dump_json()
+        # Round-trip through JSON should give an equal model
+        again = AAVSOSubmissionHeader(**json.loads(as_json))
+        assert again == h
+
+    def test_type_must_be_extended(self):
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(type="VISUAL"))
+        # Lowercase is also wrong
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(type="extended"))
+
+    @pytest.mark.parametrize("good", ["JD", "HJD", "EXCEL"])
+    def test_date_format_accepts_spec_values(self, good):
+        h = AAVSOSubmissionHeader(**_good_kwargs(date_format=good))
+        assert h.date_format == good
+
+    @pytest.mark.parametrize("bad", ["jd", "hjd", "MJD", ""])
+    def test_date_format_rejects_others(self, bad):
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(date_format=bad))
+
+    @pytest.mark.parametrize("delim", [",", ";", "!", "comma", "tab"])
+    def test_delim_accepts_spec_values(self, delim):
+        h = AAVSOSubmissionHeader(**_good_kwargs(delim=delim))
+        assert h.delim == delim
+
+    @pytest.mark.parametrize("bad", ["|", "#", " ", "", ",,"])
+    def test_delim_rejects_forbidden_values(self, bad):
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(delim=bad))
+
+    def test_software_max_length(self):
+        # 255 is the limit per the schema; 255 is OK, 256 is not
+        AAVSOSubmissionHeader(**_good_kwargs(software="x" * 255))
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(software="x" * 256))
+
+    def test_header_lines_returns_six_lines_in_spec_order(self):
+        h = AAVSOSubmissionHeader(
+            **_good_kwargs(
+                obscode="ABC",
+                software="stellarphot 1.0",
+                delim="comma",
+                date_format="JD",
+            )
+        )
+        lines = h.header_lines()
+        assert lines == [
+            "#TYPE=EXTENDED",
+            "#OBSCODE=ABC",
+            "#SOFTWARE=stellarphot 1.0",
+            "#DELIM=comma",
+            "#DATE=JD",
+            "#OBSTYPE=CCD",
+        ]
+        # Should not contain trailing newlines
+        for line in lines:
+            assert not line.endswith("\n")
+
+    def test_obscode_required(self):
+        kw = _good_kwargs()
+        del kw["obscode"]
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**kw)
+
+    def test_software_required(self):
+        kw = _good_kwargs()
+        del kw["software"]
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**kw)

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -48,7 +48,9 @@ class TestAAVSOSubmissionHeader:
         h = AAVSOSubmissionHeader(**_good_kwargs(delim=delim))
         assert h.delim == delim
 
-    @pytest.mark.parametrize("bad", ["|", "#", " ", "", ",,"])
+    @pytest.mark.parametrize(
+        "bad", ["|", "#", " ", "", ",,", "\x00", "\x1f", "\x7f", "\xff"]
+    )
     def test_delim_rejects_forbidden_values(self, bad):
         with pytest.raises(ValidationError):
             AAVSOSubmissionHeader(**_good_kwargs(delim=bad))
@@ -86,6 +88,10 @@ class TestAAVSOSubmissionHeader:
         del kw["obscode"]
         with pytest.raises(ValidationError):
             AAVSOSubmissionHeader(**kw)
+
+    def test_obscode_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            AAVSOSubmissionHeader(**_good_kwargs(obscode=""))
 
     def test_software_required(self):
         kw = _good_kwargs()

--- a/stellarphot/settings/tests/test_aavso_submission_header.py
+++ b/stellarphot/settings/tests/test_aavso_submission_header.py
@@ -41,6 +41,13 @@ def _good_kwargs(**overrides):
 
 
 class TestAAVSOSubmissionHeader:
+    def test_defaults(self):
+        h = AAVSOSubmissionHeader(obscode="ABC")
+        assert h.type == "EXTENDED"
+        assert h.delim == ","
+        assert h.date_format == "JD"
+        assert h.software.startswith("stellarphot")
+
     def test_create_and_round_trip(self):
         h = AAVSOSubmissionHeader(**_good_kwargs())
         as_json = h.model_dump_json()
@@ -48,19 +55,32 @@ class TestAAVSOSubmissionHeader:
         again = AAVSOSubmissionHeader(**json.loads(as_json))
         assert again == h
 
-    def test_type_must_be_extended(self):
+    def test_type_rejects_non_spec_values(self):
         with pytest.raises(ValidationError):
             AAVSOSubmissionHeader(**_good_kwargs(type="VISUAL"))
-        # Lowercase is also wrong
-        with pytest.raises(ValidationError):
-            AAVSOSubmissionHeader(**_good_kwargs(type="extended"))
 
-    @pytest.mark.parametrize("good", ["JD", "HJD", "EXCEL"])
-    def test_date_format_accepts_spec_values(self, good):
-        h = AAVSOSubmissionHeader(**_good_kwargs(date_format=good))
-        assert h.date_format == good
+    @pytest.mark.parametrize("variant", ["EXTENDED", "extended", "Extended"])
+    def test_type_normalizes_case(self, variant):
+        h = AAVSOSubmissionHeader(**_good_kwargs(type=variant))
+        assert h.type == "EXTENDED"
 
-    @pytest.mark.parametrize("bad", ["jd", "hjd", "MJD", ""])
+    @pytest.mark.parametrize(
+        "given,expected",
+        [
+            ("JD", "JD"),
+            ("HJD", "HJD"),
+            ("EXCEL", "EXCEL"),
+            ("jd", "JD"),
+            ("hjd", "HJD"),
+            ("excel", "EXCEL"),
+            ("Hjd", "HJD"),
+        ],
+    )
+    def test_date_format_accepts_spec_values(self, given, expected):
+        h = AAVSOSubmissionHeader(**_good_kwargs(date_format=given))
+        assert h.date_format == expected
+
+    @pytest.mark.parametrize("bad", ["MJD", ""])
     def test_date_format_rejects_others(self, bad):
         with pytest.raises(ValidationError):
             AAVSOSubmissionHeader(**_good_kwargs(date_format=bad))
@@ -114,9 +134,3 @@ class TestAAVSOSubmissionHeader:
     def test_obscode_rejects_empty(self):
         with pytest.raises(ValidationError):
             AAVSOSubmissionHeader(**_good_kwargs(obscode=""))
-
-    def test_software_required(self):
-        kw = _good_kwargs()
-        del kw["software"]
-        with pytest.raises(ValidationError):
-            AAVSOSubmissionHeader(**kw)


### PR DESCRIPTION
## Summary

Closes #559. Adds the ability to export a `PhotometryData` ensemble photometry
table as an [AAVSO Extended File Format](https://www.aavso.org/aavso-extended-file-format)
CSV that can be uploaded directly to WebObs.

- New `stellarphot.io.write_aavso_extended` (in `stellarphot/io/aavso.py`,
  matching the existing `io/aij.py`, `io/tess.py` pattern) plus a thin
  `PhotometryData.write_aavso_extended` convenience method. Each call writes
  one (target star, check star) pair; the AAVSO spec allows multiple FILTER
  values within a single file (FILTER is a per-row data column), and the
  writer emits whatever passbands appear in the input table.
- New `AAVSOSubmissionHeader` Pydantic model in
  `stellarphot/settings/aavso_submission.py`, validated against the existing
  `stellarphot/io/aavso_submission_schema.yml` (enum values, character
  limits, the `DELIM` "no pipe/hash/space" rule, etc.). `OBSTYPE` is always
  emitted as `CCD`.
- Ensemble-specific cells are hardcoded per the AAVSO spec: `CNAME=ENSEMBLE`,
  `CMAG=na`. `KMAG` uses the check star's calibrated magnitude (matched by
  image/group) so a future zeropoint correction is a simple offset.
- v1 scope: `DATE=JD` only — `HJD` and `EXCEL` raise `NotImplementedError`
  rather than silently writing the wrong time system. `MTYPE` is hardcoded
  to `STD` for ensemble use.
- User guide section added to `docs/user_guide/calibrating_photometry.rst`
  and a bullet in the README.

## Test plan

- [x] `pytest stellarphot/io/tests/test_aavso.py` — writer, header lines,
      row/field counts, ensemble cell values, missing-passband-mapping error,
      `HJD`/`EXCEL` `NotImplementedError`.
- [x] `pytest stellarphot/settings/tests/test_aavso_submission_header.py` —
      schema-driven validation (enum values, char limits, DELIM rule).
- [x] Reviewer: open the generated CSV against the AAVSO format checker /
      WebObs upload sanity step before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
