### PR TITLE
Remove sort/separation helper columns from aperture file (#34)

### DIFF
--- a/stellarphot/gui_tools/comparison_functions.py
+++ b/stellarphot/gui_tools/comparison_functions.py
@@ -661,6 +661,10 @@ class ComparisonViewer:
         # Assign the IDs
         comp_table["star_id"] = range(1, len(comp_table) + 1)
 
+        # Remove the helper columns that were only added to control the sort order
+        # so they do not end up in the aperture file (issue #34).
+        comp_table.remove_columns(["separation", "sort"])
+
         return comp_table
 
     def show_labels(self):

--- a/stellarphot/gui_tools/tests/test_comparison_functions.py
+++ b/stellarphot/gui_tools/tests/test_comparison_functions.py
@@ -91,6 +91,11 @@ def test_comparison_properties(tmp_path, has_object, source_file_name):
     table = comparison_widget.generate_table()
     assert "APASS comparison" in table["marker name"]
 
+    # The "separation" and "sort" columns are only used to order the table and
+    # should not be present in the table returned by generate_table (issue #34).
+    assert "separation" not in table.colnames
+    assert "sort" not in table.colnames
+
     # Check that if we show labels then the label names we expect show up in
     # the astrowidgets marker table.
     comparison_widget.show_labels()
@@ -239,6 +244,11 @@ def test_loading_input_source_list(tmp_path, tic_id):
 
     comp_viewer_sources = SourceListData.read("source_locations.ecsv")
     input_sources = SourceListData.read(input_source_list)
+
+    # The "separation" and "sort" columns are only used to order the table and
+    # should not be written to the aperture file (issue #34).
+    assert "separation" not in comp_viewer_sources.colnames
+    assert "sort" not in comp_viewer_sources.colnames
 
     tess_targets = comp_viewer_sources["marker name"] == "TESS Targets"
 


### PR DESCRIPTION
## What this does

Fixes #34.

`ComparisonViewer.generate_table()` added two columns — `separation` and `sort` — purely to control the row order of the comparison-star table, sorted on them, but never removed them. Because `BaseEnhancedTable` deliberately keeps columns it doesn't know about, those helper columns ended up written into the aperture (source list) file.

This drops `separation` and `sort` at the end of `generate_table()`, right after the sort and `star_id` assignment, so they no longer appear in the returned table or the saved aperture file. The `coord` column handling on the save path is unchanged (it's still needed by `variables`/`show_labels`).

Note: the issue's other ask — moving the sorting code out of a notebook into `comparison_functions.py` — was already done previously; only the leftover-column cleanup remained.

## Tests

Added assertions (TDD, verified red before the fix) that neither `generate_table()`'s output nor the written `source_locations.ecsv` contains `separation`/`sort`:
- `test_comparison_properties`
- `test_loading_input_source_list`

Full `test_comparison_functions.py` passes with `--remote-data` (9 passed).

## Notebook impact

None. No tracked notebook references the `separation`/`sort` columns; aperture-file consumers use only `star_id`/`marker name`/`ra`/`dec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
