### PR TITLE
Dedup change_to_tmp_dir test fixture into conftest (#426)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Other Changes and Additions
   They remain available as top-level names (``from stellarphot import
   apass_dr9``) and, for one or two releases, from ``stellarphot.core`` via a
   back-compat shim that raises an ``AstropyDeprecationWarning``. [#194]
++ The ``change_to_tmp_dir`` test fixture, previously duplicated in four test
+  modules, is now defined once in the top-level ``conftest.py``. [#426]
 
 Bug Fixes
 ^^^^^^^^^

--- a/stellarphot/conftest.py
+++ b/stellarphot/conftest.py
@@ -43,6 +43,22 @@ def pytest_unconfigure():
 
 
 @pytest.fixture
+def change_to_tmp_dir(tmp_path):
+    # Change the working directory to the temporary directory and then change
+    # back to the original directory after the test is done. This fixture is
+    # not autouse; tests (or a small autouse wrapper) that need it should
+    # request it explicitly.
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+    # Yielding here is important. It means that when the test is done, the remainder
+    # of the function will be executed. This is important because the test is run in
+    # a temporary directory and we want to change back to the original directory
+    # when the test is done.
+    yield
+    os.chdir(original_dir)
+
+
+@pytest.fixture
 def profile_stars():
     # Make a few round stars
     return Table(

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1,4 +1,3 @@
-import os
 from copy import deepcopy
 from pathlib import Path
 
@@ -960,18 +959,11 @@ class TestReviewSettings:
     Test of the magical ReviewSettings widget.
     """
 
-    # This auto-used fixture changes the working directory to the temporary directory
-    # and then changes back to the original directory after the test is done.
+    # Auto-use the shared change_to_tmp_dir fixture (defined in the top-level
+    # conftest) so every test in this class runs in a temporary directory.
     @pytest.fixture(autouse=True)
-    def change_to_tmp_dir(self, tmp_path):
-        original_dir = os.getcwd()
-        os.chdir(tmp_path)
-        # Yielding here is important. It means that when the test is done, the remainder
-        # of the function will be executed. This is important because the test is run in
-        # a temporary directory and we want to change back to the original directory
-        # when the test is done.
-        yield
-        os.chdir(original_dir)
+    def _change_to_tmp_dir(self, change_to_tmp_dir):
+        pass
 
     @pytest.mark.parametrize("container_type", ["tabs", "accordion"])
     def test_creation_no_saved_settings(self, container_type):

--- a/stellarphot/gui/tests/test_photometry_runner.py
+++ b/stellarphot/gui/tests/test_photometry_runner.py
@@ -1,4 +1,3 @@
-import os
 from copy import deepcopy
 from pathlib import Path
 
@@ -28,18 +27,11 @@ def fake_settings_dir(mocker, tmp_path):
 
 
 class TestPhotometryRunner:
-    # This auto-used fixture changes the working directory to the temporary directory
-    # and then changes back to the original directory after the test is done.
+    # Auto-use the shared change_to_tmp_dir fixture (defined in the top-level
+    # conftest) so every test in this class runs in a temporary directory.
     @pytest.fixture(autouse=True)
-    def change_to_tmp_dir(self, tmp_path):
-        original_dir = os.getcwd()
-        os.chdir(tmp_path)
-        # Yielding here is important. It means that when the test is done, the remainder
-        # of the function will be executed. This is important because the test is run in
-        # a temporary directory and we want to change back to the original directory
-        # when the test is done.
-        yield
-        os.chdir(original_dir)
+    def _change_to_tmp_dir(self, change_to_tmp_dir):
+        pass
 
     def test_photometry_runner_creation(self):
         # This test simply makes sure we can create the object

--- a/stellarphot/gui/tests/test_tess_photometry_setup.py
+++ b/stellarphot/gui/tests/test_tess_photometry_setup.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -11,18 +10,11 @@ from stellarphot.io.tess import TOI
 
 
 class TestTessPhotometrySetup:
-    # This auto-used fixture changes the working directory to the temporary directory
-    # and then changes back to the original directory after the test is done.
+    # Auto-use the shared change_to_tmp_dir fixture (defined in the top-level
+    # conftest) so every test in this class runs in a temporary directory.
     @pytest.fixture(autouse=True)
-    def change_to_tmp_dir(self, tmp_path):
-        original_dir = os.getcwd()
-        os.chdir(tmp_path)
-        # Yielding here is important. It means that when the test is done, the remainder
-        # of the function will be executed. This is important because the test is run in
-        # a temporary directory and we want to change back to the original directory
-        # when the test is done.
-        yield
-        os.chdir(original_dir)
+    def _change_to_tmp_dir(self, change_to_tmp_dir):
+        pass
 
     def test_creation(self):
         widget = TessPhotometrySetup()

--- a/stellarphot/io/tests/test_tess.py
+++ b/stellarphot/io/tests/test_tess.py
@@ -1,4 +1,3 @@
-import os
 import re
 import warnings
 from pathlib import Path
@@ -239,18 +238,11 @@ class TestTOI:
 
 
 class TestTessPhotometrySetup:
-    # This auto-used fixture changes the working directory to the temporary directory
-    # and then changes back to the original directory after the test is done.
+    # Auto-use the shared change_to_tmp_dir fixture (defined in the top-level
+    # conftest) so every test in this class runs in a temporary directory.
     @pytest.fixture(autouse=True)
-    def change_to_tmp_dir(self, tmp_path):
-        original_dir = os.getcwd()
-        os.chdir(tmp_path)
-        # Yielding here is important. It means that when the test is done, the remainder
-        # of the function will be executed. This is important because the test is run in
-        # a temporary directory and we want to change back to the original directory
-        # when the test is done.
-        yield
-        os.chdir(original_dir)
+    def _change_to_tmp_dir(self, change_to_tmp_dir):
+        pass
 
     def test_creation_invalid_input_raises_error(self):
         with pytest.raises(


### PR DESCRIPTION
Closes #426.

The same autouse `change_to_tmp_dir` fixture (chdir into a temp dir, yield, chdir back) was copied verbatim into four test modules:

- `stellarphot/io/tests/test_tess.py`
- `stellarphot/gui/tests/test_photometry_runner.py`
- `stellarphot/gui/tests/test_custom_widgets.py`
- `stellarphot/gui/tests/test_tess_photometry_setup.py`

This PR defines it once (as a **non-autouse** fixture) in the top-level `stellarphot/conftest.py`, and replaces each duplicate with a tiny autouse wrapper that just depends on the shared fixture:

```python
@pytest.fixture(autouse=True)
def _change_to_tmp_dir(self, change_to_tmp_dir):
    pass
```

This keeps the existing autouse behavior in each class while removing the duplicated chdir logic, and drops the now-unused `os` imports.

All four affected modules pass (`91 passed, 6 deselected` excluding remote-data tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
