### PR TITLE
Retry Vizier queries on a mirror when a server returns empty results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ Bug Fixes
   marked. [#43]
 + Fixed ``TypeError`` in ``multi_image_photometry`` when exactly one source was
   missing from at least one image and ``reject_unmatched`` was enabled. [#474]
++ ``CatalogData.from_vizier`` now retries the query against a VizieR mirror
+  when a server returns an empty result (as happens when a server is up but
+  its database is unreachable), and raises an informative ``RuntimeError``
+  instead of an ``IndexError`` if every server comes back empty. [#585]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -46,6 +46,16 @@ __all__ = [
 # from ``stellarphot.core`` (with a deprecation warning) for one or two releases.
 _MOVED_TO_CATALOGS = frozenset({"apass_dr9", "vsx_vizier", "refcat2"})
 
+# VizieR servers to try, in order, when fetching a catalog. A server that is up
+# but whose database is broken answers with a VOTable containing only error
+# messages, which astroquery silently turns into an empty result -- so
+# ``CatalogData.from_vizier`` falls through this list whenever a query comes
+# back empty.
+VIZIER_SERVERS = (
+    "vizier.cds.unistra.fr",  # astroquery's default, at CDS
+    "vizier.cfa.harvard.edu",
+)
+
 
 def __getattr__(name):
     # PEP 562 module-level attribute access. Lazily forward the moved catalog
@@ -1248,13 +1258,27 @@ class CatalogData(BaseEnhancedTable):
             if magnitude_limit is not None
             else {}
         )
-        vizier = Vizier(
-            columns=["all"],
-            row_limit=-1,
-            column_filters=column_filter,
-            timeout=180,
-        )
-        cat = vizier.query_region(center, radius=radius, catalog=desired_catalog)
+        # When a VizieR server is unreachable it may still respond with a
+        # VOTable that contains only error messages, which astroquery turns
+        # into an empty result, so an empty result on one server is retried
+        # on the others.
+        for server in VIZIER_SERVERS:
+            vizier = Vizier(
+                columns=["all"],
+                row_limit=-1,
+                column_filters=column_filter,
+                timeout=180,
+                vizier_server=server,
+            )
+            cat = vizier.query_region(center, radius=radius, catalog=desired_catalog)
+            if len(cat) > 0:
+                break
+        else:
+            raise RuntimeError(
+                f"No results returned from Vizier for catalog {desired_catalog} "
+                f"around {center}. The region may contain no matching sources, "
+                "or the VizieR servers may be unavailable."
+            )
 
         # Vizier always returns list even if there is only one element. Grab that
         # element.

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -1041,6 +1041,90 @@ def test_from_vizier_with_header_no_wcs_raise_error():
         CatalogData.from_vizier(header, "B/vsx/vsx", clip_by_frame=True)
 
 
+class FakeVizier:
+    """
+    Stand-in for astroquery's Vizier that returns a canned result per server,
+    recording the servers queried. Empty-list results mimic what astroquery
+    returns when a VizieR server is down (it turns the error VOTable into an
+    empty TableList).
+    """
+
+    # server name -> list of tables to return; tests set this.
+    results_by_server = {}
+    servers_queried = []
+
+    def __init__(self, *_args, vizier_server=None, **_kwargs):
+        self.vizier_server = vizier_server
+
+    def query_region(self, *_args, **_kwargs):
+        FakeVizier.servers_queried.append(self.vizier_server)
+        return FakeVizier.results_by_server[self.vizier_server]
+
+
+def fake_vizier_table():
+    return Table(
+        {
+            "Name": ["DQ Psc"],
+            "RAJ2000": [359.94371],
+            "DEJ2000": [-0.2801],
+            "mag": [5.9],
+            "passband": ["Hp"],
+        }
+    )
+
+
+def test_from_vizier_falls_back_to_mirror(monkeypatch):
+    # When the first VizieR server returns an empty result (e.g. the server's
+    # database is down), from_vizier should retry against the next server in
+    # the list and succeed.
+    monkeypatch.setattr("stellarphot.core.Vizier", FakeVizier)
+    monkeypatch.setattr(
+        "stellarphot.core.VIZIER_SERVERS", ("dead.example.com", "mirror.example.com")
+    )
+    FakeVizier.results_by_server = {
+        "dead.example.com": [],
+        "mirror.example.com": [fake_vizier_table()],
+    }
+    FakeVizier.servers_queried = []
+
+    cat = CatalogData.from_vizier(
+        SkyCoord(ra=359.94371 * u.deg, dec=-0.2801 * u.deg),
+        "B/vsx/vsx",
+        colname_map=dict(Name="id", RAJ2000="ra", DEJ2000="dec"),
+        no_catalog_error=True,
+        tidy_catalog=False,
+    )
+
+    assert FakeVizier.servers_queried == ["dead.example.com", "mirror.example.com"]
+    assert len(cat) == 1
+    assert cat["id"][0] == "DQ Psc"
+
+
+def test_from_vizier_all_servers_empty_raises(monkeypatch):
+    # If every VizieR server returns an empty result the user should get an
+    # informative error, not an IndexError.
+    monkeypatch.setattr("stellarphot.core.Vizier", FakeVizier)
+    monkeypatch.setattr(
+        "stellarphot.core.VIZIER_SERVERS", ("dead.example.com", "mirror.example.com")
+    )
+    FakeVizier.results_by_server = {
+        "dead.example.com": [],
+        "mirror.example.com": [],
+    }
+    FakeVizier.servers_queried = []
+
+    with pytest.raises(RuntimeError, match="No results returned from Vizier"):
+        CatalogData.from_vizier(
+            SkyCoord(ra=359.94371 * u.deg, dec=-0.2801 * u.deg),
+            "B/vsx/vsx",
+            colname_map=dict(Name="id", RAJ2000="ra", DEJ2000="dec"),
+            no_catalog_error=True,
+            tidy_catalog=False,
+        )
+
+    assert FakeVizier.servers_queried == ["dead.example.com", "mirror.example.com"]
+
+
 # Load test apertures
 test_sl_data = ascii.read(
     get_pkg_data_filename("data/test_sourcelist.ecsv"), format="ecsv", fast_reader=False


### PR DESCRIPTION
## Root cause

All 24 remote-data test failures in recent CI runs (on `main` as well as PR #584) come from a single point: the CDS VizieR server (`vizier.cds.unistra.fr`, astroquery's default) is currently up but its database is down. In that state it answers cone searches with a VOTable containing only error records:

> "The database is not currently reachable ... Postgres connect error"

astroquery silently parses that error VOTable into an **empty `TableList`**, and `CatalogData.from_vizier` did `cat[0]` on it, crashing with a bare `IndexError: list index out of range`. All three catalog fetchers (`apass_dr9`, `vsx_vizier`, `refcat2`) funnel through `from_vizier`, so every remote-data catalog test failed.

The Harvard mirror (`vizier.cfa.harvard.edu`) is working. Note that the server must be selected per `Vizier` instance via the `vizier_server=` kwarg — setting `astroquery.vizier.conf.server` after import has no effect, because the default is bound at import time.

## Fix

- `from_vizier` now tries each server in a new module-level `VIZIER_SERVERS` tuple (CDS first, then the Harvard mirror) until one returns a non-empty result. A downed server returns its error VOTable quickly, so the retry is cheap.
- If every server comes back empty, it raises an informative `RuntimeError` instead of an `IndexError`. This integrates with existing behavior: `comparison_utils.set_up` already catches `RuntimeError` from the VSX lookup and treats it as "no variable stars in the field", so a genuinely empty region degrades gracefully.

## Testing

- Two new offline tests (fake Vizier class): fallback engages when the first server returns empty; informative `RuntimeError` when all servers return empty. Written first and confirmed failing before the fix.
- Live verification while the CDS outage is ongoing: `pytest stellarphot/tests/test_catalogs.py --remote-data=any` — all 17 pass via the mirror (they fail with `IndexError` on `main`).
- Non-GUI offline suite passes (the GUI modules don't import in my env, which has astrowidgets 0.5 installed for #584; unrelated to this change).

This PR was written by Claude Code at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoLkBuZUbs5kJY94pbsrdT
