### PR TITLE
Fix CI: broaden astrowidgets TestRunner deprecation-warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,10 @@ filterwarnings = [
     # Apparently some change in pytest or coverage or pytest-cov exposes warnings
     # that were previously ignored.
     'ignore:.*:coverage.exceptions.CoverageWarning',
-    # We are currently stuck on an old version of astrowidgets, which uses
-    # the deprecated astropy test runner, so suppress that warning for now.
-    'ignore:The TestRunner.* class will be deprecated in a future version:astropy.utils.exceptions.AstropyPendingDeprecationWarning'
+    # We are currently stuck on an old version of astrowidgets, which imports
+    # astropy's deprecated TestRunner on import. astropy has changed both the
+    # wording and the category of this warning over time (AstropyPendingDeprecation
+    # -> AstropyDeprecation), so match any "TestRunner ... deprecated" message
+    # regardless of category.
+    'ignore:The TestRunner.*deprecated:'
 ]


### PR DESCRIPTION
## What & why

Every test job on current PRs (and `main` itself, if re-run) fails at **pytest startup** with an `INTERNALERROR`, before any test runs:

```
astropy.utils.exceptions.AstropyDeprecationWarning: The TestRunner class is
deprecated and may be removed in a future version. Use pytest instead.
```

This happens because the `pytest-astropy-header` plugin imports `astrowidgets` to display its version in the test header (our `conftest.py` adds `astrowidgets` to `PYTEST_HEADER_MODULES`), and `astrowidgets` imports astropy's deprecated `TestRunner` on import.

A **recent astropy release changed this warning**: the wording went from "…will be deprecated…" to "…is deprecated…", and the category from `AstropyPendingDeprecationWarning` to `AstropyDeprecationWarning`. Our existing `filterwarnings` ignore matched only the old wording **and** the old category, so under `filterwarnings = error` the warning is now an unhandled error that aborts the whole session.

This is an astropy-version-driven breakage, not caused by any open feature PR — the last `main` Test run (#568) passed a few hours before the astropy update landed.

## Fix

Broaden the ignore filter to match any `The TestRunner ... deprecated` message regardless of category:

```diff
-    'ignore:The TestRunner.* class will be deprecated in a future version:astropy.utils.exceptions.AstropyPendingDeprecationWarning'
+    'ignore:The TestRunner.*deprecated:'
```

This matches both the old and new wording (verified), and drops the category pin so a future category change won't break it again.

## Notes

- Should unblock CI on the open reorg PRs (#569, #570) once it lands on `main` and they re-run.
- This PR was written by Claude at mwcraig's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
