### PR TITLE
Raise a clear error if transit eccentricity is un-fixed before fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ Bug Fixes
 + The v1 to v2 photometry migration now writes ``NaN`` and emits a warning for
   observations whose passband has no matching ``mag_inst_<band>`` column,
   instead of silently writing ``mag_inst = 0``. [#613]
++ ``TransitModelFit.fit`` now raises an error if the ``eccentricity`` parameter
+  has been un-fixed, and warns if a fixed nonzero value is set, instead of
+  silently ignoring the parameter. [#614]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -148,6 +148,13 @@ class TransitModelFit:
     <https://pytransit.readthedocs.io/en/latest/notebooks/models/roadrunner/roadrunner_model_example_1.html>`_
     using a quadratic limb-darkening law and a circular orbit.
 
+    Because the orbit is always circular, the model's ``eccentricity``
+    parameter has no effect on the computed light curve. It is kept in the
+    model for API stability, but it must remain fixed (the default) and its
+    value is ignored. Calling ``fit`` with ``eccentricity.fixed`` set to
+    ``False`` raises a ``ValueError``, and a fixed nonzero eccentricity
+    triggers a warning.
+
     Attributes
     ----------
 
@@ -335,11 +342,12 @@ class TransitModelFit:
             width_trend=0.0,
             spp_trend=0.0,
         ):
-            # pytransit uses inclination in radians. The orbit is circular
-            # (eccentricity is always fixed at 0 in this model), so ``evaluate``
-            # is left with its default ``e=0``; the ``eccentricity`` argument is
-            # retained in the signature for API stability but is unused, matching
-            # the previous behavior where batman's ``ecc`` was fixed at 0.
+            # pytransit uses inclination in radians. The orbit is circular:
+            # ``evaluate`` is left with its default ``e=0``/``w=0`` and the
+            # ``eccentricity`` argument is NOT forwarded, matching the previous
+            # behavior where batman's ``ecc`` was fixed at 0. The argument is
+            # retained in the signature only for API stability; ``fit()``
+            # raises if a user un-fixes it and warns if it is nonzero.
             flux = self._transit_model.evaluate(
                 k=rp,
                 ldc=[limb_u1, limb_u2],
@@ -357,7 +365,9 @@ class TransitModelFit:
 
         self._model = ModelClass()
 
-        # Set up some defaults for what is fixed
+        # Set up some defaults for what is fixed. The eccentricity must stay
+        # fixed: it is not forwarded to pytransit (the orbit is always
+        # circular) and fit() raises if it has been un-fixed.
         self._model.period.fixed = True
         self._model.eccentricity.fixed = True
         self._model.limb_u1.fixed = True
@@ -477,12 +487,42 @@ class TransitModelFit:
     def fit(self):
         """
         Perform a fit and update the model with best-fit values.
+
+        Raises
+        ------
+        ValueError
+            If the times or model have not been set, or if
+            ``model.eccentricity.fixed`` has been set to ``False``. The
+            eccentricity is not forwarded to the underlying pytransit model
+            (the orbit is always circular), so it cannot be fit.
         """
         # Maybe do some correctness check of the model before starting.
         if self.times is None:
             raise ValueError("The times must be set before trying " "to fit.")
         if self._model is None:
             raise ValueError("Run setup_model() before trying to fit.")
+
+        # The eccentricity parameter is never forwarded to the underlying
+        # pytransit model (the orbit is always circular, e=0). Fitting it
+        # would silently do nothing: the fitter would see a zero Jacobian
+        # column, report a meaningless "best-fit" value, and inflate the
+        # fit parameter count (and hence the BIC). Fail loudly instead.
+        if not self.model.eccentricity.fixed:
+            raise ValueError(
+                "The eccentricity cannot be fit: the underlying pytransit "
+                "model always uses a circular orbit (eccentricity 0), so the "
+                "eccentricity parameter has no effect on the model. Leave "
+                "eccentricity.fixed set to True."
+            )
+
+        if self.model.eccentricity.value != 0:
+            warnings.warn(
+                f"The eccentricity value {self.model.eccentricity.value} is "
+                "ignored by the underlying pytransit model, which always "
+                "uses a circular orbit (eccentricity 0).",
+                AstropyUserWarning,
+                stacklevel=2,
+            )
 
         # The pytransit model already has its time array (set via the ``times``
         # setter), so no additional model setup is needed here.

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -148,13 +148,6 @@ class TransitModelFit:
     <https://pytransit.readthedocs.io/en/latest/notebooks/models/roadrunner/roadrunner_model_example_1.html>`_
     using a quadratic limb-darkening law and a circular orbit.
 
-    Because the orbit is always circular, the model's ``eccentricity``
-    parameter has no effect on the computed light curve. It is kept in the
-    model for API stability, but it must remain fixed (the default) and its
-    value is ignored. Calling ``fit`` with ``eccentricity.fixed`` set to
-    ``False`` raises a ``ValueError``, and a fixed nonzero eccentricity
-    triggers a warning.
-
     Attributes
     ----------
 
@@ -168,6 +161,15 @@ class TransitModelFit:
 
     width : array-like
         Width of the star in pixels at each time. Must be set before fitting.
+
+    Notes
+    -----
+    Because the orbit is always circular, the model's ``eccentricity``
+    parameter has no effect on the computed light curve. It is kept in the
+    model for API stability, but it must remain fixed (the default) and its
+    value is ignored. Calling ``fit`` with ``eccentricity.fixed`` set to
+    ``False`` raises a ``ValueError``, and a fixed nonzero eccentricity
+    triggers a warning.
     """
 
     def __init__(self):

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -1,7 +1,10 @@
+import warnings
+
 import numpy as np
 import pytest
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 
 from stellarphot.transit_fitting import TransitModelFit
 
@@ -359,6 +362,50 @@ def test_transit_data_detrend():
         + tmod.model.width_trend * tmod.width
         + tmod.model.spp_trend * tmod.spp,
     )
+
+
+def test_fit_raises_if_eccentricity_not_fixed():
+    # The eccentricity parameter is not forwarded to the underlying pytransit
+    # model, so trying to fit it would silently do nothing (a zero Jacobian
+    # column and a meaningless "best-fit" value). Un-fixing it must raise a
+    # clear error at fit time instead. See issue #593.
+    tmod = _make_transit_model_with_data(
+        noise_dev=1e-5, with_airmass=False, with_width=False, with_spp=False
+    )
+
+    tmod.model.eccentricity.fixed = False
+
+    with pytest.raises(ValueError, match="eccentricity cannot be fit"):
+        tmod.fit()
+
+
+def test_fit_warns_if_fixed_eccentricity_is_nonzero():
+    # A fixed but nonzero eccentricity is silently ignored by the underlying
+    # pytransit model (the orbit is always circular), so the user should be
+    # warned that the value they set has no effect. See issue #593.
+    tmod = _make_transit_model_with_data(
+        noise_dev=1e-5, with_airmass=False, with_width=False, with_spp=False
+    )
+
+    tmod.model.eccentricity = 0.5
+    assert tmod.model.eccentricity.fixed
+
+    with pytest.warns(AstropyUserWarning, match="eccentricity.*ignored"):
+        tmod.fit()
+
+
+def test_fit_with_default_eccentricity_neither_raises_nor_warns():
+    # The default configuration (eccentricity fixed at 0) should fit without
+    # any eccentricity-related error or warning.
+    tmod = _make_transit_model_with_data(
+        noise_dev=1e-5, with_airmass=False, with_width=False, with_spp=False
+    )
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        tmod.fit()
+
+    assert not any("eccentricity" in str(w.message) for w in recorded)
 
 
 def test_transit_fit_parameters_unfreeze_as_expected():


### PR DESCRIPTION
### The bug (#593)

Since the pytransit migration, `transit_model_with_trends` never forwards `eccentricity` to `self._transit_model.evaluate(...)` — pytransit always uses a circular orbit (`e=0`, `w=0`). The model sets `eccentricity.fixed = True` by default, but nothing stopped a user from setting `model.eccentricity.fixed = False`. The fit then ran anyway: the LM fitter saw a zero Jacobian column for that parameter, reported a meaningless "best-fit" eccentricity, and the extra free parameter inflated `n_fit_parameters` and the BIC. (Verified: un-fixing and setting eccentricity to 0.9 changes the model output by exactly 0.0.)

### The fix

Fail loudly instead of fitting a no-op:

- `fit()` now raises a `ValueError` with an explanatory message if `eccentricity.fixed` is `False`.
- `fit()` emits an `AstropyUserWarning` if the (fixed) eccentricity has a nonzero value, since that value is silently ignored by the pytransit model.
- The limitation is now documented in the `TransitModelFit` class docstring and the `fit()` docstring, not just buried in inline comments.

Erroring on un-fix was chosen over implementing `e`/`w` forwarding to pytransit: actually fitting eccentricity is a new feature (it also requires an argument-of-periastron parameter and sensible bounds/defaults) and is tracked by the broader transit-stack proposal. This PR just stops the silent no-op fit.

### Tests

- `test_fit_raises_if_eccentricity_not_fixed`
- `test_fit_warns_if_fixed_eccentricity_is_nonzero`
- `test_fit_with_default_eccentricity_neither_raises_nor_warns`

Written first (TDD, confirmed failing before the fix); the whole transit-fitting test file passes (19 tests).

Fixes #593

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
