### PR TITLE
Apply comparison magnitude limit to VSX lookup (#43)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Bug Fixes
 ^^^^^^^^^
 + Fixed dependence on non-release version of astrowidgets for overwrite capability on output images. [#108]
 + Fixed computation of FWHM when fitting to data that includes NaNs. [#164]
++ The comparison-star viewer now applies its dim magnitude limit to the VSX
+  variable-star lookup, so variables fainter than the limit are no longer
+  marked. [#43]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/gui/comparison_functions.py
+++ b/stellarphot/gui/comparison_functions.py
@@ -312,7 +312,9 @@ class ComparisonViewer:
         self._legend_spinner_box.children = [spinner]
         self.help_stuff.selected_index = 1
 
-        self.vsx = set_up(self.ccd)
+        # Apply the same dim magnitude limit to the VSX lookup that is used for
+        # the comparison stars so faint variables are not included (issue #43).
+        self.vsx = set_up(self.ccd, magnitude_limit=self.dim_mag_limit)
 
         apass, vsx_apass_angle, targets_apass_angle = crossmatch_APASS2VSX(
             self.ccd, self.targets_from_file, self.vsx

--- a/stellarphot/utils/comparison_utils.py
+++ b/stellarphot/utils/comparison_utils.py
@@ -36,7 +36,7 @@ def read_file(radec_file):
     return target_table
 
 
-def set_up(ccd):
+def set_up(ccd, magnitude_limit=None):
     """
     Read in sample image and find known variables in the field of view.
 
@@ -45,6 +45,12 @@ def set_up(ccd):
 
     ccd: `astropy.nddata.CCDData`
         Sample image.
+
+    magnitude_limit : float, optional (Default: None)
+        Faint magnitude limit applied to the VSX variable-star lookup. When
+        ``None`` (the default) no limit is applied. Pass the same dim magnitude
+        limit used for the comparison stars so that variable stars fainter than
+        that limit are not included (see issue #43).
 
     Returns
     -------
@@ -55,7 +61,9 @@ def set_up(ccd):
     """
 
     try:
-        vsx = vsx_vizier(ccd.wcs, radius=0.5 * u.degree)
+        vsx = vsx_vizier(
+            ccd.wcs, radius=0.5 * u.degree, magnitude_limit=magnitude_limit
+        )
     except RuntimeError:
         vsx = []
     else:

--- a/stellarphot/utils/tests/test_comparison_utils.py
+++ b/stellarphot/utils/tests/test_comparison_utils.py
@@ -1,0 +1,46 @@
+import astropy.units as u
+
+from stellarphot.utils import comparison_utils
+
+
+class _FakeCCD:
+    """Minimal stand-in for a CCDData that only needs a ``wcs`` attribute."""
+
+    wcs = object()
+
+
+def test_set_up_passes_magnitude_limit_to_vsx(monkeypatch):
+    # Regression test for #43. set_up should forward a magnitude limit to the
+    # VSX lookup so the comparison viewer can apply the same dim-magnitude
+    # cutoff to variable stars that it uses for comparison stars.
+    captured = {}
+
+    def fake_vsx_vizier(wcs, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        # Behave like "no variables found" so set_up returns without needing a
+        # real query result.
+        raise RuntimeError("no VSX results")
+
+    monkeypatch.setattr(comparison_utils, "vsx_vizier", fake_vsx_vizier)
+
+    result = comparison_utils.set_up(_FakeCCD(), magnitude_limit=13.5)
+
+    assert captured["magnitude_limit"] == 13.5
+    assert result == []
+
+
+def test_set_up_defaults_to_no_magnitude_limit(monkeypatch):
+    # By default no magnitude limit is applied to the VSX lookup.
+    captured = {}
+
+    def fake_vsx_vizier(wcs, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        raise RuntimeError("no VSX results")
+
+    monkeypatch.setattr(comparison_utils, "vsx_vizier", fake_vsx_vizier)
+
+    comparison_utils.set_up(_FakeCCD())
+
+    assert captured["magnitude_limit"] is None
+    # The search radius is still passed through unchanged.
+    assert captured["radius"] == 0.5 * u.degree


### PR DESCRIPTION
Closes #43.

The comparison-star viewer looked up VSX variable stars via `set_up(self.ccd)`, which called `vsx_vizier(ccd.wcs, radius=0.5 deg)` with **no** magnitude limit. As a result it marked variable stars far fainter than the comparison-star magnitude range the user selected. As noted in the issue, the viewer should apply the same magnitude limit to the variable-star lookup that it applies to the comparison stars.

## Changes
- `set_up()` ([`comparison_utils.py`](stellarphot/utils/comparison_utils.py)) gains a `magnitude_limit=None` parameter, forwarded to `vsx_vizier(...)` (which already supports `magnitude_limit`, defaulting its passband to `"max"`, the faint VSX magnitude).
- The comparison viewer now calls `set_up(self.ccd, magnitude_limit=self.dim_mag_limit)` ([`comparison_functions.py`](stellarphot/gui/comparison_functions.py)), reusing the same dim limit already used for the APASS comparison stars.

`magnitude_limit` defaults to `None`, so non-GUI callers of `set_up` are unaffected.

## Tests
New `stellarphot/utils/tests/test_comparison_utils.py` monkeypatches `vsx_vizier` and asserts (a) `set_up(..., magnitude_limit=13.5)` forwards the limit, and (b) the default applies no limit while still passing the search radius. Both fail against the old signature and pass now. The existing comparison-function GUI tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
