### PR TITLE
Update architecture diagrams after the stellarphot.gui reorg

### DIFF
--- a/docs/diagrams-01-package-overview.md
+++ b/docs/diagrams-01-package-overview.md
@@ -11,12 +11,12 @@ The modules group into these logical components:
 | Component | Modules | Role |
 |---|---|---|
 | **Core data layer** | `core.py`, `table_representations.py` | Validated astropy `QTable` subclasses (`PhotometryData`, `CatalogData`, `SourceListData`) and catalog fetchers; YAML (de)serialization of settings stored in table metadata |
-| **Settings & configuration** | `settings/` | Pydantic models for all configuration, saved-settings file management, widget generation |
+| **Settings & configuration** | `settings/` | Pydantic models for all configuration and saved-settings file management — pure Pydantic, no GUI imports |
 | **Photometry engine** | `photometry/` | Source detection, FWHM measurement, aperture photometry pipeline |
 | **Differential photometry** | `differential_photometry/` | Relative flux (AIJ-style) and variable-star magnitude calculations |
-| **Transit fitting** | `transit_fitting/` | Exoplanet transit modeling (batman), EXOTIC helper GUI, TIC queries |
+| **Transit fitting** | `transit_fitting/` | Exoplanet transit modeling (batman), TIC/MAST queries (the EXOTIC helper GUI moved to `gui/`) |
 | **Input/output** | `io/` | AstroImageJ, AAVSO extended format, TESS/TFOP files |
-| **GUI tools** | `gui_tools/` | Interactive notebook widgets (seeing profile, comparison-star selection) |
+| **GUI layer** | `gui/` | All notebook/widget UI, consolidated here so the rest of the package stays headless: the settings-form generator (`views.py`), settings widgets (`custom_widgets.py`), file chooser (`fits_opener.py`), seeing-profile/comparison-star widgets, and the EXOTIC helper. Requires the optional `[gui]` extra |
 | **Plotting** | `plotting/` | Seeing, transit, and multi-night light-curve plots |
 | **Utilities** | `utils/` | Magnitude calibration/transforms, comparison-star helpers, version migration |
 | **Notebooks** | `notebooks/` | Shipped workflow notebooks (the user-facing entry points) |
@@ -64,7 +64,7 @@ flowchart LR
     classDef output fill:#f3e5f5,stroke:#7b1fa2,color:#212121
 
     nb["notebooks/<br/>(10 launcher notebooks)"]:::ui
-    gui["gui_tools/"]:::ui
+    gui["gui/"]:::ui
     sett["settings/"]:::ui
     phot["photometry/"]:::engine
     diff["differential_photometry/"]:::engine
@@ -84,8 +84,7 @@ flowchart LR
     gui --> iop
     gui --> uts
     gui --> corem
-
-    sett -->|"custom_widgets uses io.tess"| iop
+    gui -->|"transit_fitting_gui uses get_tic_info"| tfit
 
     phot --> corem
     phot --> sett
@@ -103,7 +102,7 @@ flowchart LR
     trep --> sett
 
     click nb href "../stellarphot/notebooks/" "notebooks/"
-    click gui href "../stellarphot/gui_tools/" "gui_tools/"
+    click gui href "../stellarphot/gui/" "gui/"
     click sett href "../stellarphot/settings/" "settings/"
     click phot href "../stellarphot/photometry/" "photometry/"
     click diff href "../stellarphot/differential_photometry/" "differential_photometry/"
@@ -226,20 +225,22 @@ Key contents of each file:
   `mag_scale()`, `in_field()`, `read_file()`.
 - [`utils/version_migrator.py`](../stellarphot/utils/version_migrator.py) — `VersionMigrator` (stellarphot 1 → 2 data).
 
-## UI cluster (settings + gui_tools, file level)
+## UI cluster (gui + settings, file level)
 
-The widget layer is built from pydantic models (`models.py`), auto-generated
-UIs (`views.py`), and persistent storage (`settings_files.py`).
+The entire widget layer now lives in `stellarphot.gui`: the auto-generated
+settings forms (`views.py`, `ui_generator`), the settings widgets
+(`custom_widgets.py`), the file chooser (`fits_opener.py`), and the
+seeing-profile/comparison-star widgets. It is built on top of the pure-Pydantic
+`stellarphot.settings` package (`models.py`, `settings_files.py`).
 
-`stellarphot.settings` is **data-only at import time**: importing it (and hence
+`stellarphot.settings` is **data-only**: importing it (and hence
 `import stellarphot` and the core data layer) loads only the pydantic models and
-file handling, not the GUI stack. The widget layer (`views.py`,
-`custom_widgets.py`, `fits_opener.py`) pulls in `ipywidgets`/`ipyautoui` and is
-imported on demand — `ui_generator` is re-exported lazily from the package via a
-module-level `__getattr__`, so `from stellarphot.settings import ui_generator`
-keeps working without loading widgets eagerly.
+file handling, never the GUI stack. The GUI libraries
+(`ipywidgets`/`ipyautoui`/`astrowidgets`/`ginga`) are confined to
+`stellarphot.gui` and ship only with the optional `[gui]` extra, so a base
+install stays headless; importing `stellarphot.gui` is what pulls them in.
 
-*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, a lazy import, or a looser link.*
+*Arrows: **solid** = an import (importer → imported); **dashed** = a notebook driving a UI layer, or a looser link.*
 
 ```mermaid
 flowchart LR
@@ -248,21 +249,21 @@ flowchart LR
 
     nb["notebooks/<br/>(launcher)"]:::nbstyle
 
-    subgraph sg_gui["stellarphot.gui_tools"]
+    subgraph sg_gui["stellarphot.gui (the [gui] extra)"]
         direction TB
         pac_py["profile_and_comps.py<br/>ComparisonAndSeeing"]
         comp_py["comparison_functions.py<br/>ComparisonViewer"]
         seeing_py["seeing_profile_functions.py<br/>SeeingProfileWidget"]
         photwidg_py["photometry_widget_functions.py<br/>TessAnalysisInputControls"]
-    end
-
-    subgraph sg_set["stellarphot.settings"]
-        direction TB
         cw_py["custom_widgets.py<br/>ReviewSettings, ChooseOrMakeNew,<br/>PhotometryRunner, TessPhotometrySetup"]
         views_py["views.py<br/>ui_generator"]
+        fo_py["fits_opener.py<br/>FitsOpener"]
+    end
+
+    subgraph sg_set["stellarphot.settings (pure Pydantic)"]
+        direction TB
         sf_py["settings_files.py<br/>SavedSettings,<br/>PhotometryWorkingDirSettings"]
         models_py["models.py<br/>PhotometrySettings, Camera,<br/>Observatory, ..."]
-        fo_py["fits_opener.py<br/>FitsOpener"]
         ap_py["astropy_pydantic.py"]
         aavsom_py["aavso_models.py"]
         aavsos_py["aavso_submission.py"]
@@ -295,7 +296,7 @@ flowchart LR
 
     cw_py --> models_py
     cw_py --> sf_py
-    cw_py -.->|"ui_generator (lazy)"| views_py
+    cw_py -->|"ui_generator"| views_py
     cw_py --> fo_py
     cw_py -->|"tess_photometry_setup"| io_ext
     sf_py --> models_py
@@ -305,15 +306,15 @@ flowchart LR
     aavsos_py --> models_py
 
     click nb href "../stellarphot/notebooks/" "notebooks/"
-    click pac_py href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
-    click comp_py href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click seeing_py href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click photwidg_py href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
-    click cw_py href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click views_py href "../stellarphot/settings/views.py" "views.py"
+    click pac_py href "../stellarphot/gui/profile_and_comps.py" "profile_and_comps.py"
+    click comp_py href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click seeing_py href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click photwidg_py href "../stellarphot/gui/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click cw_py href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click views_py href "../stellarphot/gui/views.py" "views.py"
     click sf_py href "../stellarphot/settings/settings_files.py" "settings_files.py"
     click models_py href "../stellarphot/settings/models.py" "models.py"
-    click fo_py href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click fo_py href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
     click ap_py href "../stellarphot/settings/astropy_pydantic.py" "astropy_pydantic.py"
     click aavsom_py href "../stellarphot/settings/aavso_models.py" "aavso_models.py"
     click aavsos_py href "../stellarphot/settings/aavso_submission.py" "aavso_submission.py"
@@ -332,20 +333,20 @@ Key contents of each file:
 - [`settings/settings_files.py`](../stellarphot/settings/settings_files.py) — `SavedSettings` (per-user storage of
   cameras/observatories/passband maps), `PhotometryWorkingDirSettings`
   (loads/saves `photometry_settings.json` in the working directory).
-- [`settings/views.py`](../stellarphot/settings/views.py) — `ui_generator()` (builds an `ipyautoui` widget from
+- [`gui/views.py`](../stellarphot/gui/views.py) — `ui_generator()` (builds an `ipyautoui` widget from
   any pydantic model).
-- [`settings/custom_widgets.py`](../stellarphot/settings/custom_widgets.py) — `ChooseOrMakeNew`, `Confirm`,
+- [`gui/custom_widgets.py`](../stellarphot/gui/custom_widgets.py) — `ChooseOrMakeNew`, `Confirm`,
   `SettingWithTitle`, `ReviewSettings`, `PhotometryRunner`,
   `TessPhotometrySetup`, `Spinner`.
-- [`settings/fits_opener.py`](../stellarphot/settings/fits_opener.py) — `FitsOpener` (file chooser + lazy
+- [`gui/fits_opener.py`](../stellarphot/gui/fits_opener.py) — `FitsOpener` (file chooser + lazy
   `CCDData`/header access).
-- [`gui_tools/seeing_profile_functions.py`](../stellarphot/gui_tools/seeing_profile_functions.py) — `SeeingProfileWidget`,
+- [`gui/seeing_profile_functions.py`](../stellarphot/gui/seeing_profile_functions.py) — `SeeingProfileWidget`,
   `set_keybindings()`.
-- [`gui_tools/comparison_functions.py`](../stellarphot/gui_tools/comparison_functions.py) — `ComparisonViewer`,
+- [`gui/comparison_functions.py`](../stellarphot/gui/comparison_functions.py) — `ComparisonViewer`,
   `make_markers()`.
-- [`gui_tools/photometry_widget_functions.py`](../stellarphot/gui_tools/photometry_widget_functions.py) — `TessAnalysisInputControls`,
+- [`gui/photometry_widget_functions.py`](../stellarphot/gui/photometry_widget_functions.py) — `TessAnalysisInputControls`,
   `filter_by_dates()`.
-- [`gui_tools/profile_and_comps.py`](../stellarphot/gui_tools/profile_and_comps.py) — `ComparisonAndSeeing` (combines the
+- [`gui/profile_and_comps.py`](../stellarphot/gui/profile_and_comps.py) — `ComparisonAndSeeing` (combines the
   seeing and comparison widgets).
 
 ## Output / IO cluster (file level)
@@ -366,10 +367,11 @@ flowchart LR
     subgraph sg_tf["stellarphot.transit_fitting"]
         direction TB
         tf_core["core.py<br/>TransitModelFit"]
-        tf_gui["gui.py<br/>exotic_settings_widget"]
         tf_io["io.py<br/>get_tic_info"]
         tf_plot["plotting.py<br/>plot_predict_ingress_egress"]
     end
+
+    tf_gui["gui/transit_fitting_gui.py<br/>exotic_settings_widget<br/>(stellarphot.gui)"]:::external
 
     subgraph sg_plot["stellarphot.plotting"]
         direction TB
@@ -396,7 +398,7 @@ flowchart LR
     click aavso_py href "../stellarphot/io/aavso.py" "io/aavso.py"
     click tess_py href "../stellarphot/io/tess.py" "io/tess.py"
     click tf_core href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
-    click tf_gui href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click tf_gui href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
     click tf_io href "../stellarphot/transit_fitting/io.py" "transit_fitting/io.py"
     click tf_plot href "../stellarphot/transit_fitting/plotting.py" "transit_fitting/plotting.py"
     click aijplots_py href "../stellarphot/plotting/aij_plots.py" "plotting/aij_plots.py"
@@ -416,7 +418,7 @@ Key contents of each file:
   `tess_photometry_setup()`.
 - [`transit_fitting/core.py`](../stellarphot/transit_fitting/core.py) — `TransitModelFit`, `TransitModelOptions`,
   `VariableArgsFitter`.
-- [`transit_fitting/gui.py`](../stellarphot/transit_fitting/gui.py) — EXOTIC settings widget and TIC/TOI
+- [`gui/transit_fitting_gui.py`](../stellarphot/gui/transit_fitting_gui.py) — EXOTIC settings widget and TIC/TOI
   population helpers.
 - [`transit_fitting/io.py`](../stellarphot/transit_fitting/io.py) — `get_tic_info()` (MAST catalog query).
 - [`transit_fitting/plotting.py`](../stellarphot/transit_fitting/plotting.py) — `plot_predict_ingress_egress()`.
@@ -431,7 +433,7 @@ Key contents of each file:
 |---|---|
 | Core data layer | astropy (QTable, SkyCoord, Time, units), astroquery (Vizier, XMatch), pandas, lightkurve — no GUI stack at import time |
 | Photometry engine | photutils (apertures, DAOStarFinder, centroids, profiles), astropy, ccdproc |
-| Settings | pydantic (eager); ipywidgets, ipyautoui, papermill (lazy — widget layer `views`/`custom_widgets`/`fits_opener` only) |
+| Settings | pydantic only — no GUI dependencies (the widget layer moved to `stellarphot.gui`) |
 | Transit fitting | batman-package, astropy.modeling, scipy, astroquery (MAST) |
-| GUI tools | ipywidgets, astrowidgets, matplotlib |
+| GUI layer | the optional `[gui]` extra: ipywidgets, ipyautoui, ipyfilechooser, astrowidgets, ginga, jupyter-app-launcher, papermill (plus matplotlib from the base install) — not installed by a base `pip install stellarphot` |
 | Plotting | matplotlib |

--- a/docs/diagrams-02-entry-points.md
+++ b/docs/diagrams-02-entry-points.md
@@ -101,15 +101,15 @@ flowchart LR
     click nb_fit1 href "../stellarphot/notebooks/tess-initial-model-fit.ipynb" "tess-initial-model-fit.ipynb"
     click nb_fit2 href "../stellarphot/notebooks/tess-second-model-fit.ipynb" "tess-second-model-fit.ipynb"
     click nb_exotic href "../stellarphot/notebooks/tess-EXOTIC-fit.ipynb" "tess-EXOTIC-fit.ipynb"
-    click review1 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click cas href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
-    click review3 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click review1 href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click cas href "../stellarphot/gui/profile_and_comps.py" "profile_and_comps.py"
+    click review3 href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click runner href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click tps href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click addflux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
     click calib href "../stellarphot/utils/magnitude_transforms.py" "magnitude_transforms.py"
     click fitstack href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
-    click exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click exotic href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
     click apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
 ```
 
@@ -167,8 +167,8 @@ flowchart LR
         apphot["stellarphot.photometry<br/>AperturePhotometry"]:::api
         tmf["stellarphot.transit_fitting<br/>TransitModelFit"]:::api
         relflux["stellarphot.differential_photometry<br/>calc_aij_relative_flux()"]:::api
-        cview["stellarphot.gui_tools<br/>ComparisonViewer, SeeingProfileWidget"]:::widget
-        rsw["stellarphot.settings.custom_widgets<br/>ReviewSettings, PhotometryRunner"]:::widget
+        cview["stellarphot.gui<br/>ComparisonViewer, SeeingProfileWidget"]:::widget
+        rsw["stellarphot.gui.custom_widgets<br/>ReviewSettings, PhotometryRunner"]:::widget
         waavso["stellarphot.io<br/>write_aavso_extended(), TOI"]:::api
     end
 
@@ -187,8 +187,8 @@ flowchart LR
     click apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
     click tmf href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
     click relflux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
-    click cview href "../stellarphot/gui_tools/" "gui_tools/"
-    click rsw href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click cview href "../stellarphot/gui/" "gui/"
+    click rsw href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click waavso href "../stellarphot/io/" "io/"
 ```
 

--- a/docs/diagrams-03-user-flows.md
+++ b/docs/diagrams-03-user-flows.md
@@ -87,15 +87,15 @@ flowchart LR
     srclist -.->|"reads"| w_apphot
     w_apphot -.->|"writes"| photecsv
 
-    click w_review1 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click w_seeing href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click w_comp href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click w_review3 href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click w_runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click w_review1 href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click w_seeing href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click w_comp href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click w_review3 href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click w_runner href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click w_apphot href "../stellarphot/photometry/photometry.py" "photometry.py"
 ```
 
-*Source: [seeing_profile_functions.py](../stellarphot/gui_tools/seeing_profile_functions.py), [comparison_functions.py](../stellarphot/gui_tools/comparison_functions.py), [custom_widgets.py](../stellarphot/settings/custom_widgets.py), [photometry.py](../stellarphot/photometry/photometry.py)*
+*Source: [seeing_profile_functions.py](../stellarphot/gui/seeing_profile_functions.py), [comparison_functions.py](../stellarphot/gui/comparison_functions.py), [custom_widgets.py](../stellarphot/gui/custom_widgets.py), [photometry.py](../stellarphot/photometry/photometry.py)*
 
 ## Flow 2 — Exoplanet transit analysis
 
@@ -157,15 +157,15 @@ flowchart LR
     aavso -.->|"writes"| aavsofile
 
     click w_flux href "../stellarphot/differential_photometry/aij_rel_fluxes.py" "aij_rel_fluxes.py"
-    click w_inputs1 href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click w_inputs1 href "../stellarphot/gui/photometry_widget_functions.py" "photometry_widget_functions.py"
     click w_fit1 href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
     click w_plot1 href "../stellarphot/plotting/transit_plots.py" "transit_plots.py"
     click w_fit2 href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
-    click w_exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click w_exotic href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
     click aavso href "../stellarphot/core.py" "core.py"
 ```
 
-*Source: [aij_rel_fluxes.py](../stellarphot/differential_photometry/aij_rel_fluxes.py), [photometry_widget_functions.py](../stellarphot/gui_tools/photometry_widget_functions.py), [transit_fitting/core.py](../stellarphot/transit_fitting/core.py), [transit_plots.py](../stellarphot/plotting/transit_plots.py), [transit_fitting/gui.py](../stellarphot/transit_fitting/gui.py)*
+*Source: [aij_rel_fluxes.py](../stellarphot/differential_photometry/aij_rel_fluxes.py), [photometry_widget_functions.py](../stellarphot/gui/photometry_widget_functions.py), [transit_fitting/core.py](../stellarphot/transit_fitting/core.py), [transit_plots.py](../stellarphot/plotting/transit_plots.py), [gui/transit_fitting_gui.py](../stellarphot/gui/transit_fitting_gui.py)*
 
 ## Flow 3 — Supporting flows
 
@@ -199,11 +199,11 @@ flowchart LR
     f_setup -.->|"writes"| info
     f_setup -.->|"writes"| srclist
 
-    click w_tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click w_tps href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click f_setup href "../stellarphot/io/tess.py" "io/tess.py"
 ```
 
-*Source: [custom_widgets.py](../stellarphot/settings/custom_widgets.py), [io/tess.py](../stellarphot/io/tess.py)*
+*Source: [custom_widgets.py](../stellarphot/gui/custom_widgets.py), [io/tess.py](../stellarphot/io/tess.py)*
 
 ### Calibrate magnitudes to a catalog (APASS DR9)
 

--- a/docs/diagrams-04-call-graphs.md
+++ b/docs/diagrams-04-call-graphs.md
@@ -314,7 +314,7 @@ flowchart LR
     click tabrep href "../stellarphot/table_representations.py" "table_representations.py"
 ```
 
-## [settings/custom_widgets.py](../stellarphot/settings/custom_widgets.py) — widget layer
+## [gui/custom_widgets.py](../stellarphot/gui/custom_widgets.py) — widget layer
 
 *Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
 
@@ -359,24 +359,24 @@ flowchart LR
     tps --> spinner
     tps -->|"watch_confirmation()"| tpsetup
 
-    click review href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click swt href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click cmn href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click confirm href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click addsave href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click runner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click tps href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
-    click spinner href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click review href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click swt href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click cmn href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click confirm href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click addsave href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click runner href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click tps href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
+    click spinner href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click saved href "../stellarphot/settings/settings_files.py" "settings_files.py"
     click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
-    click uigen href "../stellarphot/settings/views.py" "views.py"
-    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click uigen href "../stellarphot/gui/views.py" "views.py"
+    click fo href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
     click tpsetup href "../stellarphot/io/tess.py" "io/tess.py"
     click runsettings href "../stellarphot/settings/models.py" "models.py"
     click papermill href "../stellarphot/notebooks/photometry_runner.ipynb" "photometry_runner.ipynb"
 ```
 
-## [settings/settings_files.py](../stellarphot/settings/settings_files.py) + [settings/fits_opener.py](../stellarphot/settings/fits_opener.py)
+## [settings/settings_files.py](../stellarphot/settings/settings_files.py) + [gui/fits_opener.py](../stellarphot/gui/fits_opener.py)
 
 *Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
 
@@ -449,9 +449,9 @@ flowchart LR
     click pwds_load href "../stellarphot/settings/settings_files.py" "settings_files.py"
     click pwds_partial href "../stellarphot/settings/settings_files.py" "settings_files.py"
     click pwds_conflict href "../stellarphot/settings/settings_files.py" "settings_files.py"
-    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
-    click fo_ccd href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
-    click fo_load href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click fo href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
+    click fo_ccd href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
+    click fo_load href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
     click models href "../stellarphot/settings/models.py" "models.py"
 ```
 
@@ -638,7 +638,7 @@ flowchart LR
         opts["TransitModelOptions"]:::cls
     end
 
-    subgraph sg_gui["gui.py"]
+    subgraph sg_gui["gui/transit_fitting_gui.py<br/>(stellarphot.gui)"]
         direction TB
         exotic["exotic_settings_widget()"]:::fn
         pop_tic["populate_TIC_boxes()"]:::fn
@@ -678,18 +678,18 @@ flowchart LR
     click tmf_bic href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
     click fitter href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
     click opts href "../stellarphot/transit_fitting/core.py" "transit_fitting/core.py"
-    click exotic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click pop_tic href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click pop_toi href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click checker href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click getvals href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click genjson href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
-    click setjson href "../stellarphot/transit_fitting/gui.py" "transit_fitting/gui.py"
+    click exotic href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click pop_tic href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click pop_toi href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click checker href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click getvals href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click genjson href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
+    click setjson href "../stellarphot/gui/transit_fitting_gui.py" "gui/transit_fitting_gui.py"
     click gettic href "../stellarphot/transit_fitting/io.py" "transit_fitting/io.py"
     click ingress href "../stellarphot/transit_fitting/plotting.py" "transit_fitting/plotting.py"
 ```
 
-## [gui_tools/comparison_functions.py](../stellarphot/gui_tools/comparison_functions.py)
+## [gui/comparison_functions.py](../stellarphot/gui/comparison_functions.py)
 
 *Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
 
@@ -732,24 +732,24 @@ flowchart LR
     cv_saveap --> cv_table
     cv_tess --> markers
 
-    click cv_init href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_setup href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_viewer href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_table href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_saveloc href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_saveap href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click cv_tess href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click markers href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click wrapfn href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
-    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
+    click cv_init href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_setup href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_viewer href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_table href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_saveloc href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_saveap href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click cv_tess href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click markers href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click wrapfn href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
+    click fo href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
     click setup_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
     click xmatch_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
     click magscale_ext href "../stellarphot/utils/comparison_utils.py" "comparison_utils.py"
-    click keybind href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click keybind href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
     click sld href "../stellarphot/core.py" "core.py"
 ```
 
-## [gui_tools](../stellarphot/gui_tools/) — seeing profile and TESS analysis widgets
+## [gui](../stellarphot/gui/) — seeing profile and TESS analysis widgets
 
 *Arrows: **solid** = a direct call or instantiation; **dashed** = file or network I/O, or an optional path.*
 
@@ -806,23 +806,23 @@ flowchart LR
     taic --> pdata
     taic -.-> fbd
 
-    click spw_init href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click spw_show href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click spw_plots href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click spw_save href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click spw_tess href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click keybind href "../stellarphot/gui_tools/seeing_profile_functions.py" "seeing_profile_functions.py"
-    click cas href "../stellarphot/gui_tools/profile_and_comps.py" "profile_and_comps.py"
-    click taic href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
-    click fbd href "../stellarphot/gui_tools/photometry_widget_functions.py" "photometry_widget_functions.py"
-    click fo href "../stellarphot/settings/fits_opener.py" "fits_opener.py"
-    click cmn href "../stellarphot/settings/custom_widgets.py" "custom_widgets.py"
+    click spw_init href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_show href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_plots href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_save href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click spw_tess href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click keybind href "../stellarphot/gui/seeing_profile_functions.py" "seeing_profile_functions.py"
+    click cas href "../stellarphot/gui/profile_and_comps.py" "profile_and_comps.py"
+    click taic href "../stellarphot/gui/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click fbd href "../stellarphot/gui/photometry_widget_functions.py" "photometry_widget_functions.py"
+    click fo href "../stellarphot/gui/fits_opener.py" "fits_opener.py"
+    click cmn href "../stellarphot/gui/custom_widgets.py" "custom_widgets.py"
     click pwds href "../stellarphot/settings/settings_files.py" "settings_files.py"
     click cap href "../stellarphot/photometry/profiles.py" "profiles.py"
     click splot href "../stellarphot/plotting/aij_plots.py" "aij_plots.py"
     click apert href "../stellarphot/settings/models.py" "models.py"
     click tsub href "../stellarphot/io/tess.py" "io/tess.py"
-    click cviewer href "../stellarphot/gui_tools/comparison_functions.py" "comparison_functions.py"
+    click cviewer href "../stellarphot/gui/comparison_functions.py" "comparison_functions.py"
     click pdata href "../stellarphot/core.py" "core.py"
 ```
 


### PR DESCRIPTION
Follow-up to #569 (move widget code into `stellarphot.gui`) and #570 (make the GUI an optional `[gui]` extra). The four mermaid architecture pages under `docs/` still described the pre-reorg layout, so their source links resolved to the wrong API sections (and to the back-compat shim files on GitHub).

## Changes
- **All four pages:** repath every `click`, markdown link, section header, and node label — `gui_tools/*`, the former settings widget layer (`views`/`custom_widgets`/`fits_opener`), and `transit_fitting/gui.py` now point at the real modules under `stellarphot.gui` (`transit_fitting/gui.py` → `gui/transit_fitting_gui.py`).
- **diagrams-01:**
  - Move the widget nodes into the `stellarphot.gui` subgraph; leave only pure-Pydantic modules in `settings`.
  - Drop the now-false `settings → io` edge; add `gui → transit_fitting`.
  - Remove the no-longer-true claim that `from stellarphot.settings import ui_generator` keeps working (it now raises `ImportError`); make the `custom_widgets → views` edge a plain import.
  - Pull the transit-fitting GUI node out of the `transit_fitting` subgraph (it lives in `gui` now).
  - Refresh the component and external-dependency tables: `settings` is pure Pydantic; the GUI stack is the optional `[gui]` extra.
- **diagrams-04:** relabel the `gui.py` subgraph in the transit-fitting section to its new `gui/transit_fitting_gui.py` home.

## Verification
- No stale path tokens remain; every `../stellarphot/<path>` link target exists on disk.
- All mermaid blocks have consistent node references after the restructure.
- `sphinx-build` completes cleanly (exit 0); all four diagram pages render and the `source-read` link rewriter resolves every `gui` reference. `docs/conf.py` was already updated in #569 (it documents `stellarphot.gui` and `stellarphot.gui.transit_fitting_gui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)