### PR TITLE
Stop clearing foreign log handlers in photometry (#153)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ Bug Fixes
 ^^^^^^^^^
 + Fixed dependence on non-release version of astrowidgets for overwrite capability on output images. [#108]
 + Fixed computation of FWHM when fitting to data that includes NaNs. [#164]
++ The photometry logging no longer clears the root logger's handlers or removes
+  handlers it did not add. Stellarphot now tags its own handlers, removes only
+  those, and disables propagation so its messages are not duplicated by the
+  root logger. [#153]
 + The comparison-star viewer now applies its dim magnitude limit to the VSX
   variable-star lookup, so variables fainter than the limit are no longer
   marked. [#43]

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -45,6 +45,11 @@ __all__ = [
 # Allowed FITS header keywords for exposure values
 EXPOSURE_KEYWORDS = ["EXPOSURE", "EXPTIME", "TELAPSE", "ELAPTIME", "ONTIME", "LIVETIME"]
 
+# Attribute used to tag logging handlers that stellarphot itself created, so
+# that we can later remove only those and leave any caller-supplied handlers
+# (and the root logger's handlers) untouched. See issue #153.
+_STELLARPHOT_HANDLER = "_stellarphot_handler"
+
 
 class AperturePhotometry(BaseModel):
     """Class to perform aperture photometry on one or more images"""
@@ -134,8 +139,19 @@ def _add_log_handlers(logger, logfile, console_log):
     file_handler : `logging.FileHandler` or None
         The file handler that was created, or ``None`` if ``logfile`` was
         ``None``. Callers use this to flush/close the file when finished.
+
+    Notes
+    -----
+    Handlers created here are tagged with ``_STELLARPHOT_HANDLER`` so that
+    `_remove_our_handlers` can later remove only the handlers stellarphot
+    added. Propagation is also disabled on ``logger`` so its messages are not
+    duplicated by handlers attached to ancestor loggers (such as the root
+    logger), which means we never need to touch handlers we did not create.
     """
     logger.setLevel(logging.INFO)
+    # Do not propagate to ancestor loggers; the handlers added below fully
+    # handle our output, so there is no need to clear the root logger's handlers.
+    logger.propagate = False
 
     file_handler = None
     if logfile is not None:
@@ -143,15 +159,35 @@ def _add_log_handlers(logger, logfile, console_log):
         file_handler = logging.FileHandler(logfile)
         file_handler.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
         file_handler.setLevel(logging.INFO)
+        setattr(file_handler, _STELLARPHOT_HANDLER, True)
         logger.addHandler(file_handler)
 
     # Set up logging to console if requested, otherwise effectively suppress output
     console_handler = logging.StreamHandler() if console_log else logging.NullHandler()
     console_handler.setFormatter(logging.Formatter("%(message)s"))
     console_handler.setLevel(logging.INFO)
+    setattr(console_handler, _STELLARPHOT_HANDLER, True)
     logger.addHandler(console_handler)
 
     return file_handler
+
+
+def _remove_our_handlers(logger):
+    """
+    Remove only the handlers stellarphot added to ``logger``.
+
+    Handlers created by `_add_log_handlers` are tagged with
+    ``_STELLARPHOT_HANDLER``; any other handlers (added by the caller or by
+    other libraries) are left in place.
+
+    Parameters
+    ----------
+    logger : `logging.Logger`
+        Logger to clean up.
+    """
+    for handler in logger.handlers[:]:
+        if getattr(handler, _STELLARPHOT_HANDLER, False):
+            logger.removeHandler(handler)
 
 
 def single_image_photometry(
@@ -653,8 +689,8 @@ def single_image_photometry(
         fh.flush()
         fh.close()
 
-    # Remove logger handler
-    logger.handlers.clear()
+    # Remove only the handlers we added
+    _remove_our_handlers(logger)
 
     # Create PhotometryData object to return
     photom_data = PhotometryData(
@@ -730,12 +766,10 @@ def multi_image_photometry(
             "coordinates to use this function."
         )
 
-    # Set up logging (retrieve a logger but purge any existing handlers)
+    # Set up logging. Remove any handlers we added on a previous call but leave
+    # handlers the caller (or other libraries) installed in place.
     multilogger = logging.getLogger("multi_image_photometry")
-    # Remove all other existing handlers from the logger
-    # (Kind of brute force, but works for our purposes
-    for handler in multilogger.handlers[:]:
-        multilogger.removeHandler(handler)
+    _remove_our_handlers(multilogger)
 
     logfile = photometry_settings.logging_settings.logfile
     console_log = photometry_settings.logging_settings.console_log
@@ -760,12 +794,6 @@ def multi_image_photometry(
 
     # Build image file collection
     ifc = ImageFileCollection(directory_with_images)
-
-    # Disable any root logger handlers that are active before using
-    # logging (must be done here because ImageFileCollection() creates
-    # a logger)
-    if logging.root.hasHandlers():
-        logging.root.handlers.clear()
 
     n_files_processed = 0
 
@@ -858,8 +886,8 @@ def multi_image_photometry(
     if logfile is not None:
         fh.flush()
         fh.close()
-    # Remove logger handler
-    multilogger.handlers.clear()
+    # Remove only the handlers we added
+    _remove_our_handlers(multilogger)
 
     return all_phot
 

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -301,15 +301,19 @@ def single_image_photometry(
     logfile = logging_options.logfile
     console_log = logging_options.console_log
 
-    # If we have no handlers, set up logging
     logger = logging.getLogger("single_image_photometry")
 
-    # Use this to catch if logging was already set up by a call
-    # from multi_image_photometry before creating new log file handler
-    # (Warning: This actually just catches if the logger has any handlers.
-    # Probably not the best way to do this.)
+    # Only add our handlers if we have not already added them to *this* logger
+    # on an earlier call. We deliberately look at this logger's own handlers
+    # rather than logger.hasHandlers() (which walks up to the root logger), so
+    # that handlers configured elsewhere -- e.g. the root logger in a notebook
+    # or test session -- do not stop us from setting up our own log file. See
+    # issues #152 and #153.
+    we_set_up_logging = any(
+        getattr(handler, _STELLARPHOT_HANDLER, False) for handler in logger.handlers
+    )
     fh = None  # Default to file handler not existing
-    if logger.hasHandlers() is False:
+    if not we_set_up_logging:
         fh = _add_log_handlers(logger, logfile, console_log)
     fh_exists = fh is not None
 

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -568,6 +568,73 @@ class TestAperturePhotometry:
                     or np.abs(expected_flux - obs_avg_net_cnts) > expected_deviation
                 )
 
+    def test_multi_image_photometry_preserves_foreign_log_handlers(
+        self, photometry_settings_for_test
+    ):
+        # Regression test for #153. multi_image_photometry used to clear the
+        # root logger's handlers (and remove every handler from its own logger),
+        # which destroyed logging configuration that stellarphot did not set up.
+        # It must now leave handlers it did not add in place.
+        num_files = 3
+        fake_images = self.list_of_fakes(num_files)
+
+        noise_unit = photometry_settings_for_test.camera.read_noise.unit
+        photometry_settings_for_test.camera.read_noise = (
+            fake_images[0].noise_dev * noise_unit
+        )
+
+        root_logger = logging.getLogger()
+        multilogger = logging.getLogger("multi_image_photometry")
+        foreign_root_handler = logging.NullHandler()
+        foreign_named_handler = logging.NullHandler()
+        root_logger.addHandler(foreign_root_handler)
+        multilogger.addHandler(foreign_named_handler)
+
+        try:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+                temp_file_names = [
+                    Path(temp_dir) / f"tempfile_{i:02d}.fit"
+                    for i in range(1, num_files + 1)
+                ]
+                for i, image in enumerate(fake_images):
+                    image.write(temp_file_names[i])
+                object_name = fake_images[0].header["OBJECT"]
+
+                found_sources = source_detection(
+                    fake_images[0],
+                    fwhm=fake_images[0].sources["x_stddev"].mean(),
+                    threshold=10,
+                )
+                source_list_file = Path(temp_dir) / "source_list.ecsv"
+                found_sources.write(
+                    source_list_file, format="ascii.ecsv", overwrite=True
+                )
+
+                phot_options = (
+                    photometry_settings_for_test.photometry_optional_settings.model_copy()
+                )
+                phot_options.fwhm_method = FwhmMethods.FIT
+                photometry_settings_for_test.photometry_optional_settings = phot_options
+                source_locations = photometry_settings_for_test.source_location_settings
+                source_locations.use_coordinates = "sky"
+                source_locations.source_list_file = str(source_list_file)
+
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message="Cannot merge meta key",
+                        category=MergeConflictWarning,
+                    )
+                    ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
+                    ap_phot(temp_dir, object_of_interest=object_name)
+
+            # Handlers stellarphot did not add must still be present.
+            assert foreign_root_handler in root_logger.handlers
+            assert foreign_named_handler in multilogger.handlers
+        finally:
+            root_logger.removeHandler(foreign_root_handler)
+            multilogger.removeHandler(foreign_named_handler)
+
     def test_photometry_on_directory_with_no_ra_dec(self, photometry_settings_for_test):
         # Create list of fake CCDData objects
         num_files = 5

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -575,6 +575,13 @@ class TestAperturePhotometry:
         # root logger's handlers (and remove every handler from its own logger),
         # which destroyed logging configuration that stellarphot did not set up.
         # It must now leave handlers it did not add in place.
+        #
+        # The foreign root handler added below also guards against a subtler
+        # regression: single_image_photometry must still write to the log file
+        # even when the root logger already has handlers. It used to rely on
+        # multi_image_photometry clearing the root handlers and skipped its own
+        # setup (via logger.hasHandlers(), which walks up to root) when any were
+        # present.
         num_files = 3
         fake_images = self.list_of_fakes(num_files)
 
@@ -619,6 +626,14 @@ class TestAperturePhotometry:
                 source_locations.use_coordinates = "sky"
                 source_locations.source_list_file = str(source_list_file)
 
+                logging_settings = (
+                    photometry_settings_for_test.logging_settings.model_copy()
+                )
+                logging_settings.logfile = "test.log"
+                photometry_settings_for_test.logging_settings = logging_settings
+                # multi_image_photometry writes the log file into the image dir.
+                full_logfile = Path(temp_dir) / "test.log"
+
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore",
@@ -627,6 +642,12 @@ class TestAperturePhotometry:
                     )
                     ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
                     ap_phot(temp_dir, object_of_interest=object_name)
+
+                # single_image_photometry must still write to the log file even
+                # though the root logger already has a handler.
+                assert full_logfile.exists()
+                log_content = full_logfile.read_text()
+                assert "Calculating noise for all sources" in log_content
 
             # Handlers stellarphot did not add must still be present.
             assert foreign_root_handler in root_logger.handlers

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -590,6 +590,12 @@ class TestAperturePhotometry:
             fake_images[0].noise_dev * noise_unit
         )
 
+        # Add "foreign" handlers -- handlers added by something other than
+        # stellarphot -- to both the root logger and the multi_image_photometry
+        # logger. These stand in for handlers a downstream app or user might have
+        # installed. The asserts at the end of the test check that running
+        # photometry leaves these handlers in place instead of nuking handlers it
+        # did not create.
         root_logger = logging.getLogger()
         multilogger = logging.getLogger("multi_image_photometry")
         foreign_root_handler = logging.NullHandler()
@@ -641,6 +647,10 @@ class TestAperturePhotometry:
                         category=MergeConflictWarning,
                     )
                     ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
+                    # Calling AperturePhotometry on a directory (rather than a
+                    # single file) dispatches to multi_image_photometry, which in
+                    # turn calls single_image_photometry once per image. That is
+                    # how this test exercises the multi-image logging path.
                     ap_phot(temp_dir, object_of_interest=object_name)
 
                 # single_image_photometry must still write to the log file even


### PR DESCRIPTION
Closes #153.

> **Stacked on #575** (factor logging setup). Until #575 merges, this PR's diff also shows that commit; review the second commit here, or merge #575 first.

## Problem
The logging added in #150 needed to remove handlers to get clean output, and did so bluntly:

- `multi_image_photometry` ran `logging.root.handlers.clear()` — wiping handlers stellarphot never installed (the caller's / other libraries' logging config);
- both functions did `logger.handlers.clear()` / a remove-all loop on their own named loggers.

## Fix
- Handlers created by `_add_log_handlers` are tagged with a `_stellarphot_handler` attribute, and a new `_remove_our_handlers()` removes **only** tagged handlers.
- `_add_log_handlers` sets `logger.propagate = False`, so stellarphot's messages are fully handled by its own handlers and are not duplicated through the root logger. This removes the reason the root handlers were being cleared, so the `logging.root.handlers.clear()` block is deleted entirely.

## Test
`test_multi_image_photometry_preserves_foreign_log_handlers` installs a handler on the root logger and on the `multi_image_photometry` logger, runs a multi-image photometry pass, and asserts both survive. It fails against the old code (handlers cleared) and passes now. Existing logging output tests still pass, confirming logging itself is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
