### PR TITLE
Raise clear error when GAIA target-file service returns no link

### DIFF
--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -536,6 +536,15 @@ class TessTargetFile:
             'href="(.+)"',
             result.text.replace("\n", ""),
         )
+        if links is None:
+            # The server responded (status 200) but the body contains no
+            # download link, which happens when the service is up but
+            # misbehaving. Raise a clear, catchable error rather than letting
+            # the subsequent subscript fail with an opaque TypeError.
+            raise ValueError(
+                "GAIA target-file service returned no download link; the "
+                f"server may be misbehaving. Response was: {result.text!r}"
+            )
         download_link = self.aperture_server + links[1]
         target_file_contents = requests.get(download_link)
         # Write GAIA data to local file

--- a/stellarphot/io/tests/test_tess.py
+++ b/stellarphot/io/tests/test_tess.py
@@ -16,6 +16,11 @@ from stellarphot.io.tess import (
     tess_photometry_setup,
 )
 
+# Errors raised when the external TESS/GAIA target-file service is down or
+# misbehaving (e.g. returns HTTP 200 with no usable download link, which now
+# surfaces as a ValueError). Remote-data tests xfail rather than fail on these.
+SERVER_DOWN_ERRORS = (ConnectionError, ReadTimeout, ValueError)
+
 GOOD_HEADER = {
     "date-obs": "2022-06-04T05:44:28.010",
     "filter": "ip",
@@ -136,6 +141,25 @@ def test_target_file():
             pytest.xfail("TESS/gaia Server down")
 
 
+def test_target_file_no_download_link_raises(monkeypatch):
+    # When the GAIA aperture service returns HTTP 200 but a body with no
+    # download link (i.e. the server is "back but producing garbage"), we
+    # should raise a clear, catchable ValueError instead of an opaque
+    # ``TypeError: 'NoneType' object is not subscriptable``.
+    class FakeResponse:
+        status_code = 200
+        text = "<html>The server is having a bad day -- no link here.</html>"
+
+    def fake_get(*args, **kwargs):  # noqa: ARG001
+        return FakeResponse()
+
+    monkeypatch.setattr("stellarphot.io.tess.requests.get", fake_get)
+
+    coord = SkyCoord(ra=104.733225, dec=49.968739, unit="degree")
+    with pytest.raises(ValueError, match="no download link"):
+        TessTargetFile(coord, magnitude=12, depth=10)
+
+
 class TestTOI:
     @pytest.fixture
     def sample_toi(self):
@@ -235,11 +259,14 @@ class TestTessPhotometrySetup:
         # Check that we can create the necessary files for TESS photometry
         # from a TIC ID.
         tic_id = tess_tic_expected_values["tic_id"]
-        if creation_method == "tic_id":
-            tess_photometry_setup(tic_id=tic_id)
-        else:
-            toi_info = TOI.from_tic_id(tic_id)
-            tess_photometry_setup(TOI_object=toi_info)
+        try:
+            if creation_method == "tic_id":
+                tess_photometry_setup(tic_id=tic_id)
+            else:
+                toi_info = TOI.from_tic_id(tic_id)
+                tess_photometry_setup(TOI_object=toi_info)
+        except SERVER_DOWN_ERRORS as e:
+            pytest.xfail(f"TESS/GAIA server down or misbehaving: {e}")
 
         p_info = Path(f"TIC-{tic_id}-info.json")
         assert p_info.exists()
@@ -252,8 +279,13 @@ class TestTessPhotometrySetup:
         # Check to see that an error is raised if the files already exist
         # and the overwrite flag is not set.
         tic_id = tess_tic_expected_values["tic_id"]
-        tess_photometry_setup(tic_id=tic_id)
+        try:
+            tess_photometry_setup(tic_id=tic_id)
+        except SERVER_DOWN_ERRORS as e:
+            pytest.xfail(f"TESS/GAIA server down or misbehaving: {e}")
 
+        # The first call succeeded, so the server is up and the remaining
+        # calls below should reach the FileExistsError checks.
         # Try re-running with both files present, where we hit the error from
         # the source list file first
         with pytest.raises(FileExistsError):

--- a/stellarphot/io/tests/test_tess.py
+++ b/stellarphot/io/tests/test_tess.py
@@ -141,7 +141,7 @@ def test_target_file():
             pytest.xfail("TESS/gaia Server down")
 
 
-def test_target_file_no_download_link_raises(monkeypatch):
+def test_target_file_no_download_link_raises(monkeypatch, tmp_path):
     # When the GAIA aperture service returns HTTP 200 but a body with no
     # download link (i.e. the server is "back but producing garbage"), we
     # should raise a clear, catchable ValueError instead of an opaque
@@ -156,8 +156,13 @@ def test_target_file_no_download_link_raises(monkeypatch):
     monkeypatch.setattr("stellarphot.io.tess.requests.get", fake_get)
 
     coord = SkyCoord(ra=104.733225, dec=49.968739, unit="degree")
-    with pytest.raises(ValueError, match="no download link"):
-        TessTargetFile(coord, magnitude=12, depth=10)
+    # Provide a file we manage ourselves so TessTargetFile does not create a
+    # NamedTemporaryFile that would be left open when construction fails. A
+    # leaked open handle raises an unclosed-file ResourceWarning, which is
+    # promoted to an error on Windows CI.
+    with open(tmp_path / "gaia_targets.dat", "w") as target_file:
+        with pytest.raises(ValueError, match="no download link"):
+            TessTargetFile(coord, magnitude=12, depth=10, file=target_file)
 
 
 class TestTOI:


### PR DESCRIPTION
## Summary

`TessTargetFile._retrieve_target_file` assumed the GAIA aperture service response always contained a download link. When the service is up but misbehaving (HTTP 200 with no `href` in the body), `re.search` returns `None` and the subsequent subscript raised an opaque `TypeError: 'NoneType' object is not subscriptable`. This both failed CI (`test_target_file`, `test_creation_with_overwrite` on the 3.13/ubuntu job) and gave users an unhelpful error.

## Changes

- **`io/tess.py`**: raise a clear, catchable `ValueError` when the service returns no download link, instead of letting the subscript blow up.
- **`io/tests/test_tess.py`**:
  - Add `test_target_file_no_download_link_raises` — a fast unit test (mocked `requests.get`, no network) that reproduces the condition and asserts the new `ValueError`.
  - Make the remote-data `TestTessPhotometrySetup` tests xfail gracefully when the server is down/misbehaving, via a shared `SERVER_DOWN_ERRORS` tuple — matching the existing pattern in `test_target_file`.

## Testing

- New unit test confirmed red before the fix (reproduced the exact `TypeError`) and green after.
- Full `test_tess.py` passes locally (remote-data tests skipped); `ruff` clean.

## Notes

This addresses two of the three failures seen on the CI run for #564. The unrelated third failure (`test_compute_fwhm[units0]`, a Python-3.13-only unraisable-exception warning) is tracked separately in #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
