### PR TITLE
Add architecture diagram pages to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@
 # be accessible, and the documentation will not build correctly.
 
 import datetime
+import re
 import sys
 import tomllib
 from importlib import import_module
@@ -68,7 +69,23 @@ rst_epilog += """
 extensions += [
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
+    "myst_parser",
+    "sphinxcontrib.mermaid",
 ]
+
+# Render ```mermaid fences (in the diagram Markdown pages) as the mermaid
+# directive. 'antiscript' keeps the diagrams' click-through href links working
+# while stripping any scripts.
+myst_fence_as_directive = ["mermaid"]
+# 'antiscript' keeps the diagrams' click-through href links working while
+# stripping any scripts. startOnLoad stays False -- sphinxcontrib-mermaid runs
+# the diagrams itself.
+mermaid_init_config = {"startOnLoad": False, "securityLevel": "antiscript"}
+# The only Markdown pages are docs/diagrams-*.md, whose links are either
+# external (GitHub) or rewritten below to point at the rendered API docs.
+# Emit them verbatim rather than trying to resolve them as Sphinx cross
+# references (which mangles the rewritten ``.html#anchor`` targets).
+myst_all_links_external = True
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
@@ -206,3 +223,102 @@ man_pages = [("index", project.lower(), project + " Documentation", [author], 1)
 #     dtype, target = line.split(None, 1)
 #     target = target.strip()
 #     nitpick_ignore.append((dtype, six.u(target)))
+
+# -- Rewrite in-repo source links in the diagram pages -----------------------
+#
+# The docs/diagrams-*.md pages link to source files/directories with paths that
+# are relative to the repo (e.g. ``../stellarphot/core.py``) so they remain
+# browsable on GitHub. When Sphinx builds those pages we instead point each
+# link at the rendered API documentation, at module-section granularity. The
+# Markdown files themselves are left untouched -- the rewrite happens only on
+# the in-memory source via the ``source-read`` event.
+
+# Modules that have an automodapi section on the API Reference page (see
+# stellarphot/api_reference.rst). A referenced file resolves to its nearest
+# documented ancestor module.
+_DOCUMENTED_MODULES = {
+    "stellarphot",
+    "stellarphot.core",
+    "stellarphot.table_representations",
+    "stellarphot.differential_photometry",
+    "stellarphot.gui_tools",
+    "stellarphot.io",
+    "stellarphot.photometry.photometry",
+    "stellarphot.photometry.source_detection",
+    "stellarphot.photometry.profiles",
+    "stellarphot.plotting",
+    "stellarphot.settings",
+    "stellarphot.transit_fitting",
+    "stellarphot.transit_fitting.gui",
+    "stellarphot.transit_fitting.io",
+    "stellarphot.transit_fitting.plotting",
+    "stellarphot.utils",
+}
+# Diagram pages live at the docs root; the API page is one level down.
+_API_PAGE = "stellarphot/api_reference.html"
+# Modules documented on a different page than the API Reference. The settings
+# package is documented on the settings user-guide page.
+_MODULE_PAGES = {
+    "stellarphot.settings": "stellarphot/settings.html",
+}
+_GH_BLOB = "https://github.com/feder-observatory/stellarphot/blob/main/"
+_GH_TREE = "https://github.com/feder-observatory/stellarphot/tree/main/"
+
+_DIAGRAM_DOCS = {
+    "diagrams-01-package-overview",
+    "diagrams-02-entry-points",
+    "diagrams-03-user-flows",
+    "diagrams-04-call-graphs",
+}
+
+# Packages with no automodapi section of their own -- point references at them
+# to their primary documented submodule instead.
+_MODULE_ALIASES = {
+    "stellarphot.photometry": "stellarphot.photometry.photometry",
+}
+
+
+def _github_fallback(path):
+    # ``path`` is what follows ``../stellarphot/``.
+    base = _GH_TREE if path.endswith("/") else _GH_BLOB
+    return base + "stellarphot/" + path
+
+
+def _resolve_link(path):
+    # Notebooks are not importable Python, so they have no API page -- send
+    # them to GitHub, which renders .ipynb files natively.
+    if path.startswith("notebooks") or path.endswith(".ipynb"):
+        return _github_fallback(path)
+    # Build a dotted module name from the path and walk up to the nearest
+    # documented module.
+    stem = path.rstrip("/")
+    if stem.endswith(".py"):
+        stem = stem[:-3]
+    if stem in ("", "__init__"):
+        dotted = "stellarphot"
+    else:
+        dotted = "stellarphot." + stem.replace("/", ".")
+    parts = dotted.split(".")
+    while parts:
+        candidate = ".".join(parts)
+        candidate = _MODULE_ALIASES.get(candidate, candidate)
+        if candidate in _DOCUMENTED_MODULES:
+            page = _MODULE_PAGES.get(candidate, _API_PAGE)
+            return f"{page}#module-{candidate}"
+        parts.pop()
+    # Shouldn't happen, but fall back to GitHub rather than emit a broken link.
+    return _github_fallback(path)
+
+
+def _rewrite_repo_links(app, docname, source):
+    if docname not in _DIAGRAM_DOCS:
+        return
+    source[0] = re.sub(
+        r'\.\./stellarphot/([^\s)"]*)',
+        lambda m: _resolve_link(m.group(1)),
+        source[0],
+    )
+
+
+def setup(app):
+    app.connect("source-read", _rewrite_repo_links)

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -101,6 +101,20 @@ These typically need to be done every time you make a contribution.
     you need to make additional commits, make sure you push them to your
     fork on GitHub. The pull request will be updated automatically.
 
+Architecture and design diagrams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These pages map the package structure, entry points, example user flows, and
+per-file call graphs.
+
+.. toctree::
+    :maxdepth: 1
+
+    /diagrams-01-package-overview
+    /diagrams-02-entry-points
+    /diagrams-03-user-flows
+    /diagrams-04-call-graphs
+
 Some specific examples
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/diagrams-01-package-overview.md
+++ b/docs/diagrams-01-package-overview.md
@@ -1,0 +1,425 @@
+# stellarphot — Package Overview
+
+This page maps every module in the `stellarphot` package and the import
+relationships between them. The package has no command-line scripts; users
+interact with it through Jupyter notebooks (launched via
+`jupyter-app-launcher`), through ipywidgets-based GUI tools, or by importing
+the library directly.
+
+The modules group into these logical components:
+
+| Component | Modules | Role |
+|---|---|---|
+| **Core data layer** | `core.py`, `table_representations.py` | Validated astropy `QTable` subclasses (`PhotometryData`, `CatalogData`, `SourceListData`) and catalog fetchers; YAML (de)serialization of settings stored in table metadata |
+| **Settings & configuration** | `settings/` | Pydantic models for all configuration, saved-settings file management, widget generation |
+| **Photometry engine** | `photometry/` | Source detection, FWHM measurement, aperture photometry pipeline |
+| **Differential photometry** | `differential_photometry/` | Relative flux (AIJ-style) and variable-star magnitude calculations |
+| **Transit fitting** | `transit_fitting/` | Exoplanet transit modeling (batman), EXOTIC helper GUI, TIC queries |
+| **Input/output** | `io/` | AstroImageJ, AAVSO extended format, TESS/TFOP files |
+| **GUI tools** | `gui_tools/` | Interactive notebook widgets (seeing profile, comparison-star selection) |
+| **Plotting** | `plotting/` | Seeing, transit, and multi-night light-curve plots |
+| **Utilities** | `utils/` | Magnitude calibration/transforms, comparison-star helpers, version migration |
+| **Notebooks** | `notebooks/` | Shipped workflow notebooks (the user-facing entry points) |
+
+**Legend** — the node types used on this page:
+
+```mermaid
+flowchart LR
+    classDef data fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef engine fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef ui fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef output fill:#f3e5f5,stroke:#7b1fa2,color:#212121
+    classDef nbstyle fill:#fff8e1,stroke:#f9a825,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    l_data["Core data layer"]:::data
+    l_engine["Processing engine"]:::engine
+    l_ui["UI layer"]:::ui
+    l_output["Output<br/>(io, plotting)"]:::output
+    l_nb["Launcher notebook"]:::nbstyle
+    l_ext["Outside the<br/>cluster shown"]:::external
+
+    l_data ~~~ l_engine ~~~ l_ui ~~~ l_output ~~~ l_nb ~~~ l_ext
+```
+
+- **Solid arrows** — an import, pointing from the importing module to the one
+  it imports.
+- **Dashed arrows** — notebooks driving a UI layer, or other looser links.
+- Files are grouped into labeled **subgraphs** by subpackage in the
+  cluster diagrams.
+
+## Subpackage dependency map
+
+Arrows point from the importing module to the module it imports.
+The notebooks drive the GUI layers (dashed arrows) and, through them, the rest
+of the package.
+
+*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, or a looser link.*
+
+```mermaid
+flowchart LR
+    classDef data fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef engine fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef ui fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef output fill:#f3e5f5,stroke:#7b1fa2,color:#212121
+
+    nb["notebooks/<br/>(10 launcher notebooks)"]:::ui
+    gui["gui_tools/"]:::ui
+    sett["settings/"]:::ui
+    phot["photometry/"]:::engine
+    diff["differential_photometry/"]:::engine
+    tfit["transit_fitting/"]:::engine
+    uts["utils/"]:::engine
+    plt["plotting/"]:::output
+    iop["io/"]:::output
+    corem["core.py"]:::data
+    trep["table_representations.py"]:::data
+
+    nb -.->|"drives"| gui
+    nb -.->|"drives"| sett
+
+    gui --> sett
+    gui --> phot
+    gui --> plt
+    gui --> iop
+    gui --> uts
+    gui --> corem
+
+    sett -->|"custom_widgets uses io.tess"| iop
+
+    phot --> corem
+    phot --> sett
+    diff --> corem
+    uts --> corem
+    uts --> sett
+    plt --> sett
+    iop --> corem
+    iop --> sett
+    iop -->|"get_tic_info"| tfit
+
+    corem --> sett
+    corem --> trep
+    trep --> sett
+
+    click nb href "../stellarphot/notebooks/" "notebooks/"
+    click gui href "../stellarphot/gui_tools/" "gui_tools/"
+    click sett href "../stellarphot/settings/" "settings/"
+    click phot href "../stellarphot/photometry/" "photometry/"
+    click diff href "../stellarphot/differential_photometry/" "differential_photometry/"
+    click tfit href "../stellarphot/transit_fitting/" "transit_fitting/"
+    click uts href "../stellarphot/utils/" "utils/"
+    click plt href "../stellarphot/plotting/" "plotting/"
+    click iop href "../stellarphot/io/" "io/"
+    click corem href "../stellarphot/core.py" "core.py"
+    click trep href "../stellarphot/table_representations.py" "table_representations.py"
+```
+
+*Source: the [stellarphot/](../stellarphot/) package — each box is a subpackage directory or top-level module.*
+
+Notes:
+
+- The notebooks also import `differential_photometry`, `transit_fitting`,
+  `io`, `plotting`, `utils`, and the top-level `stellarphot` package directly;
+  only the two main dashed edges are drawn to keep the diagram readable.
+- There is an intentional cycle at the package level:
+  `core.py → settings → io → core.py`. It is harmless because the individual
+  files involved do not form a cycle (`settings/custom_widgets.py` imports
+  `io/tess.py`, which imports `core.py`, which imports `settings/models.py`).
+
+## Core + pipeline cluster (file level)
+
+The photometry pipeline, differential photometry, and calibration utilities
+all sit on top of the core data layer.
+
+*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, or a looser link.*
+
+```mermaid
+flowchart LR
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_phot["stellarphot.photometry"]
+        direction TB
+        phot_py["photometry.py<br/>AperturePhotometry"]
+        srcdet_py["source_detection.py<br/>source_detection, compute_fwhm"]
+        prof_py["profiles.py<br/>CenterAndProfile, find_center"]
+    end
+
+    subgraph sg_diff["stellarphot.differential_photometry"]
+        direction TB
+        relflux_py["aij_rel_fluxes.py<br/>calc_aij_relative_flux"]
+        vsxmag_py["vsx_mags.py<br/>calc_vmag, calc_multi_vmag"]
+    end
+
+    subgraph sg_utils["stellarphot.utils"]
+        direction TB
+        magtrans_py["magnitude_transforms.py"]
+        magsys_py["magnitude_system_transforms.py"]
+        computil_py["comparison_utils.py"]
+        vermig_py["version_migrator.py"]
+    end
+
+    subgraph sg_core["core data layer"]
+        direction TB
+        core_py["core.py<br/>PhotometryData, CatalogData,<br/>SourceListData"]
+        tabrep_py["table_representations.py"]
+    end
+
+    settings_ext["stellarphot.settings"]:::external
+
+    phot_py -->|"compute_fwhm,<br/>fast_fwhm_from_image"| srcdet_py
+    prof_py -->|"calculate_noise"| phot_py
+    phot_py --> core_py
+    phot_py --> settings_ext
+    srcdet_py --> core_py
+    srcdet_py --> settings_ext
+    relflux_py --> core_py
+    magtrans_py -->|"apass_dr9, refcat2"| core_py
+    magtrans_py --> magsys_py
+    computil_py -->|"apass_dr9, vsx_vizier"| core_py
+    vermig_py --> core_py
+    vermig_py --> settings_ext
+    core_py --> settings_ext
+    core_py --> tabrep_py
+    tabrep_py --> settings_ext
+
+    click phot_py href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click srcdet_py href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click prof_py href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click relflux_py href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click vsxmag_py href "../stellarphot/differential_photometry/vsx_mags.py" "vsx_mags.py"
+    click magtrans_py href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click magsys_py href "../stellarphot/utils/magnitude_system_transforms.py" "magnitude_system_transforms.py"
+    click computil_py href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click vermig_py href "../stellarphot/utils/version_migrator.py" "version_migrator.py"
+    click core_py href "../stellarphot/core.py" "core.py"
+    click tabrep_py href "../stellarphot/table_representations.py" "table_representations.py"
+```
+
+Key contents of each file:
+
+- [`core.py`](../stellarphot/core.py) — `BaseEnhancedTable` (validated `QTable`) and its subclasses
+  `PhotometryData`, `CatalogData`, `SourceListData`; catalog fetchers
+  `apass_dr9()`, `refcat2()`, `vsx_vizier()`.
+- [`table_representations.py`](../stellarphot/table_representations.py) — `generate_table_representers()`,
+  `serialize_models_in_table_meta()`, `deserialize_models_in_table_meta()`
+  (round-trips pydantic settings models stored in table metadata).
+- [`photometry/photometry.py`](../stellarphot/photometry/photometry.py) — `AperturePhotometry`,
+  `single_image_photometry()`, `multi_image_photometry()`,
+  `find_too_close()`, `clipped_sky_per_pix_stats()`, `calculate_noise()`.
+- [`photometry/source_detection.py`](../stellarphot/photometry/source_detection.py) — `source_detection()`,
+  `compute_fwhm()`, `fast_fwhm_from_image()`.
+- [`photometry/profiles.py`](../stellarphot/photometry/profiles.py) — `find_center()`, `CenterAndProfile`
+  (radial profile, curve of growth, SNR).
+- [`differential_photometry/aij_rel_fluxes.py`](../stellarphot/differential_photometry/aij_rel_fluxes.py) — `calc_aij_relative_flux()`,
+  `add_relative_flux_column()`, `add_in_quadrature()`.
+- [`differential_photometry/vsx_mags.py`](../stellarphot/differential_photometry/vsx_mags.py) — `calc_vmag()`, `calc_multi_vmag()`.
+- [`utils/magnitude_transforms.py`](../stellarphot/utils/magnitude_transforms.py) — `transform_to_catalog()`,
+  `calculate_transform_coefficients()`, `transform_magnitudes()`,
+  `filter_transform()`.
+- [`utils/magnitude_system_transforms.py`](../stellarphot/utils/magnitude_system_transforms.py) — `PanStarrs1ToJohnsonCousins`,
+  `USNOPrimeToSDSSDR7`, `transform_apass_bands()`, `transform_refcat2_bands()`.
+- [`utils/comparison_utils.py`](../stellarphot/utils/comparison_utils.py) — `set_up()`, `crossmatch_APASS2VSX()`,
+  `mag_scale()`, `in_field()`, `read_file()`.
+- [`utils/version_migrator.py`](../stellarphot/utils/version_migrator.py) — `VersionMigrator` (stellarphot 1 → 2 data).
+
+## UI cluster (settings + gui_tools, file level)
+
+The widget layer is built from pydantic models (`models.py`), auto-generated
+UIs (`views.py`), and persistent storage (`settings_files.py`).
+
+*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, or a looser link.*
+
+```mermaid
+flowchart LR
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+    classDef nbstyle fill:#fff8e1,stroke:#f9a825,color:#212121
+
+    nb["notebooks/<br/>(launcher)"]:::nbstyle
+
+    subgraph sg_gui["stellarphot.gui_tools"]
+        direction TB
+        pac_py["profile_and_comps.py<br/>ComparisonAndSeeing"]
+        comp_py["comparison_functions.py<br/>ComparisonViewer"]
+        seeing_py["seeing_profile_functions.py<br/>SeeingProfileWidget"]
+        photwidg_py["photometry_widget_functions.py<br/>TessAnalysisInputControls"]
+    end
+
+    subgraph sg_set["stellarphot.settings"]
+        direction TB
+        cw_py["custom_widgets.py<br/>ReviewSettings, ChooseOrMakeNew,<br/>PhotometryRunner, TessPhotometrySetup"]
+        views_py["views.py<br/>ui_generator"]
+        sf_py["settings_files.py<br/>SavedSettings,<br/>PhotometryWorkingDirSettings"]
+        models_py["models.py<br/>PhotometrySettings, Camera,<br/>Observatory, ..."]
+        fo_py["fits_opener.py<br/>FitsOpener"]
+        ap_py["astropy_pydantic.py"]
+        aavsom_py["aavso_models.py"]
+        aavsos_py["aavso_submission.py"]
+    end
+
+    core_ext["core.py"]:::external
+    phot_ext["photometry/"]:::external
+    plot_ext["plotting/"]:::external
+    io_ext["io/"]:::external
+    utils_ext["utils/"]:::external
+
+    nb -.-> pac_py
+    nb -.-> photwidg_py
+    nb -.-> cw_py
+
+    pac_py --> comp_py
+    pac_py --> seeing_py
+    comp_py -->|"set_keybindings"| seeing_py
+    comp_py --> cw_py
+    comp_py --> fo_py
+    comp_py --> core_ext
+    comp_py --> utils_ext
+    seeing_py --> cw_py
+    seeing_py --> fo_py
+    seeing_py -->|"CenterAndProfile"| phot_ext
+    seeing_py -->|"seeing_plot"| plot_ext
+    seeing_py -->|"TessSubmission"| io_ext
+    photwidg_py --> cw_py
+    photwidg_py --> core_ext
+
+    cw_py --> models_py
+    cw_py --> sf_py
+    cw_py -->|"ui_generator"| views_py
+    cw_py --> fo_py
+    cw_py -->|"tess_photometry_setup"| io_ext
+    sf_py --> models_py
+    views_py --> models_py
+    models_py --> ap_py
+    models_py --> aavsom_py
+    aavsos_py --> models_py
+
+    click nb href "../stellarphot/notebooks/" "notebooks/"
+    click pac_py href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
+    click comp_py href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click seeing_py href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click photwidg_py href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click cw_py href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click views_py href "../stellarphot/settings/views.py" "views.py"
+    click sf_py href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click models_py href "../stellarphot/settings/models.py" "models.py"
+    click fo_py href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click ap_py href "../stellarphot/settings/astropy_pydantic.py" "astropy_pydantic.py"
+    click aavsom_py href "../stellarphot/settings/aavso_models.py" "aavso_models.py"
+    click aavsos_py href "../stellarphot/settings/aavso_submission.py" "aavso_submission.py"
+```
+
+Key contents of each file:
+
+- [`settings/models.py`](../stellarphot/settings/models.py) — pydantic models: `Camera`, `Observatory`,
+  `PhotometryApertures`, `SourceLocationSettings`,
+  `PhotometryOptionalSettings`, `PassbandMap`/`PassbandMapEntry`,
+  `LoggingSettings`, `PhotometrySettings` (the aggregate), `Exoplanet`,
+  `PhotometryRunSettings`, `PartialPhotometrySettings`.
+- [`settings/astropy_pydantic.py`](../stellarphot/settings/astropy_pydantic.py) — pydantic validators for astropy types
+  (`UnitType`, `QuantityType`, `EquivalentTo`, `WithPhysicalType`,
+  `AstropyValidator`).
+- [`settings/settings_files.py`](../stellarphot/settings/settings_files.py) — `SavedSettings` (per-user storage of
+  cameras/observatories/passband maps), `PhotometryWorkingDirSettings`
+  (loads/saves `photometry_settings.json` in the working directory).
+- [`settings/views.py`](../stellarphot/settings/views.py) — `ui_generator()` (builds an `ipyautoui` widget from
+  any pydantic model).
+- [`settings/custom_widgets.py`](../stellarphot/settings/custom_widgets.py) — `ChooseOrMakeNew`, `Confirm`,
+  `SettingWithTitle`, `ReviewSettings`, `PhotometryRunner`,
+  `TessPhotometrySetup`, `Spinner`.
+- [`settings/fits_opener.py`](../stellarphot/settings/fits_opener.py) — `FitsOpener` (file chooser + lazy
+  `CCDData`/header access).
+- [`gui_tools/seeing_profile_functions.py`](../stellarphot/gui_tools/seeing_profile_functions.py) — `SeeingProfileWidget`,
+  `set_keybindings()`.
+- [`gui_tools/comparison_functions.py`](../stellarphot/gui_tools/comparison_functions.py) — `ComparisonViewer`,
+  `make_markers()`.
+- [`gui_tools/photometry_widget_functions.py`](../stellarphot/gui_tools/photometry_widget_functions.py) — `TessAnalysisInputControls`,
+  `filter_by_dates()`.
+- [`gui_tools/profile_and_comps.py`](../stellarphot/gui_tools/profile_and_comps.py) — `ComparisonAndSeeing` (combines the
+  seeing and comparison widgets).
+
+## Output / IO cluster (file level)
+
+*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, or a looser link.*
+
+```mermaid
+flowchart LR
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_io["stellarphot.io"]
+        direction TB
+        aij_py["aij.py<br/>ApertureFileAIJ, parse_aij_table"]
+        aavso_py["aavso.py<br/>write_aavso_extended"]
+        tess_py["tess.py<br/>TOI, TessSubmission,<br/>TessTargetFile"]
+    end
+
+    subgraph sg_tf["stellarphot.transit_fitting"]
+        direction TB
+        tf_core["core.py<br/>TransitModelFit"]
+        tf_gui["gui.py<br/>exotic_settings_widget"]
+        tf_io["io.py<br/>get_tic_info"]
+        tf_plot["plotting.py<br/>plot_predict_ingress_egress"]
+    end
+
+    subgraph sg_plot["stellarphot.plotting"]
+        direction TB
+        aijplots_py["aij_plots.py<br/>seeing_plot"]
+        transitplots_py["transit_plots.py<br/>plot_transit_lightcurve"]
+        multinight_py["multi_night_plots.py<br/>multi_night"]
+    end
+
+    core_ext["core.py"]:::external
+    settings_ext["settings/"]:::external
+    batman_ext["batman<br/>(transit models)"]:::external
+    mast_ext["astroquery MAST"]:::external
+
+    tess_py -->|"get_tic_info"| tf_io
+    tess_py --> core_ext
+    tess_py --> settings_ext
+    aavso_py -->|"AAVSOFilters,<br/>AAVSOSubmissionHeader"| settings_ext
+    tf_gui --> tf_io
+    tf_io -.-> mast_ext
+    tf_core -.-> batman_ext
+    aijplots_py -->|"PhotometryApertures"| settings_ext
+
+    click aij_py href "../stellarphot/io/aij.py" "io/aij.py"
+    click aavso_py href "../stellarphot/io/aavso.py" "io/aavso.py"
+    click tess_py href "../stellarphot/io/tess.py" "io/tess.py"
+    click tf_core href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tf_gui href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click tf_io href "../stellarphot/transit_fitting/io.py" "transit_fitting/io.py"
+    click tf_plot href "../stellarphot/transit_fitting/plotting.py" "transit_fitting/plotting.py"
+    click aijplots_py href "../stellarphot/plotting/aij_plots.py" "plotting/aij_plots.py"
+    click transitplots_py href "../stellarphot/plotting/transit_plots.py" "plotting/transit_plots.py"
+    click multinight_py href "../stellarphot/plotting/multi_night_plots.py" "plotting/multi_night_plots.py"
+```
+
+Key contents of each file:
+
+- [`io/aij.py`](../stellarphot/io/aij.py) — `ApertureAIJ`, `MultiApertureAIJ`, `ApertureFileAIJ`,
+  `Star`, `generate_aij_table()`, `parse_aij_table()` (AstroImageJ
+  compatibility).
+- [`io/aavso.py`](../stellarphot/io/aavso.py) — `write_aavso_extended()` plus field
+  validators/formatters for the AAVSO extended file format.
+- [`io/tess.py`](../stellarphot/io/tess.py) — `TessSubmission` (TFOP file naming), `TOI` (transit
+  parameters fetched by TIC ID), `TessTargetFile` (nearby GAIA sources),
+  `tess_photometry_setup()`.
+- [`transit_fitting/core.py`](../stellarphot/transit_fitting/core.py) — `TransitModelFit`, `TransitModelOptions`,
+  `VariableArgsFitter`.
+- [`transit_fitting/gui.py`](../stellarphot/transit_fitting/gui.py) — EXOTIC settings widget and TIC/TOI
+  population helpers.
+- [`transit_fitting/io.py`](../stellarphot/transit_fitting/io.py) — `get_tic_info()` (MAST catalog query).
+- [`transit_fitting/plotting.py`](../stellarphot/transit_fitting/plotting.py) — `plot_predict_ingress_egress()`.
+- [`plotting/aij_plots.py`](../stellarphot/plotting/aij_plots.py) — `seeing_plot()`.
+- [`plotting/transit_plots.py`](../stellarphot/plotting/transit_plots.py) — `plot_transit_lightcurve()`,
+  `plot_many_factors()`, `bin_data()`, `scale_and_shift()`.
+- [`plotting/multi_night_plots.py`](../stellarphot/plotting/multi_night_plots.py) — `plot_magnitudes()`, `multi_night()`.
+
+## External dependencies (major ones per component)
+
+| Component | Major external dependencies |
+|---|---|
+| Core data layer | astropy (QTable, SkyCoord, Time, units), astroquery (Vizier, XMatch), pandas, lightkurve |
+| Photometry engine | photutils (apertures, DAOStarFinder, centroids, profiles), astropy, ccdproc |
+| Settings | pydantic, ipywidgets, ipyautoui, papermill |
+| Transit fitting | batman-package, astropy.modeling, scipy, astroquery (MAST) |
+| GUI tools | ipywidgets, astrowidgets, matplotlib |
+| Plotting | matplotlib |

--- a/docs/diagrams-02-entry-points.md
+++ b/docs/diagrams-02-entry-points.md
@@ -1,0 +1,291 @@
+# stellarphot — Entry Points
+
+stellarphot has **no command-line scripts**. There are three ways in:
+
+1. **The Jupyter launcher** — `.jp_app_launcher_stellarphot.yaml` registers ten
+   notebooks with `jupyter-app-launcher`, organized into three catalogs.
+2. **The public import API** — `from stellarphot import ...` re-exports the
+   core data classes and catalog fetchers.
+3. **Direct library use** — importing classes such as
+   `stellarphot.photometry.AperturePhotometry` or
+   `stellarphot.transit_fitting.TransitModelFit` from subpackages.
+
+**Legend** — the node types used on this page:
+
+```mermaid
+flowchart LR
+    classDef nb fill:#fff8e1,stroke:#f9a825,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef api fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef pkg fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef file fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    l_nb["Launcher notebook"]:::nb
+    l_widget["stellarphot widget"]:::widget
+    l_api["Importable function<br/>or class (public API)"]:::api
+    l_pkg["Import entry point<br/>or settings model"]:::pkg
+    l_file["A file on disk"]:::file
+
+    l_nb ~~~ l_widget ~~~ l_api ~~~ l_pkg ~~~ l_file
+```
+
+- **Solid arrows** — opens, instantiates, calls, or returns.
+- **Dashed arrows** — loading from or saving to a file.
+
+## Launcher notebooks and the widgets behind them
+
+Each launcher entry opens a notebook whose first cells instantiate one main
+widget or function; the diagram shows what each notebook puts on screen.
+
+*Arrows: **solid** = opens / instantiates / calls / returns; **dashed** = loading from or saving to a file.*
+
+```mermaid
+flowchart LR
+    classDef nb fill:#fff8e1,stroke:#f9a825,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef api fill:#e8f5e9,stroke:#2e7d32,color:#212121
+
+    subgraph sg_setup["catalog: Stellarphot setup"]
+        direction TB
+        nb01["1 - Saveable settings"]:::nb
+    end
+
+    subgraph sg_phot["catalog: Stellarphot photometry"]
+        direction TB
+        nb02["2 - Seeing profile and<br/>comparison stars"]:::nb
+        nb03["3 - Review settings"]:::nb
+        nb04["4 - Launch photometry"]:::nb
+    end
+
+    subgraph sg_tools["catalog: Stellarphot analysis and tools"]
+        direction TB
+        nb_target["Generate TESS target list"]:::nb
+        nb_flux["Calculate relative flux"]:::nb
+        nb_calib["Calibrate magnitudes"]:::nb
+        nb_fit1["Initial exoplanet model"]:::nb
+        nb_fit2["Second exoplanet model fit"]:::nb
+        nb_exotic["Exoplanet model fit<br/>with EXOTIC"]:::nb
+    end
+
+    review1["ReviewSettings([Camera,<br/>Observatory, PassbandMap])"]:::widget
+    cas["ComparisonAndSeeing"]:::widget
+    review3["ReviewSettings(7 settings models)"]:::widget
+    runner["PhotometryRunner"]:::widget
+    tps["TessPhotometrySetup"]:::widget
+    addflux["add_relative_flux_column()"]:::api
+    calib["transform_to_catalog() and<br/>calculate_transform_coefficients()"]:::api
+    fitstack["TessAnalysisInputControls +<br/>TransitModelFit + TransitModelOptions"]:::widget
+    exotic["exotic_settings_widget() +<br/>populate_TOI_boxes()"]:::widget
+
+    apphot["AperturePhotometry"]:::api
+
+    nb01 --> review1
+    nb02 --> cas
+    nb03 --> review3
+    nb04 --> runner
+    runner -->|"papermill runs<br/>photometry_runner.ipynb"| apphot
+    nb_target --> tps
+    nb_flux --> addflux
+    nb_calib --> calib
+    nb_fit1 --> fitstack
+    nb_fit2 --> fitstack
+    nb_exotic --> exotic
+
+    click nb01 href "../stellarphot/notebooks/01-initial-settings.ipynb" "01-initial-settings.ipynb"
+    click nb02 href "../stellarphot/notebooks/02-seeing-and-comparison.ipynb" "02-seeing-and-comparison.ipynb"
+    click nb03 href "../stellarphot/notebooks/03-final-review-of-settings.ipynb" "03-final-review-of-settings.ipynb"
+    click nb04 href "../stellarphot/notebooks/04-launch-photometry.ipynb" "04-launch-photometry.ipynb"
+    click nb_target href "../stellarphot/notebooks/tess-target-source-list-generator.ipynb" "tess-target-source-list-generator.ipynb"
+    click nb_flux href "../stellarphot/notebooks/relative-flux-calculation.ipynb" "relative-flux-calculation.ipynb"
+    click nb_calib href "../stellarphot/notebooks/transform-to-appas-dr9.ipynb" "transform-to-appas-dr9.ipynb"
+    click nb_fit1 href "../stellarphot/notebooks/tess-initial-model-fit.ipynb" "tess-initial-model-fit.ipynb"
+    click nb_fit2 href "../stellarphot/notebooks/tess-second-model-fit.ipynb" "tess-second-model-fit.ipynb"
+    click nb_exotic href "../stellarphot/notebooks/tess-EXOTIC-fit.ipynb" "tess-EXOTIC-fit.ipynb"
+    click review1 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click cas href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
+    click review3 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click addflux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click calib href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click fitstack href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
+```
+
+What sits behind each widget:
+
+| Launcher entry | Notebook | Main objects used |
+|---|---|---|
+| 1 - Saveable settings | [`01-initial-settings.ipynb`](../stellarphot/notebooks/01-initial-settings.ipynb) | `ReviewSettings([Camera, Observatory, PassbandMap])` |
+| 2 - Seeing profile and comparison stars | [`02-seeing-and-comparison.ipynb`](../stellarphot/notebooks/02-seeing-and-comparison.ipynb) | `ComparisonAndSeeing` (= `SeeingProfileWidget` + `ComparisonViewer`) |
+| 3 - Review settings | [`03-final-review-of-settings.ipynb`](../stellarphot/notebooks/03-final-review-of-settings.ipynb) | `ReviewSettings` over all seven `PhotometrySettings` component models |
+| 4 - Launch photometry | [`04-launch-photometry.ipynb`](../stellarphot/notebooks/04-launch-photometry.ipynb) | `PhotometryRunner` → papermill → `AperturePhotometry` |
+| Generate TESS target list | [`tess-target-source-list-generator.ipynb`](../stellarphot/notebooks/tess-target-source-list-generator.ipynb) | `TessPhotometrySetup` → `tess_photometry_setup()` |
+| Calculate relative flux | [`relative-flux-calculation.ipynb`](../stellarphot/notebooks/relative-flux-calculation.ipynb) | `add_relative_flux_column()`, `FitsOpener`, `Spinner` |
+| Calibrate magnitudes | [`transform-to-appas-dr9.ipynb`](../stellarphot/notebooks/transform-to-appas-dr9.ipynb) | `transform_to_catalog()`, `vsx_vizier()`, `PhotometryData` |
+| Initial / Second exoplanet model | [`tess-initial-model-fit.ipynb`](../stellarphot/notebooks/tess-initial-model-fit.ipynb), [`tess-second-model-fit.ipynb`](../stellarphot/notebooks/tess-second-model-fit.ipynb) | `TessAnalysisInputControls`, `filter_by_dates()`, `TransitModelFit`, `TransitModelOptions`, `TOI`, `plot_transit_lightcurve()` |
+| Exoplanet model fit with EXOTIC | [`tess-EXOTIC-fit.ipynb`](../stellarphot/notebooks/tess-EXOTIC-fit.ipynb) | `exotic_settings_widget()`, `populate_TOI_boxes()`, `get_values_from_widget()`, `generate_json_file_name()` |
+
+## Public import API
+
+*Arrows: **solid** = opens / instantiates / calls / returns; **dashed** = loading from or saving to a file.*
+
+```mermaid
+flowchart LR
+    classDef pkg fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef api fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+
+    top["from stellarphot import ..."]:::pkg
+
+    subgraph sg_tables["data classes (core.py)"]
+        direction TB
+        bet["BaseEnhancedTable"]:::api
+        pdata["PhotometryData"]:::api
+        cdata["CatalogData"]:::api
+        sldata["SourceListData"]:::api
+    end
+
+    subgraph sg_cats["catalog fetchers (core.py)"]
+        direction TB
+        apass["apass_dr9()"]:::api
+        refcat["refcat2()"]:::api
+        vsx["vsx_vizier()"]:::api
+    end
+
+    top --> bet
+    top --> pdata
+    top --> cdata
+    top --> sldata
+    top --> apass
+    top --> refcat
+    top --> vsx
+
+    subgraph sg_deep["main subpackage imports"]
+        direction TB
+        apphot["stellarphot.photometry<br/>AperturePhotometry"]:::api
+        tmf["stellarphot.transit_fitting<br/>TransitModelFit"]:::api
+        relflux["stellarphot.differential_photometry<br/>calc_aij_relative_flux()"]:::api
+        cview["stellarphot.gui_tools<br/>ComparisonViewer, SeeingProfileWidget"]:::widget
+        rsw["stellarphot.settings.custom_widgets<br/>ReviewSettings, PhotometryRunner"]:::widget
+        waavso["stellarphot.io<br/>write_aavso_extended(), TOI"]:::api
+    end
+
+    apphot -->|"returns"| pdata
+    relflux -->|"adds column to"| pdata
+    cview -->|"writes"| sldata
+
+    click top href "../stellarphot/__init__.py" "stellarphot/__init__.py"
+    click bet href "../stellarphot/core.py" "core.py"
+    click pdata href "../stellarphot/core.py" "core.py"
+    click cdata href "../stellarphot/core.py" "core.py"
+    click sldata href "../stellarphot/core.py" "core.py"
+    click apass href "../stellarphot/core.py" "core.py"
+    click refcat href "../stellarphot/core.py" "core.py"
+    click vsx href "../stellarphot/core.py" "core.py"
+    click apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click tmf href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click relflux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click cview href "../stellarphot/gui_tools/" "gui_tools/"
+    click rsw href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click waavso href "../stellarphot/io/" "io/"
+```
+
+*Source: [__init__.py](../stellarphot/__init__.py) (the re-exports), [core.py](../stellarphot/core.py) (the data classes and catalog fetchers).*
+
+## The main programmatic entry point: `AperturePhotometry`
+
+`AperturePhotometry` is configured by a single `PhotometrySettings` object,
+usually loaded from `photometry_settings.json` via
+`PhotometryWorkingDirSettings`.
+
+*Arrows: **solid** = opens / instantiates / calls / returns; **dashed** = loading from or saving to a file.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef api fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef file fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    json["photometry_settings.json"]:::file
+    pwds["PhotometryWorkingDirSettings<br/>.load()"]:::cls
+    ps["PhotometrySettings"]:::cls
+
+    subgraph sg_parts["component models"]
+        direction TB
+        cam["camera: Camera"]:::cls
+        obs["observatory: Observatory"]:::cls
+        apert["photometry_apertures:<br/>PhotometryApertures"]:::cls
+        srcloc["source_location_settings:<br/>SourceLocationSettings"]:::cls
+        opt["photometry_optional_settings:<br/>PhotometryOptionalSettings"]:::cls
+        pbm["passband_map:<br/>PassbandMap or None"]:::cls
+        logset["logging_settings:<br/>LoggingSettings"]:::cls
+    end
+
+    apinst["AperturePhotometry(settings=...)"]:::api
+    apcall["__call__(file_or_directory,<br/>reject_unmatched, object_of_interest)"]:::api
+    result["PhotometryData"]:::api
+
+    json -.-> pwds
+    pwds --> ps
+    ps --> cam
+    ps --> obs
+    ps --> apert
+    ps --> srcloc
+    ps --> opt
+    ps --> pbm
+    ps --> logset
+    ps --> apinst
+    apinst --> apcall
+    apcall --> result
+
+    click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click ps href "../stellarphot/settings/models.py" "models.py"
+    click cam href "../stellarphot/settings/models.py" "models.py"
+    click obs href "../stellarphot/settings/models.py" "models.py"
+    click apert href "../stellarphot/settings/models.py" "models.py"
+    click srcloc href "../stellarphot/settings/models.py" "models.py"
+    click opt href "../stellarphot/settings/models.py" "models.py"
+    click pbm href "../stellarphot/settings/models.py" "models.py"
+    click logset href "../stellarphot/settings/models.py" "models.py"
+    click apinst href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click apcall href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click result href "../stellarphot/core.py" "core.py"
+```
+
+*Source: [photometry.py](../stellarphot/photometry/photometry.py), [models.py](../stellarphot/settings/models.py), [settings_files.py](../stellarphot/settings/settings_files.py), [core.py](../stellarphot/core.py).*
+
+### `AperturePhotometry.__call__` arguments
+
+| Argument | Type / default | Meaning |
+|---|---|---|
+| `file_or_directory` | `str \| Path` (required) | A single FITS file → `single_image_photometry()`; a directory → `multi_image_photometry()` over every matching image |
+| `logline` | `str`, `"single_image_photometry:"` | Prefix for log messages (single-image only) |
+| `reject_unmatched` | `bool`, `True` | Drop sources not detected on every image (multi-image only) |
+| `object_of_interest` | `str`, `None` | Only process files whose `OBJECT` header matches (multi-image only) |
+
+### Settings model fields (what the JSON file / widgets configure)
+
+| Model | Fields |
+|---|---|
+| `Camera` | `name`, `data_unit`, `gain`, `read_noise`, `dark_current`, `pixel_scale`, `max_data_value` |
+| `Observatory` | `name`, `latitude`, `longitude`, `elevation`, `AAVSO_code`, `TESS_telescope_code` |
+| `PhotometryApertures` | `variable_aperture`, `radius`, `gap`, `annulus_width`, `fwhm_estimate` |
+| `SourceLocationSettings` | `source_list_file`, `use_coordinates` (`"sky"` or `"pixel"`), `shift_tolerance` |
+| `PhotometryOptionalSettings` | `include_dig_noise`, `reject_too_close`, `reject_background_outliers`, `fwhm_method` (`fit`/`profile`/`moments`), `partial_pixel_method` (`exact`/`center`/`subpixel`) |
+| `PassbandMap` | `name`, `your_filter_names_to_aavso` (list of `PassbandMapEntry`: instrument filter → AAVSO filter) |
+| `LoggingSettings` | `logfile`, `console_log` |
+| `PhotometryRunSettings` | `directory_with_images`, `photometry_settings_file`, `reject_unmatched`, `object_of_interest` (parameters papermill passes to `photometry_runner.ipynb`) |
+
+## Other notable callable entry points
+
+| Entry point | Module | Key arguments | What's behind it |
+|---|---|---|---|
+| `source_detection()` | `stellarphot.photometry` | `ccd`, `fwhm`, `sigma`, `iters`, `threshold`, `find_fwhm` | `DAOStarFinder` + `compute_fwhm()` → returns `SourceListData` |
+| `calc_aij_relative_flux()` | `stellarphot.differential_photometry` | `star_data`, `comp_stars`, `in_place`, `coord_column`, `star_id_column` | AIJ-style comparison-star ensemble flux |
+| `TransitModelFit.setup_model()` / `.fit()` | `stellarphot.transit_fitting` | `t0`, `depth`, `duration`, `period`, `inclination`, plus airmass/width/sky detrending | batman transit model + `VariableArgsFitter` (scipy leastsq) |
+| `transform_to_catalog()` | `stellarphot.utils` | photometry table, passband options, fit order | Cross-match to APASS DR9 / RefCat2 and fit `calibrated_from_instrumental()` |
+| `write_aavso_extended()` | `stellarphot.io` | photometry table, destination path, header info | Formats and writes an AAVSO extended-format submission file |
+| `tess_photometry_setup()` | `stellarphot.io` | `tic_id` or `TOI_object`, `overwrite` | Queries MAST/ExoFOP, writes `TIC-<id>-info.json` and `TIC-<id>-source-list-input.ecsv` |
+| `apass_dr9()`, `refcat2()`, `vsx_vizier()` | `stellarphot` | a WCS or `SkyCoord` (+ search radius) | Vizier/XMatch query → `CatalogData` |

--- a/docs/diagrams-03-user-flows.md
+++ b/docs/diagrams-03-user-flows.md
@@ -1,0 +1,241 @@
+# stellarphot — Example User Flows
+
+These flowcharts show how a typical user moves through stellarphot, from
+configuring their equipment to submitting results.
+
+**Legend** — the node types used on this page:
+
+```mermaid
+flowchart LR
+    classDef action fill:#e3f2fd,stroke:#1565c0,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef artifact fill:#eceff1,stroke:#546e7a,color:#212121
+    classDef external fill:#f3e5f5,stroke:#7b1fa2,color:#212121
+
+    l_action(["A user action"]):::action
+    l_widget["A stellarphot widget<br/>or function"]:::widget
+    l_artifact[("A file in the<br/>working directory")]:::artifact
+    l_external["An external service<br/>or web query"]:::external
+
+    l_action ~~~ l_widget ~~~ l_artifact ~~~ l_external
+```
+
+- **Solid arrows** — progression from one step to the next.
+- **Dashed arrows** — file reads and writes.
+
+## Flow 1 — Main photometry workflow (launcher notebooks 1 → 4)
+
+A first-time user configures their camera and observatory once (saved
+per-user), then for each night of images: inspects a star's seeing profile to
+pick apertures, selects comparison stars, reviews the combined settings, and
+runs photometry on the whole folder.
+
+*Arrows: **solid** = progression from one step to the next; **dashed** = file reads and writes.*
+
+```mermaid
+flowchart LR
+    classDef action fill:#e3f2fd,stroke:#1565c0,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef artifact fill:#eceff1,stroke:#546e7a,color:#212121
+
+    start(["Start JupyterLab,<br/>open launcher"]):::action
+
+    subgraph sg_nb1["1 - Saveable settings"]
+        direction TB
+        w_review1["ReviewSettings:<br/>Camera, Observatory,<br/>PassbandMap"]:::widget
+    end
+
+    subgraph sg_nb2["2 - Seeing profile and comparison stars"]
+        direction TB
+        a_open["Open a FITS image,<br/>click on target star"]:::action
+        w_seeing["SeeingProfileWidget:<br/>pick aperture radius from<br/>radial profile and SNR"]:::widget
+        w_comp["ComparisonViewer:<br/>select comparison stars<br/>(APASS, VSX overlays)"]:::widget
+    end
+
+    subgraph sg_nb3["3 - Review settings"]
+        direction TB
+        w_review3["ReviewSettings:<br/>confirm all seven<br/>settings groups"]:::widget
+    end
+
+    subgraph sg_nb4["4 - Launch photometry"]
+        direction TB
+        a_pick["Choose one image of<br/>the object of interest"]:::action
+        w_runner["PhotometryRunner:<br/>papermill executes<br/>photometry_runner.ipynb"]:::widget
+        w_apphot["AperturePhotometry on<br/>every image in folder"]:::widget
+    end
+
+    saved[("per-user saved settings<br/>(cameras, observatories,<br/>passband maps)")]:::artifact
+    partial[("partial_photometry_settings.json")]:::artifact
+    srclist[("source_locations.ecsv")]:::artifact
+    full[("photometry_settings.json")]:::artifact
+    photecsv[("photometry.ecsv<br/>(PhotometryData)")]:::artifact
+
+    start --> w_review1
+    w_review1 -.->|"save"| saved
+    start --> a_open
+    a_open --> w_seeing
+    w_seeing --> w_comp
+    w_seeing -.->|"aperture settings"| partial
+    w_comp -.->|"writes"| srclist
+    w_comp -.->|"source list path"| partial
+    w_review3 -.->|"reads"| partial
+    saved -.->|"choose camera /<br/>observatory"| w_review3
+    w_review3 -.->|"saves complete"| full
+    a_pick --> w_runner
+    w_runner --> w_apphot
+    full -.->|"reads"| w_apphot
+    srclist -.->|"reads"| w_apphot
+    w_apphot -.->|"writes"| photecsv
+
+    click w_review1 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click w_seeing href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click w_comp href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click w_review3 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click w_runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click w_apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
+```
+
+*Source: [seeing_profile_functions.py](../stellarphot/gui_tools/seeing_profile_functions.py), [comparison_functions.py](../stellarphot/gui_tools/comparison_functions.py), [custom_widgets.py](../stellarphot/settings/custom_widgets.py), [photometry.py](../stellarphot/photometry/photometry.py)*
+
+## Flow 2 — Exoplanet transit analysis
+
+Starting from the photometry table produced by Flow 1, the user computes
+relative fluxes, then fits transit models of increasing sophistication and
+prepares submission files.
+
+*Arrows: **solid** = progression from one step to the next; **dashed** = file reads and writes.*
+
+```mermaid
+flowchart LR
+    classDef action fill:#e3f2fd,stroke:#1565c0,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef artifact fill:#eceff1,stroke:#546e7a,color:#212121
+
+    photecsv[("photometry.ecsv")]:::artifact
+
+    subgraph sg_flux["Calculate relative flux"]
+        direction TB
+        w_flux["add_relative_flux_column():<br/>ensemble of comparison stars"]:::widget
+    end
+
+    relflux[("photometry-relative-flux.ecsv")]:::artifact
+    ticinfo[("TIC-(id)-info.json")]:::artifact
+
+    subgraph sg_fit1["Initial exoplanet model"]
+        direction TB
+        w_inputs1["TessAnalysisInputControls:<br/>choose photometry file,<br/>TIC info, passband"]:::widget
+        w_fit1["TransitModelFit.setup_model()<br/>then .fit()"]:::widget
+        w_plot1["plot_transit_lightcurve()"]:::widget
+    end
+
+    subgraph sg_fit2["Second exoplanet model fit"]
+        direction TB
+        w_fit2["TransitModelFit with<br/>detrending (airmass,<br/>width, sky) via<br/>TransitModelOptions"]:::widget
+    end
+
+    subgraph sg_exotic["Exoplanet model fit with EXOTIC"]
+        direction TB
+        w_exotic["exotic_settings_widget()<br/>populate_TOI_boxes()"]:::widget
+        a_exotic["Run EXOTIC with<br/>generated settings"]:::action
+    end
+
+    exoticjson[("EXOTIC settings .json")]:::artifact
+    aavso["PhotometryData<br/>.write_aavso_extended()"]:::widget
+    aavsofile[("AAVSO extended<br/>format file")]:::artifact
+
+    photecsv -.-> w_flux
+    w_flux -.->|"writes"| relflux
+    relflux -.-> w_inputs1
+    ticinfo -.-> w_inputs1
+    w_inputs1 --> w_fit1
+    w_fit1 --> w_plot1
+    w_plot1 --> w_fit2
+    w_fit2 --> w_exotic
+    w_exotic -.->|"writes"| exoticjson
+    exoticjson -.-> a_exotic
+    relflux -.-> aavso
+    aavso -.->|"writes"| aavsofile
+
+    click w_flux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click w_inputs1 href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click w_fit1 href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click w_plot1 href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
+    click w_fit2 href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click w_exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click aavso href "../stellarphot/core.py" "core.py"
+```
+
+*Source: [aij_rel_fluxes.py](../stellarphot/differential_photometry/aij_rel_fluxes.py), [photometry_widget_functions.py](../stellarphot/gui_tools/photometry_widget_functions.py), [transit_fitting/core.py](../stellarphot/transit_fitting/core.py), [transit_plots.py](../stellarphot/plotting/transit_plots.py), [transit_fitting/gui.py](../stellarphot/transit_fitting/gui.py)*
+
+## Flow 3 — Supporting flows
+
+### Generate a TESS target source list
+
+Run before Flow 1 when observing a TESS Object of Interest: it fetches the
+transit parameters and nearby GAIA sources so the photometry includes the
+stars TFOP wants checked.
+
+*Arrows: **solid** = progression from one step to the next; **dashed** = file reads and writes.*
+
+```mermaid
+flowchart LR
+    classDef action fill:#e3f2fd,stroke:#1565c0,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef artifact fill:#eceff1,stroke:#546e7a,color:#212121
+    classDef external fill:#f3e5f5,stroke:#7b1fa2,color:#212121
+
+    a_tic["Enter TIC ID or choose<br/>an image with one<br/>in its header"]:::action
+    w_tps["TessPhotometrySetup"]:::widget
+    f_setup["tess_photometry_setup()"]:::widget
+    mast["MAST / ExoFOP<br/>(TOI.from_tic_id)"]:::external
+    gaia["GAIA target list service<br/>(TessTargetFile)"]:::external
+    info[("TIC-(id)-info.json")]:::artifact
+    srclist[("TIC-(id)-source-list-input.ecsv")]:::artifact
+
+    a_tic --> w_tps
+    w_tps --> f_setup
+    f_setup --> mast
+    f_setup --> gaia
+    f_setup -.->|"writes"| info
+    f_setup -.->|"writes"| srclist
+
+    click w_tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click f_setup href "../stellarphot/io/tess.py" "io/tess.py"
+```
+
+*Source: [custom_widgets.py](../stellarphot/settings/custom_widgets.py), [io/tess.py](../stellarphot/io/tess.py)*
+
+### Calibrate magnitudes to a catalog (APASS DR9)
+
+Run after Flow 1 for variable-star work: instrumental magnitudes are
+transformed onto the catalog system, night by night.
+
+*Arrows: **solid** = progression from one step to the next; **dashed** = file reads and writes.*
+
+```mermaid
+flowchart LR
+    classDef action fill:#e3f2fd,stroke:#1565c0,color:#212121
+    classDef widget fill:#fff3e0,stroke:#ef6c00,color:#212121
+    classDef artifact fill:#eceff1,stroke:#546e7a,color:#212121
+    classDef external fill:#f3e5f5,stroke:#7b1fa2,color:#212121
+
+    photecsv[("photometry.ecsv")]:::artifact
+    a_load["Open 'Calibrate<br/>magnitudes' notebook"]:::action
+    w_t2c["transform_to_catalog()"]:::widget
+    apass["APASS DR9 / RefCat2<br/>via apass_dr9(), refcat2()"]:::external
+    w_fit["curve_fit of<br/>calibrated_from_instrumental()"]:::widget
+    calecsv[("photometry with<br/>calibrated mag columns")]:::artifact
+    vsx["vsx_vizier() marks known<br/>variable stars"]:::external
+
+    a_load -.->|"reads"| photecsv
+    a_load --> w_t2c
+    w_t2c --> apass
+    w_t2c --> w_fit
+    w_t2c --> vsx
+    w_t2c -.->|"writes"| calecsv
+
+    click w_t2c href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click w_fit href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+```
+
+*Source: [magnitude_transforms.py](../stellarphot/utils/magnitude_transforms.py)*

--- a/docs/diagrams-04-call-graphs.md
+++ b/docs/diagrams-04-call-graphs.md
@@ -1,0 +1,1010 @@
+# stellarphot — Per-File Call Graphs
+
+This page shows, for each file (or small group of tightly coupled files), the
+functions and classes it contains and how they call each other.
+
+**Legend** — the node types used in every diagram on this page:
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    a_class["A class or method<br/>defined in the file"]:::cls
+    a_func["A module-level function<br/>defined in the file"]:::fn
+    a_ext["Code outside the file(s)<br/>in this diagram"]:::external
+
+    a_class ~~~ a_func ~~~ a_ext
+```
+
+- **Solid arrows** — a direct call or instantiation.
+- **Dashed arrows** — file or network I/O, or an optional path.
+
+## [core.py](../stellarphot/core.py) — data classes and catalog fetchers
+
+`BaseEnhancedTable` is a validated `astropy.table.QTable`; the three public
+table classes inherit from it. The catalog fetcher functions all funnel
+through `CatalogData.from_vizier()`.
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    qtable["astropy QTable"]:::external
+
+    subgraph sg_base["BaseEnhancedTable"]
+        direction TB
+        bet_init["__init__()"]:::cls
+        bet_validate["_validate_columns()"]:::cls
+        bet_colnames["_update_colnames()"]:::cls
+        bet_read["read()"]:::cls
+        bet_write["write()"]:::cls
+        bet_clean["clean()"]:::cls
+    end
+
+    subgraph sg_subclasses["subclasses"]
+        direction TB
+        pd_cls["PhotometryData"]:::cls
+        cd_cls["CatalogData"]:::cls
+        sld_cls["SourceListData"]:::cls
+    end
+
+    subgraph sg_catalogs["catalog fetchers"]
+        direction TB
+        apass_fn["apass_dr9()"]:::fn
+        refcat_fn["refcat2()"]:::fn
+        vsx_fn["vsx_vizier()"]:::fn
+    end
+
+    trep_ser["table_representations<br/>serialize / deserialize"]:::external
+    aavso_ext["io.aavso<br/>write_aavso_extended()"]:::external
+    vizier_ext["astroquery Vizier / XMatch"]:::external
+
+    sg_base -.->|"extends"| qtable
+    pd_cls -->|"inherits"| bet_init
+    cd_cls -->|"inherits"| bet_init
+    sld_cls -->|"inherits"| bet_init
+
+    bet_init --> bet_validate
+    bet_init --> bet_colnames
+    bet_read --> trep_ser
+    bet_write --> trep_ser
+
+    pd_cls --> pd_bjd["add_bjd_col()"]:::cls
+    pd_cls --> pd_lc["lightcurve_for()"]:::cls
+    pd_cls --> pd_aavso["write_aavso_extended()"]:::cls
+    pd_aavso --> aavso_ext
+
+    cd_cls --> cd_viz["from_vizier()"]:::cls
+    cd_cls --> cd_pass["passband_columns()"]:::cls
+    cd_viz --> cd_tidy["_tidy_vizier_catalog()"]:::cls
+    cd_viz --> vizier_ext
+
+    apass_fn --> cd_viz
+    refcat_fn --> cd_viz
+    vsx_fn --> cd_viz
+
+    click bet_init href "../stellarphot/core.py" "core.py"
+    click bet_validate href "../stellarphot/core.py" "core.py"
+    click bet_colnames href "../stellarphot/core.py" "core.py"
+    click bet_read href "../stellarphot/core.py" "core.py"
+    click bet_write href "../stellarphot/core.py" "core.py"
+    click bet_clean href "../stellarphot/core.py" "core.py"
+    click pd_cls href "../stellarphot/core.py" "core.py"
+    click cd_cls href "../stellarphot/core.py" "core.py"
+    click sld_cls href "../stellarphot/core.py" "core.py"
+    click apass_fn href "../stellarphot/core.py" "core.py"
+    click refcat_fn href "../stellarphot/core.py" "core.py"
+    click vsx_fn href "../stellarphot/core.py" "core.py"
+    click pd_bjd href "../stellarphot/core.py" "core.py"
+    click pd_lc href "../stellarphot/core.py" "core.py"
+    click pd_aavso href "../stellarphot/core.py" "core.py"
+    click cd_viz href "../stellarphot/core.py" "core.py"
+    click cd_pass href "../stellarphot/core.py" "core.py"
+    click cd_tidy href "../stellarphot/core.py" "core.py"
+    click trep_ser href "../stellarphot/table_representations.py" "table_representations.py"
+    click aavso_ext href "../stellarphot/io/aavso.py" "io/aavso.py"
+```
+
+## [photometry/photometry.py](../stellarphot/photometry/photometry.py) — the aperture photometry pipeline
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    ap_call["AperturePhotometry.__call__()"]:::cls
+
+    multi["multi_image_photometry()"]:::fn
+    single["single_image_photometry()"]:::fn
+    findclose["find_too_close()"]:::fn
+    skystats["clipped_sky_per_pix_stats()"]:::fn
+    noise["calculate_noise()"]:::fn
+
+    fastfwhm["source_detection<br/>fast_fwhm_from_image()"]:::external
+    fwhm["source_detection<br/>compute_fwhm()"]:::external
+    sld_read["SourceListData.read()"]:::external
+    centroid["photutils<br/>centroid_sources()"]:::external
+    apphot["photutils<br/>aperture_photometry()"]:::external
+    pdata["PhotometryData()"]:::external
+    bjd["PhotometryData.add_bjd_col()"]:::external
+
+    ap_call -->|"path is a directory"| multi
+    ap_call -->|"path is a file"| single
+    multi -->|"once per image"| single
+    multi --> sld_read
+
+    single --> sld_read
+    single --> fastfwhm
+    single --> findclose
+    single --> centroid
+    single --> apphot
+    single --> skystats
+    single --> fwhm
+    single --> noise
+    single --> pdata
+    single --> bjd
+
+    click ap_call href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click multi href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click single href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click findclose href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click skystats href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click noise href "../stellarphot/photometry/photometry.py" "photometry.py"
+    click fastfwhm href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click fwhm href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click sld_read href "../stellarphot/core.py" "core.py"
+    click pdata href "../stellarphot/core.py" "core.py"
+    click bjd href "../stellarphot/core.py" "core.py"
+```
+
+## [photometry/source_detection.py](../stellarphot/photometry/source_detection.py) + [photometry/profiles.py](../stellarphot/photometry/profiles.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_srcdet["source_detection.py"]
+        direction TB
+        srcdet["source_detection()"]:::fn
+        fwhm["compute_fwhm()"]:::fn
+        fastfwhm["fast_fwhm_from_image()"]:::fn
+    end
+
+    subgraph sg_prof["profiles.py"]
+        direction TB
+        findcenter["find_center()"]:::fn
+        cap_init["CenterAndProfile.__init__()"]:::cls
+        cap_cog["CenterAndProfile<br/>curve_of_growth"]:::cls
+        cap_noise["CenterAndProfile<br/>noise() / snr()"]:::cls
+    end
+
+    dao["photutils DAOStarFinder"]:::external
+    fitters["photutils fit_2dgaussian /<br/>fit_fwhm / data_properties"]:::external
+    radprof["photutils RadialProfile"]:::external
+    cog["photutils CurveOfGrowth"]:::external
+    centroids["photutils centroid_com"]:::external
+    sld["SourceListData()"]:::external
+    calcnoise["photometry.py<br/>calculate_noise()"]:::external
+
+    srcdet --> dao
+    srcdet --> fwhm
+    srcdet --> sld
+    fwhm --> fitters
+    fastfwhm --> dao
+    fastfwhm --> fitters
+
+    findcenter --> centroids
+    cap_init --> findcenter
+    cap_init --> radprof
+    cap_cog --> cog
+    cap_noise --> calcnoise
+
+    click srcdet href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click fwhm href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click fastfwhm href "../stellarphot/photometry/source_detection.py" "source_detection.py"
+    click findcenter href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click cap_init href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click cap_cog href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click cap_noise href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click sld href "../stellarphot/core.py" "core.py"
+    click calcnoise href "../stellarphot/photometry/photometry.py" "photometry.py"
+```
+
+## [settings/models.py](../stellarphot/settings/models.py) + [settings/astropy_pydantic.py](../stellarphot/settings/astropy_pydantic.py)
+
+`PhotometrySettings` is a pure composition of the other models; the arrows
+below mean "has a field of this type". All models inherit from
+`BaseModelWithTableRep`, which registers YAML representers so settings can be
+embedded in table metadata.
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    ps["PhotometrySettings"]:::cls
+
+    subgraph sg_components["component models"]
+        direction TB
+        cam["Camera"]:::cls
+        obs["Observatory"]:::cls
+        apert["PhotometryApertures"]:::cls
+        srcloc["SourceLocationSettings"]:::cls
+        opt["PhotometryOptionalSettings"]:::cls
+        pbm["PassbandMap"]:::cls
+        logset["LoggingSettings"]:::cls
+    end
+
+    pbe["PassbandMapEntry"]:::cls
+    aavsof["AAVSOFilters<br/>(aavso_models.py)"]:::external
+    fwhmm["FwhmMethods"]:::cls
+
+    subgraph sg_apydantic["astropy_pydantic.py"]
+        direction TB
+        qty["UnitType / QuantityType"]:::fn
+        equiv["EquivalentTo /<br/>WithPhysicalType"]:::fn
+        astroval["AstropyValidator"]:::fn
+    end
+
+    basemodel["BaseModelWithTableRep"]:::cls
+    tabrep["table_representations<br/>generate_table_representers()"]:::external
+    partial_fn["_make_partial_model()"]:::fn
+    partialps["PartialPhotometrySettings"]:::cls
+    exo["Exoplanet"]:::cls
+    runset["PhotometryRunSettings"]:::cls
+
+    ps --> cam
+    ps --> obs
+    ps --> apert
+    ps --> srcloc
+    ps --> opt
+    ps --> pbm
+    ps --> logset
+
+    pbm --> pbe
+    pbe --> aavsof
+    opt --> fwhmm
+
+    cam --> qty
+    cam --> equiv
+    obs --> qty
+    exo --> astroval
+
+    basemodel --> tabrep
+    ps -->|"inherits"| basemodel
+    partial_fn -->|"generates"| partialps
+    partialps -.-> ps
+    runset -.->|"plain pydantic<br/>BaseModel"| ps
+
+    click ps href "../stellarphot/settings/models.py" "models.py"
+    click cam href "../stellarphot/settings/models.py" "models.py"
+    click obs href "../stellarphot/settings/models.py" "models.py"
+    click apert href "../stellarphot/settings/models.py" "models.py"
+    click srcloc href "../stellarphot/settings/models.py" "models.py"
+    click opt href "../stellarphot/settings/models.py" "models.py"
+    click pbm href "../stellarphot/settings/models.py" "models.py"
+    click logset href "../stellarphot/settings/models.py" "models.py"
+    click pbe href "../stellarphot/settings/models.py" "models.py"
+    click fwhmm href "../stellarphot/settings/models.py" "models.py"
+    click basemodel href "../stellarphot/settings/models.py" "models.py"
+    click partial_fn href "../stellarphot/settings/models.py" "models.py"
+    click partialps href "../stellarphot/settings/models.py" "models.py"
+    click exo href "../stellarphot/settings/models.py" "models.py"
+    click runset href "../stellarphot/settings/models.py" "models.py"
+    click aavsof href "../stellarphot/settings/aavso_models.py" "aavso_models.py"
+    click qty href "../stellarphot/settings/astropy_pydantic.py" "astropy_pydantic.py"
+    click equiv href "../stellarphot/settings/astropy_pydantic.py" "astropy_pydantic.py"
+    click astroval href "../stellarphot/settings/astropy_pydantic.py" "astropy_pydantic.py"
+    click tabrep href "../stellarphot/table_representations.py" "table_representations.py"
+```
+
+## [settings/custom_widgets.py](../stellarphot/settings/custom_widgets.py) — widget layer
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    review["ReviewSettings"]:::cls
+    swt["SettingWithTitle"]:::cls
+    cmn["ChooseOrMakeNew"]:::cls
+    confirm["Confirm"]:::cls
+    addsave["_add_saving_to_widget()"]:::fn
+    runner["PhotometryRunner"]:::cls
+    tps["TessPhotometrySetup"]:::cls
+    spinner["Spinner"]:::cls
+
+    saved["SavedSettings<br/>(settings_files.py)"]:::external
+    pwds["PhotometryWorkingDirSettings<br/>(settings_files.py)"]:::external
+    uigen["ui_generator()<br/>(views.py)"]:::external
+    fo["FitsOpener<br/>(fits_opener.py)"]:::external
+    tpsetup["io.tess<br/>tess_photometry_setup()"]:::external
+    runsettings["PhotometryRunSettings<br/>(models.py)"]:::external
+    papermill["papermill executes<br/>photometry_runner.ipynb"]:::external
+
+    review --> swt
+    review --> addsave
+    addsave --> pwds
+    swt --> cmn
+    cmn --> saved
+    cmn --> uigen
+    cmn --> confirm
+
+    runner --> fo
+    runner --> confirm
+    runner -->|"_file_chosen()"| runsettings
+    runner -->|"_confirmation()"| papermill
+
+    tps --> fo
+    tps --> confirm
+    tps --> spinner
+    tps -->|"watch_confirmation()"| tpsetup
+
+    click review href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click swt href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click cmn href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click confirm href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click addsave href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click spinner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click saved href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click uigen href "../stellarphot/settings/views.py" "views.py"
+    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click tpsetup href "../stellarphot/io/tess.py" "io/tess.py"
+    click runsettings href "../stellarphot/settings/models.py" "models.py"
+    click papermill href "../stellarphot/notebooks/photometry_runner.ipynb" "photometry_runner.ipynb"
+```
+
+## [settings/settings_files.py](../stellarphot/settings/settings_files.py) + [settings/fits_opener.py](../stellarphot/settings/fits_opener.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_saved["per-user saved settings"]
+        direction TB
+        saved["SavedSettings"]:::cls
+        sfo["SavedFileOperations<br/>save() / get() / delete()"]:::cls
+        cams["Cameras"]:::cls
+        obss["Observatories"]:::cls
+        pbms["PassbandMaps"]:::cls
+    end
+
+    subgraph sg_wd["working-directory settings"]
+        direction TB
+        pwds["PhotometryWorkingDirSettings"]:::cls
+        pwds_save["save()"]:::cls
+        pwds_load["load()"]:::cls
+        pwds_partial["_are_partial_actually_full() /<br/>_update_settings_from_partial()"]:::cls
+        pwds_conflict["_resolve_full_partial_conflict()"]:::cls
+    end
+
+    subgraph sg_fo["fits_opener.py"]
+        direction TB
+        fo["FitsOpener"]:::cls
+        fo_ccd["ccd / header properties"]:::cls
+        fo_load["load_in_image_widget()"]:::cls
+    end
+
+    models["models.py<br/>Camera, Observatory, PassbandMap,<br/>PhotometrySettings, Partial..."]:::external
+    userdir["JSON files in<br/>platform settings dir"]:::external
+    wdjson["photometry_settings.json /<br/>partial_photometry_settings.json"]:::external
+    filechooser["ipyfilechooser FileChooser"]:::external
+    ccddata["astropy CCDData.read()"]:::external
+
+    cams -->|"inherits"| sfo
+    obss -->|"inherits"| sfo
+    pbms -->|"inherits"| sfo
+    saved --> cams
+    saved --> obss
+    saved --> pbms
+    saved --> models
+    sfo -.-> userdir
+
+    pwds --> pwds_save
+    pwds --> pwds_load
+    pwds_save --> pwds_partial
+    pwds_load --> pwds_conflict
+    pwds --> models
+    pwds_save -.-> wdjson
+    pwds_load -.-> wdjson
+
+    fo --> filechooser
+    fo_ccd --> ccddata
+    fo --> fo_ccd
+    fo --> fo_load
+
+    click saved href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click sfo href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click cams href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click obss href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pbms href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds_save href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds_load href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds_partial href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click pwds_conflict href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click fo_ccd href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click fo_load href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click models href "../stellarphot/settings/models.py" "models.py"
+```
+
+## [io/aij.py](../stellarphot/io/aij.py) + [io/aavso.py](../stellarphot/io/aavso.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_aij["aij.py — AstroImageJ compatibility"]
+        direction TB
+        afa["ApertureFileAIJ"]:::cls
+        afa_from["from_table()"]:::cls
+        afa_rw["read() / write()"]:::cls
+        multiap["MultiApertureAIJ"]:::cls
+        apaij["ApertureAIJ"]:::cls
+        gen["generate_aij_table()"]:::fn
+        parse["parse_aij_table()"]:::fn
+        iscomp["_is_comp()"]:::fn
+        star["Star"]:::cls
+    end
+
+    subgraph sg_aavso["aavso.py — AAVSO extended format"]
+        direction TB
+        waavso["write_aavso_extended()"]:::fn
+        fmt["field validators & formatters<br/>(_format_mag, _format_airmass,<br/>_require_nonblank, ...)"]:::fn
+    end
+
+    aavso_hdr["AAVSOSubmissionHeader<br/>(settings/aavso_submission.py)"]:::external
+    aavso_filters["AAVSOFilters<br/>(settings/aavso_models.py)"]:::external
+    aijfile["AIJ .apertures file"]:::external
+    aavsofile["AAVSO submission .txt"]:::external
+
+    afa --> multiap
+    multiap --> apaij
+    afa_from --> afa
+    afa_rw -.-> aijfile
+    gen --> iscomp
+    parse --> star
+
+    waavso --> fmt
+    waavso --> aavso_hdr
+    waavso --> aavso_filters
+    waavso -.-> aavsofile
+
+    click afa href "../stellarphot/io/aij.py" "io/aij.py"
+    click afa_from href "../stellarphot/io/aij.py" "io/aij.py"
+    click afa_rw href "../stellarphot/io/aij.py" "io/aij.py"
+    click multiap href "../stellarphot/io/aij.py" "io/aij.py"
+    click apaij href "../stellarphot/io/aij.py" "io/aij.py"
+    click gen href "../stellarphot/io/aij.py" "io/aij.py"
+    click parse href "../stellarphot/io/aij.py" "io/aij.py"
+    click iscomp href "../stellarphot/io/aij.py" "io/aij.py"
+    click star href "../stellarphot/io/aij.py" "io/aij.py"
+    click waavso href "../stellarphot/io/aavso.py" "io/aavso.py"
+    click fmt href "../stellarphot/io/aavso.py" "io/aavso.py"
+    click aavso_hdr href "../stellarphot/settings/aavso_submission.py" "aavso_submission.py"
+    click aavso_filters href "../stellarphot/settings/aavso_models.py" "aavso_models.py"
+```
+
+## [io/tess.py](../stellarphot/io/tess.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    tsetup["tess_photometry_setup()"]:::fn
+    toi["TOI"]:::cls
+    toi_from["TOI.from_tic_id()"]:::cls
+    toi_transit["TOI.transit_time_for_observation()"]:::cls
+    ttf["TessTargetFile"]:::cls
+    ttf_get["_retrieve_target_file()"]:::cls
+    ttf_build["_build_table()"]:::cls
+    tsub["TessSubmission"]:::cls
+    tsub_from["TessSubmission.from_header()"]:::cls
+    tsub_props["base_name / seeing_profile /<br/>field_image properties"]:::cls
+
+    gettic["transit_fitting.io<br/>get_tic_info()"]:::external
+    exofop["ExoFOP TOI table<br/>(web query)"]:::external
+    gaia_svc["astro.louisville.edu<br/>GAIA target list service"]:::external
+    sld["SourceListData"]:::external
+    outfiles["TIC-(id)-info.json,<br/>TIC-(id)-source-list-input.ecsv"]:::external
+
+    tsetup -->|"tic_id given"| toi_from
+    toi_from --> gettic
+    toi_from -.-> exofop
+    toi_from --> toi
+    toi --> toi_transit
+    tsetup --> ttf
+    ttf --> ttf_get
+    ttf --> ttf_build
+    ttf_get -.-> gaia_svc
+    tsetup --> sld
+    tsetup -.->|"writes"| outfiles
+
+    tsub_from --> tsub
+    tsub --> tsub_props
+
+    click tsetup href "../stellarphot/io/tess.py" "io/tess.py"
+    click toi href "../stellarphot/io/tess.py" "io/tess.py"
+    click toi_from href "../stellarphot/io/tess.py" "io/tess.py"
+    click toi_transit href "../stellarphot/io/tess.py" "io/tess.py"
+    click ttf href "../stellarphot/io/tess.py" "io/tess.py"
+    click ttf_get href "../stellarphot/io/tess.py" "io/tess.py"
+    click ttf_build href "../stellarphot/io/tess.py" "io/tess.py"
+    click tsub href "../stellarphot/io/tess.py" "io/tess.py"
+    click tsub_from href "../stellarphot/io/tess.py" "io/tess.py"
+    click tsub_props href "../stellarphot/io/tess.py" "io/tess.py"
+    click gettic href "../stellarphot/transit_fitting/io.py" "transit_fitting/io.py"
+    click sld href "../stellarphot/core.py" "core.py"
+```
+
+## [differential_photometry/](../stellarphot/differential_photometry/)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_rel["aij_rel_fluxes.py"]
+        direction TB
+        addcol["add_relative_flux_column()"]:::fn
+        calc["calc_aij_relative_flux()"]:::fn
+        quad["add_in_quadrature()"]:::fn
+    end
+
+    subgraph sg_vsx["vsx_mags.py"]
+        direction TB
+        multivmag["calc_multi_vmag()"]:::fn
+        vmag["calc_vmag()"]:::fn
+    end
+
+    pdread["PhotometryData.read()"]:::external
+    sldread["SourceListData.read()"]:::external
+    skymatch["SkyCoord<br/>match_to_catalog_sky()"]:::external
+
+    addcol --> pdread
+    addcol --> sldread
+    addcol --> calc
+    calc --> quad
+    calc --> skymatch
+
+    multivmag --> vmag
+    vmag --> skymatch
+
+    click addcol href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click calc href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click quad href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
+    click multivmag href "../stellarphot/differential_photometry/vsx_mags.py" "vsx_mags.py"
+    click vmag href "../stellarphot/differential_photometry/vsx_mags.py" "vsx_mags.py"
+    click pdread href "../stellarphot/core.py" "core.py"
+    click sldread href "../stellarphot/core.py" "core.py"
+```
+
+## [transit_fitting/](../stellarphot/transit_fitting/)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_core["core.py"]
+        direction TB
+        tmf_setup["TransitModelFit.setup_model()"]:::cls
+        tmf_internal["_setup_transit_model() /<br/>_set_default_batman_params()"]:::cls
+        tmf_fit["TransitModelFit.fit()"]:::cls
+        tmf_lc["model_light_curve() /<br/>data_light_curve()"]:::cls
+        tmf_detrend["_detrend()"]:::cls
+        tmf_bic["BIC / n_fit_parameters"]:::cls
+        fitter["VariableArgsFitter.__call__()"]:::cls
+        opts["TransitModelOptions"]:::cls
+    end
+
+    subgraph sg_gui["gui.py"]
+        direction TB
+        exotic["exotic_settings_widget()"]:::fn
+        pop_tic["populate_TIC_boxes()"]:::fn
+        pop_toi["populate_TOI_boxes()"]:::fn
+        checker["make_checker()"]:::fn
+        getvals["get_values_from_widget()"]:::fn
+        genjson["generate_json_file_name()"]:::fn
+        setjson["set_values_from_json_file()"]:::fn
+    end
+
+    gettic["io.py — get_tic_info()"]:::fn
+    ingress["plotting.py —<br/>plot_predict_ingress_egress()"]:::fn
+
+    batman["batman TransitModel"]:::external
+    leastsq["scipy.optimize.leastsq"]:::external
+    mast["astroquery MAST Catalogs"]:::external
+
+    tmf_setup --> tmf_internal
+    tmf_internal --> batman
+    tmf_fit --> fitter
+    fitter --> leastsq
+    tmf_lc --> tmf_detrend
+    tmf_bic -.-> tmf_fit
+    opts -.->|"configures"| tmf_setup
+
+    checker --> gettic
+    pop_tic --> gettic
+    exotic --> setjson
+    genjson --> getvals
+    gettic --> mast
+
+    click tmf_setup href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tmf_internal href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tmf_fit href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tmf_lc href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tmf_detrend href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click tmf_bic href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click fitter href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click opts href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
+    click exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click pop_tic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click pop_toi href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click checker href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click getvals href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click genjson href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click setjson href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click gettic href "../stellarphot/transit_fitting/io.py" "transit_fitting/io.py"
+    click ingress href "../stellarphot/transit_fitting/plotting.py" "transit_fitting/plotting.py"
+```
+
+## [gui_tools/comparison_functions.py](../stellarphot/gui_tools/comparison_functions.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    cv_init["ComparisonViewer.__init__()"]:::cls
+    cv_setup["_init()"]:::cls
+    cv_viewer["_viewer()"]:::cls
+    cv_table["generate_table()"]:::cls
+    cv_saveloc["_save_source_location_file()"]:::cls
+    cv_saveap["_save_aperture_to_file()"]:::cls
+    cv_tess["tess_field_view() /<br/>tess_field_zoom_view()"]:::cls
+    markers["make_markers()"]:::fn
+    wrapfn["wrap()"]:::fn
+
+    fo["FitsOpener"]:::external
+    setup_ext["comparison_utils.set_up()"]:::external
+    xmatch_ext["comparison_utils<br/>crossmatch_APASS2VSX()"]:::external
+    magscale_ext["comparison_utils.mag_scale()"]:::external
+    keybind["seeing_profile_functions<br/>set_keybindings()"]:::external
+    sld["SourceListData"]:::external
+    locfile["source_locations.ecsv"]:::external
+
+    cv_init --> cv_setup
+    cv_init --> cv_viewer
+    cv_setup --> fo
+    cv_setup --> setup_ext
+    cv_setup --> xmatch_ext
+    cv_setup --> magscale_ext
+    cv_setup --> markers
+    cv_viewer --> keybind
+    cv_viewer --> wrapfn
+    cv_saveloc --> cv_table
+    cv_saveloc --> sld
+    cv_saveloc -.->|"writes"| locfile
+    cv_saveap --> cv_table
+    cv_tess --> markers
+
+    click cv_init href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_setup href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_viewer href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_table href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_saveloc href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_saveap href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cv_tess href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click markers href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click wrapfn href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click setup_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click xmatch_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click magscale_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click keybind href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click sld href "../stellarphot/core.py" "core.py"
+```
+
+## [gui_tools](../stellarphot/gui_tools/) — seeing profile and TESS analysis widgets
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_seeing["seeing_profile_functions.py"]
+        direction TB
+        spw_init["SeeingProfileWidget.__init__()"]:::cls
+        spw_show["_make_show_event()"]:::cls
+        spw_plots["_update_plots()"]:::cls
+        spw_save["save()"]:::cls
+        spw_tess["_construct_tess_sub()"]:::cls
+        keybind["set_keybindings()"]:::fn
+    end
+
+    subgraph sg_combined["profile_and_comps.py"]
+        direction TB
+        cas["ComparisonAndSeeing"]:::cls
+    end
+
+    subgraph sg_taic["photometry_widget_functions.py"]
+        direction TB
+        taic["TessAnalysisInputControls"]:::cls
+        fbd["filter_by_dates()"]:::fn
+    end
+
+    fo["FitsOpener"]:::external
+    cmn["ChooseOrMakeNew('camera')"]:::external
+    pwds["PhotometryWorkingDirSettings"]:::external
+    cap["photometry.profiles<br/>CenterAndProfile"]:::external
+    splot["plotting.seeing_plot()"]:::external
+    apert["PhotometryApertures"]:::external
+    tsub["io.TessSubmission.from_header()"]:::external
+    cviewer["ComparisonViewer"]:::external
+    pdata["PhotometryData"]:::external
+
+    spw_init --> fo
+    spw_init --> cmn
+    spw_init --> pwds
+    spw_show --> cap
+    spw_show --> spw_plots
+    spw_plots --> splot
+    spw_show --> apert
+    spw_save --> pwds
+    spw_tess --> tsub
+
+    cas --> spw_init
+    cas --> cviewer
+
+    taic --> pdata
+    taic -.-> fbd
+
+    click spw_init href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_show href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_plots href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_save href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_tess href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click keybind href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click cas href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
+    click taic href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click fbd href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click cmn href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
+    click cap href "../stellarphot/photometry/profiles.py" "profiles.py"
+    click splot href "../stellarphot/plotting/aij_plots.py" "aij_plots.py"
+    click apert href "../stellarphot/settings/models.py" "models.py"
+    click tsub href "../stellarphot/io/tess.py" "io/tess.py"
+    click cviewer href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click pdata href "../stellarphot/core.py" "core.py"
+```
+
+## [plotting/](../stellarphot/plotting/)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_transit["transit_plots.py"]
+        direction TB
+        ptl["plot_transit_lightcurve()"]:::fn
+        pmf["plot_many_factors()"]:::fn
+        sas["scale_and_shift()"]:::fn
+        bindata["bin_data()"]:::fn
+    end
+
+    subgraph sg_multi["multi_night_plots.py"]
+        direction TB
+        mn["multi_night()"]:::fn
+        pmag["plot_magnitudes()"]:::fn
+    end
+
+    subgraph sg_aij["aij_plots.py"]
+        direction TB
+        splot["seeing_plot()"]:::fn
+    end
+
+    apert["settings<br/>PhotometryApertures"]:::external
+    mpl["matplotlib"]:::external
+
+    ptl --> pmf
+    pmf --> sas
+    mn --> pmag
+    splot --> apert
+    ptl --> mpl
+    pmag --> mpl
+    splot --> mpl
+    bindata -.->|"used directly by<br/>transit notebooks"| mpl
+
+    click ptl href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
+    click pmf href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
+    click sas href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
+    click bindata href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
+    click mn href "../stellarphot/plotting/multi_night_plots.py" "multi_night_plots.py"
+    click pmag href "../stellarphot/plotting/multi_night_plots.py" "multi_night_plots.py"
+    click splot href "../stellarphot/plotting/aij_plots.py" "aij_plots.py"
+    click apert href "../stellarphot/settings/models.py" "models.py"
+```
+
+## [utils/](../stellarphot/utils/) — magnitude transforms and comparison helpers
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_mag["magnitude_transforms.py"]
+        direction TB
+        t2c["transform_to_catalog()"]:::fn
+        tmags["transform_magnitudes()"]:::fn
+        ctc["calculate_transform_coefficients()"]:::fn
+        cfi["calibrated_from_instrumental()"]:::fn
+        resid["calc_residual()"]:::fn
+        ftrans["filter_transform()"]:::fn
+    end
+
+    subgraph sg_sys["magnitude_system_transforms.py"]
+        direction TB
+        tab["transform_apass_bands()"]:::fn
+        trb["transform_refcat2_bands()"]:::fn
+        ps1["PanStarrs1ToJohnsonCousins"]:::cls
+        usno["USNOPrimeToSDSSDR7"]:::cls
+    end
+
+    subgraph sg_comp["comparison_utils.py"]
+        direction TB
+        setup["set_up()"]:::fn
+        xmatch["crossmatch_APASS2VSX()"]:::fn
+        magscale["mag_scale()"]:::fn
+        infield["in_field()"]:::fn
+        readfile["read_file()"]:::fn
+    end
+
+    apass["core.apass_dr9()"]:::external
+    refcat["core.refcat2()"]:::external
+    vsx["core.vsx_vizier()"]:::external
+    curvefit["scipy curve_fit"]:::external
+
+    t2c --> apass
+    t2c --> refcat
+    t2c -->|"as transformer"| tab
+    t2c -->|"as transformer"| trb
+    t2c --> curvefit
+    t2c --> cfi
+    t2c --> resid
+    tmags --> ctc
+    ctc --> cfi
+    tab --> ps1
+    trb --> ps1
+    tab --> usno
+
+    setup --> vsx
+    setup --> infield
+    setup --> readfile
+    xmatch --> apass
+
+    click t2c href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click tmags href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click ctc href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click cfi href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click resid href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click ftrans href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
+    click tab href "../stellarphot/utils/magnitude_system_transforms.py" "magnitude_system_transforms.py"
+    click trb href "../stellarphot/utils/magnitude_system_transforms.py" "magnitude_system_transforms.py"
+    click ps1 href "../stellarphot/utils/magnitude_system_transforms.py" "magnitude_system_transforms.py"
+    click usno href "../stellarphot/utils/magnitude_system_transforms.py" "magnitude_system_transforms.py"
+    click setup href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click xmatch href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click magscale href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click infield href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click readfile href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
+    click apass href "../stellarphot/core.py" "core.py"
+    click refcat href "../stellarphot/core.py" "core.py"
+    click vsx href "../stellarphot/core.py" "core.py"
+```
+
+## [table_representations.py](../stellarphot/table_representations.py) + [utils/version_migrator.py](../stellarphot/utils/version_migrator.py)
+
+*Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
+
+```mermaid
+flowchart LR
+    classDef cls fill:#e1f5fe,stroke:#0277bd,color:#212121
+    classDef fn fill:#e8f5e9,stroke:#2e7d32,color:#212121
+    classDef external fill:#eceff1,stroke:#90a4ae,stroke-dasharray: 5 5,color:#212121
+
+    subgraph sg_trep["table_representations.py"]
+        direction TB
+        gen_rep["generate_table_representers()"]:::fn
+        ser["serialize_models_in_table_meta()"]:::fn
+        deser["deserialize_models_in_table_meta()"]:::fn
+        old_rep["_generate_old_table_representers()"]:::fn
+    end
+
+    subgraph sg_mig["version_migrator.py"]
+        direction TB
+        vm["VersionMigrator"]:::cls
+        vm_migrate["migrate()"]:::cls
+        vm_v1v2["_migrate_v1_v2()"]:::cls
+    end
+
+    models["settings.models<br/>(pydantic classes)"]:::external
+    bet_rw["BaseEnhancedTable<br/>read() / write()"]:::external
+    pdata["PhotometryData"]:::external
+    camobs["Camera, Observatory,<br/>PassbandMap"]:::external
+
+    gen_rep --> models
+    bet_rw --> ser
+    bet_rw --> deser
+    deser --> old_rep
+
+    vm --> vm_migrate
+    vm_migrate --> vm_v1v2
+    vm_v1v2 --> pdata
+    vm_v1v2 --> camobs
+
+    click gen_rep href "../stellarphot/table_representations.py" "table_representations.py"
+    click ser href "../stellarphot/table_representations.py" "table_representations.py"
+    click deser href "../stellarphot/table_representations.py" "table_representations.py"
+    click old_rep href "../stellarphot/table_representations.py" "table_representations.py"
+    click vm href "../stellarphot/utils/version_migrator.py" "version_migrator.py"
+    click vm_migrate href "../stellarphot/utils/version_migrator.py" "version_migrator.py"
+    click vm_v1v2 href "../stellarphot/utils/version_migrator.py" "version_migrator.py"
+    click models href "../stellarphot/settings/models.py" "models.py"
+    click bet_rw href "../stellarphot/core.py" "core.py"
+    click pdata href "../stellarphot/core.py" "core.py"
+    click camobs href "../stellarphot/settings/models.py" "models.py"
+```

--- a/docs/stellarphot/api_reference.rst
+++ b/docs/stellarphot/api_reference.rst
@@ -7,6 +7,8 @@ All of the classes and functions defined in `stellarphot` are listed below, grou
 
 .. automodapi:: stellarphot
 .. automodapi:: stellarphot.core
+.. automodapi:: stellarphot.table_representations
+.. automodapi:: stellarphot.photometry.profiles
 .. automodapi:: stellarphot.differential_photometry
 .. automodapi:: stellarphot.gui_tools
 .. automodapi:: stellarphot.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ docs = [
     "sphinx-astropy[confv2]",
     "sphinx-design",
     "graphviz",
+    "myst-parser",
+    "sphinxcontrib-mermaid",
 ]
 exo_fitting = [
     "batman-package",
@@ -149,10 +151,12 @@ select = [
 # Ignore `E402` and `F403` (import violations) in all `__init__.py` files.
 "__init__.py" = ["E402", "F403"]
 # Ignore F405 (variable may be from star imports) in docs/conf.py
-"docs/conf.py" = ["F405"]
+"docs/conf.py" = ["F405", "ARG001"]
 
 [tool.codespell]
-skip = '*.svg'
+# The diagrams-*.md files use short Mermaid node ids that codespell
+# misreads as typos.
+skip = '*.svg,docs/diagrams-*.md'
 ignore-words = "ignore-words.txt"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Wires four Mermaid-based architecture diagram pages into the Sphinx docs, nested under **Contributing**:

- `diagrams-01-package-overview` — package/module map and dependency clusters
- `diagrams-02-entry-points` — entry points
- `diagrams-03-user-flows` — example user flows
- `diagrams-04-call-graphs` — per-file call graphs

## What this enables

- Markdown support via **myst-parser** and Mermaid rendering via **sphinxcontrib-mermaid** (both added to the `docs` optional dependencies). Mermaid fences are rendered through `myst_fence_as_directive`, and `securityLevel: antiscript` is set so the diagrams' click-through node links work.
- The diagram pages link to source files/dirs using repo-relative paths (e.g. `../stellarphot/core.py`) so they stay browsable on GitHub. A `source-read` handler in `conf.py` rewrites those links **at build time only** to point at the rendered API docs at module-section granularity:
  - code files → `api_reference.html#module-stellarphot.<name>`
  - `settings/*` → the existing settings user-guide page
  - `notebooks/*.ipynb` → GitHub (not importable, so no API page)

  The Markdown files themselves are **not edited**.
- Adds `automodapi` coverage for `stellarphot.table_representations` and `stellarphot.photometry.profiles`, which had no API page, so the diagram links resolve.

## Verification

`sphinx-build -W -b html` (the same warnings-as-errors mode used by `tox -e build_docs` and ReadTheDocs) **builds clean**. Spot-checked: the four pages appear under Contributing, Mermaid diagrams render, every rewritten internal link anchor resolves, and notebook links point at GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
