### PR TITLE
Fix swapped x/y image bounds in comparison_utils.in_field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@ Bug Fixes
   computed for every row that has coordinates and only the rows without
   coordinates are masked in the resulting time column. A warning is issued
   when rows are skipped. [#622]
++ ``comparison_utils.in_field`` no longer swaps the x/y image bounds, which
+  excluded valid comparison-star candidates near the long edge of non-square
+  images (and could include off-frame stars). [#612]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/utils/comparison_utils.py
+++ b/stellarphot/utils/comparison_utils.py
@@ -217,12 +217,12 @@ def in_field(apass_good_coord, ccd, apass, good_stars):
         Table with APASS stars in the field of view.
     """
     apassx, apassy = ccd.wcs.all_world2pix(apass_good_coord.ra, apass_good_coord.dec, 0)
-    ccdx, ccdy = ccd.shape
+    # numpy image shapes are (ny, nx)
+    ccdy, ccdx = ccd.shape
 
     xin = (apassx < ccdx) & (0 < apassx)
     yin = (apassy < ccdy) & (0 < apassy)
     xy_in = xin & yin
-    apass_good_coord[xy_in]
     nt = apass[good_stars]
     ent = nt[xy_in]
     return ent

--- a/stellarphot/utils/tests/test_comparison_utils.py
+++ b/stellarphot/utils/tests/test_comparison_utils.py
@@ -1,4 +1,8 @@
 import astropy.units as u
+import numpy as np
+from astropy.nddata import CCDData
+from astropy.table import Table
+from astropy.wcs import WCS
 
 from stellarphot.utils import comparison_utils
 
@@ -44,3 +48,37 @@ def test_set_up_defaults_to_no_magnitude_limit(monkeypatch):
     assert captured["magnitude_limit"] is None
     # The search radius is still passed through unchanged.
     assert captured["radius"] == 0.5 * u.degree
+
+
+def _non_square_ccd(shape=(200, 400)):
+    # numpy shape is (ny, nx), so this image is 400 pixels wide (x) and
+    # 200 pixels tall (y).
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [shape[1] / 2, shape[0] / 2]
+    wcs.wcs.cdelt = [-2.0e-4, 2.0e-4]
+    wcs.wcs.crval = [30.0, 45.0]
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    return CCDData(np.zeros(shape), wcs=wcs, unit="adu")
+
+
+def test_in_field_non_square_image():
+    # Regression test for #589. in_field unpacked the numpy image shape as
+    # (nx, ny), swapping the x and y bounds on non-square images. That
+    # excluded valid stars near the long edge and included off-image stars.
+    ccd = _non_square_ccd()
+
+    # Pixel positions (x, y) of the test stars:
+    #   0: inside the image, but excluded by the buggy bounds (x > 200)
+    #   1: outside the image (y > 200), but included by the buggy bounds
+    #   2: inside by either version of the bounds
+    #   3: outside by either version of the bounds
+    xs = np.array([300.0, 100.0, 50.0, 500.0])
+    ys = np.array([100.0, 300.0, 50.0, 500.0])
+    coords = ccd.wcs.pixel_to_world(xs, ys)
+
+    apass = Table({"id": np.arange(len(xs)), "coords": coords})
+    good_stars = np.ones(len(apass), dtype=bool)
+
+    ent = comparison_utils.in_field(apass["coords"], ccd, apass, good_stars)
+
+    assert sorted(ent["id"]) == [0, 2]


### PR DESCRIPTION
### The bug

`in_field` in `stellarphot/utils/comparison_utils.py` unpacked the numpy image shape as `(nx, ny)`:

```python
ccdx, ccdy = ccd.shape
```

but numpy shapes are `(ny, nx)`. On non-square detectors this swapped the x/y bounds, so valid comparison-star candidates near the long edge of the image were excluded and stars that are actually off the image were included, corrupting the comparison-star pool. (Square images were unaffected, which is why this went unnoticed.)

### The fix

Unpack the shape in the correct order (`ccdy, ccdx = ccd.shape`) and remove an adjacent dead line (`apass_good_coord[xy_in]`) that computed a value and discarded it. A regression test uses a 400x200 image with stars placed so the swapped bounds misclassify them in both directions.

This is a minimal in-place fix; extracting a shared "in frame" helper is tracked separately in #608.

Fixes #589

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
