### PR TITLE
Fix v1→v2 migration writing mag_inst = 0 for passbands with no matching column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Bug Fixes
 + ``comparison_utils.in_field`` no longer swaps the x/y image bounds, which
   excluded valid comparison-star candidates near the long edge of non-square
   images (and could include off-frame stars). [#612]
++ The v1 to v2 photometry migration now writes ``NaN`` and emits a warning for
+  observations whose passband has no matching ``mag_inst_<band>`` column,
+  instead of silently writing ``mag_inst = 0``. [#613]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/utils/tests/test_version_migrator.py
+++ b/stellarphot/utils/tests/test_version_migrator.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
 
+import numpy as np
 import pytest
 from astropy import units as u
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyUserWarning
 from packaging.version import InvalidVersion
 
 from stellarphot import PhotometryData
@@ -107,3 +109,39 @@ class TestVersionMigrator:
         assert sp2_pd is not sp2
         # Check the metadata is the same
         assert sp2_pd.meta == sp2.meta
+
+    # The parameter two_filters is passed to the fixture stellphotv1_photometry_data.
+    # We want data that has two filters in the "filter" column and then remove
+    # the mag_inst column for one of them.
+    @pytest.mark.parametrize("two_filters", [True])
+    def test_migrate_v1_v2_missing_passband_column(self, stellphotv1_photometry_data):
+        # Regression test for #596 -- observations in a passband that has no
+        # matching mag_inst_<passband> column used to silently get mag_inst = 0.
+        # They should instead be NaN, and a warning should be issued naming the
+        # passbands with no matching column.
+
+        # The data has observations in both "B" and "ip", but remove the "ip"
+        # magnitude column so those observations have no source for mag_inst.
+        del stellphotv1_photometry_data["mag_inst_ip"]
+
+        camera = Camera(**TEST_CAMERA_VALUES)
+        observatory = Observatory(**TEST_OBSERVATORY_SETTINGS)
+        vm = VersionMigrator(
+            from_version="1", to_version="2", camera=camera, observatory=observatory
+        )
+
+        with pytest.warns(AstropyUserWarning, match="no matching.*column.*ip"):
+            sp2 = vm.migrate(stellphotv1_photometry_data)
+
+        # Observations in the passband with no magnitude column should be NaN...
+        no_mag_column = sp2["passband"] == "ip"
+        assert no_mag_column.sum() > 0
+        assert np.all(np.isnan(sp2["mag_inst"][no_mag_column]))
+
+        # ...and the passband that does have a column should be unaffected.
+        in_band_2 = sp2["passband"] == "B"
+        in_band_1 = stellphotv1_photometry_data["filter"] == "B"
+        assert all(
+            sp2["mag_inst"][in_band_2]
+            == stellphotv1_photometry_data["mag_inst_B"][in_band_1]
+        )

--- a/stellarphot/utils/version_migrator.py
+++ b/stellarphot/utils/version_migrator.py
@@ -1,6 +1,9 @@
+import warnings
+
 import numpy as np
 from astropy import units as u
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyUserWarning
 from packaging.version import Version
 
 from stellarphot import PhotometryData
@@ -157,11 +160,25 @@ class VersionMigrator:
         )
 
         if mag_cols_have_filter_names:
-            new_mag_col_data = np.zeros_like(new_data["date-obs"])
+            # Start from NaN so that any passband without a matching
+            # mag_inst_<passband> column ends up with NaN, not a bogus value.
+            new_mag_col_data = np.full(len(new_data), np.nan)
+            mag_col_passbands = {col.split("_")[-1] for col in mag_columns}
             for col in mag_columns:
                 passband = col.split("_")[-1]
                 this_passband = new_data["filter"] == passband
                 new_mag_col_data[this_passband] = new_data[col][this_passband]
+
+            missing_passbands = sorted(set(new_data["filter"]) - mag_col_passbands)
+            if missing_passbands:
+                warnings.warn(
+                    "There is no matching mag_inst_<passband> column for "
+                    "these passbands in the data: "
+                    f"{', '.join(missing_passbands)}. The mag_inst value for "
+                    "observations in those passbands will be NaN.",
+                    AstropyUserWarning,
+                    stacklevel=2,
+                )
             new_data["mag_inst"] = new_mag_col_data
             new_data.remove_columns(mag_columns)
 


### PR DESCRIPTION
### Bug

When migrating v1 photometry data to v2, the merged `mag_inst` column was initialized with `np.zeros_like(new_data["date-obs"])`. Any observation whose `passband` had no matching `mag_inst_<passband>` column was left at that initial value, so it silently migrated with `mag_inst = 0` — no warning, no error. (As a bonus quirk, `zeros_like` on the `Time` column produced an object-dtype column of Python int zeros.)

### Fix

- Initialize the merged column with `np.full(len(new_data), np.nan)` so unmatched rows come out as NaN in a proper float column.
- Emit an `AstropyUserWarning` listing the passbands present in the data that have no matching `mag_inst_<passband>` column.

Includes a regression test (`test_migrate_v1_v2_missing_passband_column`) that migrates a two-filter v1 table with one magnitude column removed, and checks that the affected rows are NaN, the warning names the missing passband, and the other passband's magnitudes are untouched.

Fixes #596

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3