### PR TITLE
Verify the USNO u'g'r'i'z' to SDSS ugriz transform and pin it down with tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Other Changes and Additions
   modules, is now defined once in the top-level ``conftest.py``. [#426]
 + The duplicated logging setup in ``single_image_photometry`` and
   ``multi_image_photometry`` has been factored into a shared helper. [#152]
++ The USNO u'g'r'i'z' to SDSS DR7 ugriz transform matrix has been verified
+  entry-by-entry against its SDSS reference page, and tests now pin every
+  coefficient of the transform. [#611]
 
 Bug Fixes
 ^^^^^^^^^

--- a/stellarphot/utils/magnitude_system_transforms.py
+++ b/stellarphot/utils/magnitude_system_transforms.py
@@ -257,10 +257,13 @@ class MatrixTransformMixin:
         Parameters
         ----------
         from_magnitudes : np.ArrayLike
-            Magnitudes to transform. The shape should be (n, m), where n is the number
-            of magnitudes and m is the number of passbands in the from_system. There
-            must be an entry for each passband in the from_system, even if all of the
-            entries for a particular passband are zero.
+            Magnitudes to transform. The shape should be (p + 1,) or (p + 1, n),
+            where p is the number of passbands in the from_system and n is the
+            number of stars. The rows are the magnitudes in the order of the
+            from_system passbands, followed by a final row of ones for the
+            constant term in the transform. There must be a row for each
+            passband in the from_system, even if all of the entries for a
+            particular passband are zero.
         """
         # Convert to numpy array
         from_magnitudes = np.asarray(from_magnitudes)

--- a/stellarphot/utils/magnitude_system_transforms.py
+++ b/stellarphot/utils/magnitude_system_transforms.py
@@ -271,9 +271,11 @@ class MatrixTransformMixin:
         # Ensure the input shape matches the expected number of passbands. The
         # +1 is for the constant term in the transforms
         if from_magnitudes.shape[0] != len(self.from_system.passbands) + 1:
+            n_bands = len(self.from_system.passbands)
             raise ValueError(
-                f"Input shape {from_magnitudes.shape} does not match the number "
-                f"of passbands in the from_system ({len(self.from_system.passbands)})."
+                f"Input shape {from_magnitudes.shape} is invalid: expected "
+                f"{n_bands} passband rows plus a final row of ones "
+                f"({n_bands + 1} rows total)."
             )
 
         # Perform the matrix multiplication

--- a/stellarphot/utils/tests/test_magnitude_system_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_system_transforms.py
@@ -236,8 +236,20 @@ class TestCatalogTransforms:
 
 
 class TestUSNOPrimeToSDSSDR7:
+    # The reference for the transform is
+    # https://classic.sdss.org/dr7/algorithms/jeg_photometric_eq_dr1.php#usno2SDSS
+    # which gives, with all zpOffsets zero,
+    #
+    #   u = u'
+    #   g = g' + 0.060 * ((g' - r') - 0.53)
+    #   r = r' + 0.035 * ((r' - i') - 0.21)
+    #   i = i' + 0.041 * ((r' - i') - 0.21)
+    #   z = z' - 0.030 * ((i' - z') - 0.09)
+
     def test_transform(self):
-        # Check that the zero point for ug is correct
+        # Check the constant terms: with all input magnitudes zero, each output
+        # is the product of -b and the zeropoint color (u' is checked too since
+        # its coefficient in the u row is one).
         inp_mag = np.asarray([1.39, 0.0, 0.0, 0.0, 0.0, 1.0])
         # This should produce this output:
         # u: same as u' so 1.39
@@ -245,9 +257,56 @@ class TestUSNOPrimeToSDSSDR7:
         # r: product of -b_r and -zp_ri, so -0.00735
         # i: product of -b_i and -zp_ri, so -0.00861
         # z: product of -b_z and -zp_iz, so 0.0027
-
-        # This effectively checks the whole matrix
         expected = np.asarray([1.39, -0.0318, -0.00735, -0.00861, 0.0027, 1])
         usno_to_sdss = USNOPrimeToSDSSDR7.load()
         out_mag = usno_to_sdss(inp_mag)
         assert np.allclose(out_mag, expected)
+
+    def test_transform_zeropoint_colors_are_fixed_point(self):
+        # A star whose colors are exactly the zeropoint colors of the transform
+        # ((u'-g') = 1.39, (g'-r') = 0.53, (r'-i') = 0.21, (i'-z') = 0.09) has
+        # every color correction vanish, so its ugriz magnitudes must equal its
+        # u'g'r'i'z' magnitudes. Unlike an all-zeros input, this exercises the
+        # diagonal and off-diagonal color coefficients together.
+        z_p = 10.0
+        i_p = z_p + 0.09
+        r_p = i_p + 0.21
+        g_p = r_p + 0.53
+        u_p = g_p + 1.39
+        inp_mag = np.asarray([u_p, g_p, r_p, i_p, z_p, 1.0])
+        usno_to_sdss = USNOPrimeToSDSSDR7.load()
+        out_mag = usno_to_sdss(inp_mag)
+        assert np.allclose(out_mag[:5], inp_mag[:5])
+
+    def test_transform_matches_reference_equations(self):
+        # Check every coefficient of the matrix against the published
+        # equations, using colors that are *not* the zeropoint colors so that
+        # each color term contributes. Two stars at once also checks that the
+        # matrix multiplication handles a (n_bands + 1, n_stars) input.
+        u_p = np.asarray([15.2, 13.1])
+        g_p = np.asarray([14.7, 12.8])
+        r_p = np.asarray([13.9, 12.6])
+        i_p = np.asarray([13.4, 12.5])
+        z_p = np.asarray([13.1, 12.45])
+        inp_mag = np.asarray([u_p, g_p, r_p, i_p, z_p, np.ones_like(u_p)])
+
+        expected = np.asarray(
+            [
+                u_p,
+                g_p + 0.060 * ((g_p - r_p) - 0.53),
+                r_p + 0.035 * ((r_p - i_p) - 0.21),
+                i_p + 0.041 * ((r_p - i_p) - 0.21),
+                z_p - 0.030 * ((i_p - z_p) - 0.09),
+                np.ones_like(u_p),
+            ]
+        )
+        usno_to_sdss = USNOPrimeToSDSSDR7.load()
+        out_mag = usno_to_sdss(inp_mag)
+        assert np.allclose(out_mag, expected)
+
+    def test_transform_wrong_shape_raises(self):
+        # Input without the constant-term row should raise, not silently
+        # produce wrong magnitudes.
+        usno_to_sdss = USNOPrimeToSDSSDR7.load()
+        with pytest.raises(ValueError, match="does not match the number"):
+            usno_to_sdss(np.zeros(5))

--- a/stellarphot/utils/tests/test_magnitude_system_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_system_transforms.py
@@ -246,22 +246,6 @@ class TestUSNOPrimeToSDSSDR7:
     #   i = i' + 0.041 * ((r' - i') - 0.21)
     #   z = z' - 0.030 * ((i' - z') - 0.09)
 
-    def test_transform(self):
-        # Check the constant terms: with all input magnitudes zero, each output
-        # is the product of -b and the zeropoint color (u' is checked too since
-        # its coefficient in the u row is one).
-        inp_mag = np.asarray([1.39, 0.0, 0.0, 0.0, 0.0, 1.0])
-        # This should produce this output:
-        # u: same as u' so 1.39
-        # g: product of -b_g and -zp_gr, so -0.0318
-        # r: product of -b_r and -zp_ri, so -0.00735
-        # i: product of -b_i and -zp_ri, so -0.00861
-        # z: product of -b_z and -zp_iz, so 0.0027
-        expected = np.asarray([1.39, -0.0318, -0.00735, -0.00861, 0.0027, 1])
-        usno_to_sdss = USNOPrimeToSDSSDR7.load()
-        out_mag = usno_to_sdss(inp_mag)
-        assert np.allclose(out_mag, expected)
-
     def test_transform_zeropoint_colors_are_fixed_point(self):
         # A star whose colors are exactly the zeropoint colors of the transform
         # ((u'-g') = 1.39, (g'-r') = 0.53, (r'-i') = 0.21, (i'-z') = 0.09) has

--- a/stellarphot/utils/tests/test_magnitude_system_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_system_transforms.py
@@ -260,7 +260,7 @@ class TestUSNOPrimeToSDSSDR7:
         inp_mag = np.asarray([u_p, g_p, r_p, i_p, z_p, 1.0])
         usno_to_sdss = USNOPrimeToSDSSDR7.load()
         out_mag = usno_to_sdss(inp_mag)
-        assert np.allclose(out_mag[:5], inp_mag[:5])
+        assert np.allclose(out_mag[:5], inp_mag[:5], atol=1e-6, rtol=0)
 
     def test_transform_matches_reference_equations(self):
         # Check every coefficient of the matrix against the published
@@ -286,11 +286,14 @@ class TestUSNOPrimeToSDSSDR7:
         )
         usno_to_sdss = USNOPrimeToSDSSDR7.load()
         out_mag = usno_to_sdss(inp_mag)
-        assert np.allclose(out_mag, expected)
+        assert np.allclose(out_mag, expected, atol=1e-6, rtol=0)
 
     def test_transform_wrong_shape_raises(self):
         # Input without the constant-term row should raise, not silently
         # produce wrong magnitudes.
         usno_to_sdss = USNOPrimeToSDSSDR7.load()
-        with pytest.raises(ValueError, match="does not match the number"):
+        with pytest.raises(
+            ValueError,
+            match=r"expected 5 passband rows plus a final row of ones \(6 rows total\)",
+        ):
             usno_to_sdss(np.zeros(5))


### PR DESCRIPTION
Fixes #536

### Verification result: the transform is correct

The transformation matrix in `USNO_SDSS_to_SDSS_DR7.json` was re-derived independently from its cited reference, the [SDSS DR7 photometric equations page](https://classic.sdss.org/dr7/algorithms/jeg_photometric_eq_dr1.php#usno2SDSS). With all zpOffsets zero the published equations are

```
u = u'
g = g' + 0.060 * ((g' - r') - 0.53)
r = r' + 0.035 * ((r' - i') - 0.21)
i = i' + 0.041 * ((r' - i') - 0.21)
z = z' - 0.030 * ((i' - z') - 0.09)
```

Expanded into matrix form over `[u', g', r', i', z', 1]`, every entry agrees with the stored matrix to machine precision (max difference 8.7e-19). The usage in `transform_apass_bands` was also checked: the direction is right (APASS Sloan magnitudes are tied to the Smith et al. 2002 u'g'r'i'z' standards and the Jester transform expects 2.5m ugriz, so primed → SDSS DR7 → Jester is the correct chain), and the zero placeholders for u' and z' are harmless because the g/r/i output rows never reference those columns. **No coefficient changes were needed.**

### Why this PR still changes code

The existing unit test only exercised the constant terms — its input is zero in every band except u', so all eight color coefficients multiply zero (despite the test's comment claiming it "effectively checks the whole matrix"). Checked by mutation: a swapped 0.041/-0.035 pair, a sign flip on -0.06, and a 1.06 → 1.006 typo all pass the old test. This PR pins every coefficient down:

- **Fixed-point test** — a star with exactly the zeropoint colors (u'-g' = 1.39, g'-r' = 0.53, r'-i' = 0.21, i'-z' = 0.09) must transform to identical magnitudes.
- **Reference-equation test** — two stars with non-zeropoint colors are checked against the published equations evaluated directly in the test; also covers the 2-D `(n_bands + 1, n_stars)` input path.
- **Shape-error test** — input without the constant-term row raises instead of silently producing wrong magnitudes.

All three mutations above are caught by the new tests. Also corrects the `MatrixTransformMixin` docstring, which described the input shape backwards and omitted the required final row of ones.

### Caveat noted while verifying (not enforced by this PR)

The reference states the transformation is valid for stars in roughly `0.15 <= g'-r' <= 1.20` (and the standard system is poorly determined redder than M0). The code does not warn outside that range — fine for typical comparison-star use, possible follow-up if desired.

*This PR was written by Claude Code at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
