### PR TITLE
Join Gaia IDs to refcat2 by row index instead of row order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,13 @@ Bug Fixes
   when a server returns an empty result (as happens when a server is up but
   its database is unreachable), and raises an informative ``RuntimeError``
   instead of an ``IndexError`` if every server comes back empty. [#585]
++ ``refcat2`` now joins the Gaia DR2 IDs from the CDS XMatch service to the
+  catalog on an explicit row index instead of relying on row order, which
+  XMatch does not preserve. Previously large fields could either crash with
+  ``ValueError: Inconsistent data column lengths`` or silently assign the
+  wrong Gaia ID to most stars. Only the coordinates are uploaded to XMatch
+  now, making the query much faster and less likely to fail on large
+  fields. [#586]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/catalogs.py
+++ b/stellarphot/catalogs.py
@@ -8,7 +8,13 @@ because they are data *retrieval* helpers rather than data-structure
 definitions. ``core.py`` holds the table classes only.
 """
 
+import logging
+import time
+import warnings
+
+import numpy as np
 from astropy import units as u
+from astropy.table import Table, unique
 from astroquery.xmatch import XMatch
 
 from .core import CatalogData
@@ -19,6 +25,113 @@ __all__ = [
     "vsx_vizier",
     "refcat2",
 ]
+
+logger = logging.getLogger(__name__)
+
+
+def _attach_gaia_ids(catalog, xmatch_result, index_col="_sp_index"):
+    """
+    Attach Gaia source_ids from an XMatch result to a catalog, joining on an
+    index column rather than on row order, which XMatch does not preserve.
+
+    Parameters
+    ----------
+    catalog : `astropy.table.Table`
+        The table the IDs are being attached to. The values of ``index_col``
+        in ``xmatch_result`` are row numbers into this table.
+
+    xmatch_result : `astropy.table.Table`
+        Result of an XMatch query whose uploaded table included ``index_col``.
+        Must contain ``index_col``, ``angDist`` and ``source_id`` columns.
+
+    index_col : str, optional
+        Name of the column in ``xmatch_result`` holding the row number of the
+        matching ``catalog`` row.
+
+    Returns
+    -------
+    `astropy.table.Table`
+        The matched rows of ``catalog``, in their original order, with a new
+        ``id`` column holding the Gaia source_id. Rows with no match are
+        dropped, with a warning saying how many.
+    """
+    # When one input row matches several Gaia sources, keep only the nearest.
+    xmatch_result = xmatch_result.copy()
+    xmatch_result.sort([index_col, "angDist"])
+    nearest = unique(xmatch_result, keys=index_col, keep="first")
+
+    n_unmatched = len(catalog) - len(nearest)
+    if n_unmatched > 0:
+        warnings.warn(
+            f"{n_unmatched} of {len(catalog)} catalog entries had no Gaia "
+            "match and have been dropped.",
+            stacklevel=2,
+        )
+
+    # nearest is sorted by index_col, so this preserves the original row order.
+    catalog = catalog[np.asarray(nearest[index_col])]
+    catalog["id"] = np.asarray(nearest["source_id"])
+    return catalog
+
+
+def _process_refcat2(catalog):
+    """
+    Prepare a raw Vizier refcat2 table:
+
+    1. Filter out galaxies from the catalog.
+    2. Only keep stars that are in the Gaia DR2 catalog.
+    3. Add the Gaia DR2 ID number to the catalog as the ID column.
+    """
+    # 1.
+    # The refcat2 paper says that "Virtually all galaxies can be rejected by
+    # selecting objects for which Gaia provides a nonzero proper-motion
+    # uncertainty," which in the Vizier download are called e_pmRA and e_pmDE,
+    # "at the cost of about 0.7% of all real stars." Seems like a reasonable
+    # trade-off. Vizier omits the zero entries and astroquery returns a mask for the
+    # zero entries, so galaxies are the masked ones.
+    galaxies = catalog["e_pmRA"].mask & catalog["e_pmDE"].mask
+    catalog = catalog[~galaxies]
+
+    # 2.
+    # Also from the paper, "A non-Gaia star may be identified in Refcat2 because it
+    # will always have dGaia = 0." In the Vizier version of refcat2, this column is
+    # called e_Gmag and instead of being zero, the value is masked.
+    catalog = catalog[~catalog["e_Gmag"].mask]
+
+    # 3.
+    # Everything left should be a Gaia star, so match to that.
+    # This adds some not-insignificant time to getting the catalog, but
+    # the result is automatically cached by astroquery, which helps.
+    #
+    # Upload only the coordinates plus a row index; uploading the full
+    # 40+ column table makes the query much slower and more likely to fail,
+    # and the index is the only reliable way to join the result back to the
+    # catalog because XMatch does not preserve row order.
+    upload = Table(
+        {
+            "_sp_index": np.arange(len(catalog)),
+            "RA_ICRS": catalog["RA_ICRS"],
+            "DE_ICRS": catalog["DE_ICRS"],
+        }
+    )
+    start = time.perf_counter()
+    result = XMatch.query(
+        cat1=upload,
+        cat2="vizier:gaia_dr2_j2015p5",  # "vizier:I/345/gaia2",
+        max_distance=0.01 * u.arcsec,
+        colRA1="RA_ICRS",
+        colDec1="DE_ICRS",
+    )
+    elapsed = time.perf_counter() - start
+    logger.info(
+        "XMatch query for Gaia DR2 IDs took %.1f sec "
+        "(%d rows uploaded, %d matches returned)",
+        elapsed,
+        len(upload),
+        len(result),
+    )
+
+    return _attach_gaia_ids(catalog, result)
 
 
 def apass_dr9(
@@ -338,44 +451,6 @@ def refcat2(
     #     # by magnitude.
     #     magnitude_limit_passband = None
 
-    def process_refcat2(catalog):
-        """
-        This function does a few things:
-
-        1. Filter out galaxies from the catalog.
-        2. Only keep stars that are in the Gaia DR2 catalog.
-        3. Add the Gaia DR2 ID number to the catalog as the ID column.
-        """
-        # 1.
-        # The refcat2 paper says that "Virtually all galaxies can be rejected by
-        # selecting objects for which Gaia provides a nonzero proper-motion
-        # uncertainty," which in the Vizier download are called e_pmRA and e_pmDE,
-        # "at the cost of about 0.7% of all real stars." Seems like a reasonable
-        # trade-off. Vizier omits the zero entries and astroquery returns a mask for the
-        # zero entries, so galaxies are the masked ones.
-        galaxies = catalog["e_pmRA"].mask & catalog["e_pmDE"].mask
-        catalog = catalog[~galaxies]
-
-        # 2.
-        # Also from the paper, "A non-Gaia star may be identified in Refcat2 because it
-        # will always have dGaia = 0." In the Vizier version of refcat2, this column is
-        # called e_Gmag and instead of being zero, the value is masked.
-        catalog = catalog[~catalog["e_Gmag"].mask]
-
-        # 3.
-        # Everything left should be a Gaia star, so match to that.
-        # This adds some not-insignificant time to getting the catalog, but
-        # the result is automatically cached by astroquery, which helps.
-        result = XMatch.query(
-            cat1=catalog,
-            cat2="vizier:gaia_dr2_j2015p5",  # "vizier:I/345/gaia2",
-            max_distance=0.01 * u.arcsec,
-            colRA1="RA_ICRS",
-            colDec1="DE_ICRS",
-        )
-        catalog["id"] = result["source_id"]
-        return catalog
-
     raw_catalog = CatalogData.from_vizier(
         field_center,
         "J/ApJ/867/105/refcat2",
@@ -383,7 +458,7 @@ def refcat2(
         clip_by_frame=clip_by_frame,
         padding=padding,
         colname_map=refcat2_colnames,
-        prepare_catalog=process_refcat2,
+        prepare_catalog=_process_refcat2,
         magnitude_limit=magnitude_limit,
         magnitude_limit_passband=magnitude_limit_passband,
     )

--- a/stellarphot/catalogs.py
+++ b/stellarphot/catalogs.py
@@ -43,6 +43,7 @@ def _attach_gaia_ids(catalog, xmatch_result, index_col="_sp_index"):
     xmatch_result : `astropy.table.Table`
         Result of an XMatch query whose uploaded table included ``index_col``.
         Must contain ``index_col``, ``angDist`` and ``source_id`` columns.
+        This table is sorted in place.
 
     index_col : str, optional
         Name of the column in ``xmatch_result`` holding the row number of the
@@ -56,7 +57,6 @@ def _attach_gaia_ids(catalog, xmatch_result, index_col="_sp_index"):
         dropped, with a warning saying how many.
     """
     # When one input row matches several Gaia sources, keep only the nearest.
-    xmatch_result = xmatch_result.copy()
     xmatch_result.sort([index_col, "angDist"])
     nearest = unique(xmatch_result, keys=index_col, keep="first")
 
@@ -68,7 +68,11 @@ def _attach_gaia_ids(catalog, xmatch_result, index_col="_sp_index"):
             stacklevel=2,
         )
 
-    # nearest is sorted by index_col, so this preserves the original row order.
+    # nearest[index_col] holds the row numbers of the catalog rows that got a
+    # match — one per matched star, sorted ascending. Indexing catalog with it
+    # does two things at once: it drops the unmatched rows (their index never
+    # appears in the result) and it puts the matched rows in the same order as
+    # nearest, so the source_id assignment below lines up row-for-row.
     catalog = catalog[np.asarray(nearest[index_col])]
     catalog["id"] = np.asarray(nearest["source_id"])
     return catalog

--- a/stellarphot/tests/test_catalogs.py
+++ b/stellarphot/tests/test_catalogs.py
@@ -23,7 +23,17 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.wcs import WCS
 from astropy.wcs.wcs import FITSFixedWarning
 
-from stellarphot.catalogs import apass_dr9, refcat2, vsx_vizier
+from stellarphot.catalogs import (
+    _attach_gaia_ids,
+    _process_refcat2,
+    apass_dr9,
+    refcat2,
+    vsx_vizier,
+)
+
+# Gaia DR2 source_id of EY UMa, the center of the field used in the
+# remote-data refcat2 tests. Value from SIMBAD.
+EY_UMA_GAIA_DR2_ID = 1015789765851950336
 
 
 def test_fetchers_importable_from_catalogs():
@@ -252,6 +262,140 @@ def test_find_refcat2(mag_limit, mag_limit_band):
     # # The passbands ought to have been translated to the AAVSO standard names.
     for band in ["GBP", "GRP", "GG", "SG", "SR", "SI", "SZ", "J", "H", "K"]:
         assert band in all_refcat2["passband"]
+
+    # The Gaia IDs must be unique per star. The catalog is tidy (one row per
+    # star per passband), so compare the number of distinct IDs to the number
+    # of distinct positions.
+    n_stars = len(set(ra.value for ra in all_refcat2["ra"]))
+    assert len(set(all_refcat2["id"])) == n_stars
+
+    # Spot check: the star nearest the field center (EY UMa) must carry EY UMa's
+    # known Gaia DR2 source_id, i.e. the crossmatch attached the right ID to the
+    # right row. EY UMa's refcat2 rmag is 15.24, so it is only present in the
+    # runs without a magnitude limit.
+    if mag_limit is None:
+        ey_uma = SkyCoord.from_name("EY UMa")
+        cat_coords = SkyCoord(ra=all_refcat2["ra"], dec=all_refcat2["dec"])
+        nearest = cat_coords.separation(ey_uma).argmin()
+        assert all_refcat2["id"][nearest] == EY_UMA_GAIA_DR2_ID
+
+
+def _synthetic_refcat_stars(n=5):
+    """A stand-in for the filtered refcat2 table handed to the Gaia ID join."""
+    return Table(
+        {
+            "RA_ICRS": np.linspace(135.0, 135.5, n),
+            "DE_ICRS": np.linspace(49.0, 49.5, n),
+            "rmag": np.linspace(10.0, 14.0, n),
+        }
+    )
+
+
+def _fake_xmatch_result(indices, ang_dist=None, source_ids=None):
+    """
+    Build a table shaped like an XMatch result: the echoed ``_sp_index``
+    column plus ``angDist`` and Gaia's ``source_id``. By default each input
+    row ``i`` matches Gaia source ``1000 + i``.
+    """
+    indices = np.asarray(indices)
+    if ang_dist is None:
+        ang_dist = np.full(len(indices), 0.001)
+    if source_ids is None:
+        source_ids = 1000 + indices
+    return Table(
+        {
+            "_sp_index": indices,
+            "angDist": ang_dist,
+            "source_id": source_ids,
+        }
+    )
+
+
+def test_attach_gaia_ids_shuffled_result():
+    # XMatch does not preserve input row order; every star must still get its
+    # own source_id.
+    catalog = _synthetic_refcat_stars(5)
+    result = _fake_xmatch_result([3, 0, 4, 1, 2])
+
+    matched = _attach_gaia_ids(catalog, result)
+
+    assert len(matched) == 5
+    assert list(matched["id"]) == [1000, 1001, 1002, 1003, 1004]
+    # The rest of the catalog must be untouched.
+    np.testing.assert_array_equal(matched["RA_ICRS"], catalog["RA_ICRS"])
+
+
+def test_attach_gaia_ids_unmatched_row_dropped_with_warning():
+    # A star with no Gaia match is dropped, with a warning saying how many.
+    catalog = _synthetic_refcat_stars(5)
+    result = _fake_xmatch_result([0, 1, 3, 4])  # star 2 has no match
+
+    with pytest.warns(UserWarning, match="1 of 5"):
+        matched = _attach_gaia_ids(catalog, result)
+
+    assert len(matched) == 4
+    assert list(matched["id"]) == [1000, 1001, 1003, 1004]
+    assert catalog["RA_ICRS"][2] not in matched["RA_ICRS"]
+
+
+def test_attach_gaia_ids_duplicate_match_keeps_nearest():
+    # One star matching two Gaia sources keeps only the nearest one.
+    catalog = _synthetic_refcat_stars(5)
+    # Star 1 appears twice; the farther match comes first in the result and
+    # carries a bogus source_id that must not survive.
+    result = _fake_xmatch_result(
+        [0, 1, 1, 2, 3, 4],
+        ang_dist=[0.001, 0.008, 0.002, 0.001, 0.001, 0.001],
+        source_ids=[1000, 9999, 1001, 1002, 1003, 1004],
+    )
+
+    matched = _attach_gaia_ids(catalog, result)
+
+    assert len(matched) == 5
+    assert list(matched["id"]) == [1000, 1001, 1002, 1003, 1004]
+
+
+def test_process_refcat2_uploads_slim_table(monkeypatch):
+    # The XMatch upload must contain only the index and coordinate columns,
+    # not the full 40+ column refcat2 table, and the echoed index must be
+    # used (not row order) to assign IDs.
+    n = 6
+    catalog = Table(
+        {
+            "RA_ICRS": np.linspace(135.0, 135.5, n),
+            "DE_ICRS": np.linspace(49.0, 49.5, n),
+            "e_pmRA": np.ones(n),
+            "e_pmDE": np.ones(n),
+            "e_Gmag": np.full(n, 0.01),
+            "rmag": np.linspace(10.0, 14.0, n),
+        },
+        masked=True,
+    )
+    # Row 4 is a galaxy (masked proper-motion errors), row 5 is a non-Gaia
+    # star (masked e_Gmag); both must be filtered out before the crossmatch.
+    catalog["e_pmRA"].mask = [False, False, False, False, True, False]
+    catalog["e_pmDE"].mask = [False, False, False, False, True, False]
+    catalog["e_Gmag"].mask = [False, False, False, False, False, True]
+
+    captured = {}
+
+    def fake_query(cat1=None, **kwargs):  # noqa: ARG001
+        captured["cat1"] = cat1
+        # Echo the index back in reversed order, like XMatch reordering rows.
+        indices = np.asarray(cat1["_sp_index"])[::-1]
+        return _fake_xmatch_result(indices)
+
+    import stellarphot.catalogs as catalogs_module
+
+    monkeypatch.setattr(catalogs_module.XMatch, "query", fake_query)
+
+    processed = _process_refcat2(catalog)
+
+    assert set(captured["cat1"].colnames) == {"_sp_index", "RA_ICRS", "DE_ICRS"}
+    # Only the four genuine Gaia stars survive the filters and are uploaded.
+    np.testing.assert_array_equal(captured["cat1"]["_sp_index"], np.arange(4))
+    assert len(processed) == 4
+    assert list(processed["id"]) == [1000, 1001, 1002, 1003]
 
 
 @pytest.mark.parametrize("catalog", [apass_dr9, refcat2, vsx_vizier])

--- a/stellarphot/tests/test_catalogs.py
+++ b/stellarphot/tests/test_catalogs.py
@@ -31,9 +31,12 @@ from stellarphot.catalogs import (
     vsx_vizier,
 )
 
-# Gaia DR2 source_id of EY UMa, the center of the field used in the
-# remote-data refcat2 tests. Value from SIMBAD.
+# Gaia DR2 source_id and ICRS coordinates of EY UMa, the center of the field
+# used in the remote-data refcat2 tests. Values from SIMBAD; a fixed coordinate
+# is used instead of SkyCoord.from_name so the tests do not depend on the
+# Sesame name resolver being up.
 EY_UMA_GAIA_DR2_ID = 1015789765851950336
+EY_UMA_COORD = SkyCoord(ra=135.58650087 * u.deg, dec=49.81921088 * u.deg)
 
 
 def test_fetchers_importable_from_catalogs():
@@ -274,9 +277,8 @@ def test_find_refcat2(mag_limit, mag_limit_band):
     # right row. EY UMa's refcat2 rmag is 15.24, so it is only present in the
     # runs without a magnitude limit.
     if mag_limit is None:
-        ey_uma = SkyCoord.from_name("EY UMa")
         cat_coords = SkyCoord(ra=all_refcat2["ra"], dec=all_refcat2["dec"])
-        nearest = cat_coords.separation(ey_uma).argmin()
+        nearest = cat_coords.separation(EY_UMA_COORD).argmin()
         assert all_refcat2["id"][nearest] == EY_UMA_GAIA_DR2_ID
 
 


### PR DESCRIPTION
Fixes #586

### The problem

`process_refcat2` attached Gaia DR2 IDs by uploading the full filtered refcat2 table (46 columns) to CDS XMatch and assigning `catalog["id"] = result["source_id"]` positionally. XMatch does **not** preserve input row order, so:

- when the result happened to have the same length as the input, most stars silently got the *wrong* Gaia ID (only ~2.8% of rows came back in place for a 1.8° field);
- when any star was unmatched or matched twice, the assignment crashed with `ValueError: Inconsistent data column lengths` — the failure reported in #586;
- the full-table upload itself was slow (~100 s for the 1.8° field) and flaky.

### The fix

- Upload only three columns to XMatch: a row index (`_sp_index`), `RA_ICRS`, and `DE_ICRS`, shrinking the upload from ~137 MB-scale to a few hundred kB.
- Join the result back to the catalog on the echoed index via a new unit-testable helper, `_attach_gaia_ids`: nearest match kept when a star matches more than one Gaia source, unmatched stars dropped with a warning saying how many.
- `process_refcat2` is extracted from its closure to module level (`_process_refcat2`) so the logic is testable without network.
- The XMatch call is timed and logged at info level (elapsed, rows uploaded, matches returned) to feed the decision about whether keeping Gaia IDs is worth the extra query.

### Tests

New network-free unit tests: shuffled XMatch result (every star must get its own ID), unmatched row (dropped + warning), duplicate match (nearest kept), and a monkeypatched `XMatch.query` asserting the slim upload and index round-trip. The remote-data `test_find_refcat2` now also asserts IDs are unique per star and that the star nearest the field center carries EY UMa's known Gaia DR2 source_id.

### Timing (EY UMa field, live runs with the fix)

| Radius | Total | XMatch | Vizier + rest | Stars |
|---|---|---|---|---|
| 10′ | 2.5 s | 0.9 s | 1.6 s | 187 |
| 0.5° | 4.7 s | 1.4 s | 3.3 s | 1,806 |
| 1.824° (the call from #586) | 42.4 s | 7.9 s | 34.5 s | 24,203 |

All uploaded stars matched (0 dropped), and a 200-star sample from the 1.824° run passed the Gaia HEALPix consistency check (`source_id // 2**35 == healpix12(position)`) at 100%.

*This PR was written by Claude Code at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3