### PR TITLE
Require a close sky match before labeling a star as a comparison in generate_aij_table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,9 @@ Bug Fixes
 + ``TransitModelFit.fit`` now raises an error if the ``eccentricity`` parameter
   has been un-fixed, and warns if a fixed nonzero value is set, instead of
   silently ignoring the parameter. [#614]
++ ``generate_aij_table`` no longer classifies a star as a comparison star based
+  on an arbitrarily distant sky match; a match within a couple of arcseconds is
+  now required. [#615]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/io/aij.py
+++ b/stellarphot/io/aij.py
@@ -385,8 +385,14 @@ class ApertureFileAIJ:
         return apAIJ
 
 
-def _is_comp(star_coord, comp_table):
+def _is_comp(star_coord, comp_table, match_limit=2 * u.arcsec):
     idx, d2d, _ = star_coord.match_to_catalog_sky(comp_table["coord"])
+    # match_to_catalog_sky always returns the nearest entry, however far
+    # away it is. Only trust the match if it is within match_limit;
+    # otherwise this star is not in the comparison table at all, so it
+    # is not a comparison star.
+    if d2d > match_limit:
+        return False
     return "comparison" in comp_table["marker name"][idx]
 
 

--- a/stellarphot/io/tests/test_aij_io.py
+++ b/stellarphot/io/tests/test_aij_io.py
@@ -66,7 +66,7 @@ def test_aperture_creation_from_table():
     # Note that the csv reads in the True/False column as text,
     # not as bool.
     ref_table["marker name"] = [
-        "APASS comparison" if v == "True" else "TESS target"
+        "APASS comparison" if v == "True" else "TESS Targets"
         for v in ref_table["isrefstar"]
     ]
 
@@ -151,7 +151,7 @@ def test_generate_aij_table_mixed_target_and_comps():
     comparison_table = _make_comparison_table(
         ras=[target_ra] + comp_ras,
         decs=[target_dec] + comp_decs,
-        marker_names=["TESS target", "APASS comparison", "APASS comparison"],
+        marker_names=["TESS Targets", "APASS comparison", "APASS comparison"],
     )
 
     aij_table = generate_aij_table(phot_table, comparison_table)

--- a/stellarphot/io/tests/test_aij_io.py
+++ b/stellarphot/io/tests/test_aij_io.py
@@ -3,7 +3,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 
-from stellarphot.io.aij import ApertureAIJ, ApertureFileAIJ
+from stellarphot.io.aij import ApertureAIJ, ApertureFileAIJ, generate_aij_table
 
 
 def test_aperture_eq():
@@ -84,3 +84,112 @@ def test_aperture_creation_from_table():
     ref_apertures = ApertureFileAIJ.read(ref_aperture_file)
 
     assert ref_apertures == ap_aij
+
+
+def _make_photometry_table(star_ids, ras, decs):
+    # Build a minimal photometry table with the columns that
+    # generate_aij_table expects, with one row per star.
+    n_stars = len(star_ids)
+    phot_table = Table(
+        {
+            "star_id": star_ids,
+            "RA": ras,
+            "Dec": decs,
+            "date-obs": ["2024-01-01T01:02:03.456"] * n_stars,
+            "airmass": [1.2] * n_stars,
+            "BJD": [2460310.54] * n_stars,
+            "exposure": [30.0] * n_stars,
+            "filter": ["ip"] * n_stars,
+            "aperture": [10.0] * n_stars,
+            "annulus_inner": [15.0] * n_stars,
+            "annulus_outer": [25.0] * n_stars,
+            "xcenter": [100.0] * n_stars,
+            "ycenter": [200.0] * n_stars,
+            "aperture_net_counts": [10000.0] * n_stars,
+            "aperture_area": [314.0] * n_stars,
+            "noise-aij": [100.0] * n_stars,
+            "snr": [100.0] * n_stars,
+            "sky_per_pix_avg": [10.0] * n_stars,
+            "annulus_area": [1256.0] * n_stars,
+            "fwhm_x": [5.0] * n_stars,
+            "fwhm_y": [5.0] * n_stars,
+            "width": [5.0] * n_stars,
+            "relative_flux": [0.5] * n_stars,
+            "relative_flux_error": [0.01] * n_stars,
+            "relative_flux_snr": [50.0] * n_stars,
+            "comparison counts": [20000.0] * n_stars,
+            "comparison error": [140.0] * n_stars,
+        }
+    )
+    return phot_table
+
+
+def _make_comparison_table(ras, decs, marker_names):
+    comp_table = Table(
+        {
+            "coord": SkyCoord(ra=ras, dec=decs, unit="degree"),
+            "marker name": marker_names,
+        }
+    )
+    return comp_table
+
+
+def test_generate_aij_table_mixed_target_and_comps():
+    # A comparison table that contains both the target and the
+    # comparison stars, each with the appropriate marker name, should
+    # lead to the target getting "_T" columns and the comparison stars
+    # getting "_C" columns.
+    target_ra, target_dec = 50.0, 45.0
+    comp_ras = [10.0, 10.02]
+    comp_decs = [45.0, 45.01]
+
+    phot_table = _make_photometry_table(
+        star_ids=[1, 2, 3],
+        ras=[target_ra] + comp_ras,
+        decs=[target_dec] + comp_decs,
+    )
+    comparison_table = _make_comparison_table(
+        ras=[target_ra] + comp_ras,
+        decs=[target_dec] + comp_decs,
+        marker_names=["TESS target", "APASS comparison", "APASS comparison"],
+    )
+
+    aij_table = generate_aij_table(phot_table, comparison_table)
+
+    assert "rel_flux_T1" in aij_table.colnames
+    assert "rel_flux_C2" in aij_table.colnames
+    assert "rel_flux_C3" in aij_table.colnames
+
+
+def test_generate_aij_table_target_not_in_comparison_table():
+    # Regression test for #595 -- when the comparison table contains
+    # only comparison stars, a target far from every comparison star
+    # was matched to its nearest comparison star, however far away,
+    # and mislabeled as a comparison star. The result was an AIJ table
+    # with no "_T" columns at all.
+    target_ra, target_dec = 50.0, 45.0
+    comp_ras = [10.0, 10.02]
+    comp_decs = [45.0, 45.01]
+
+    phot_table = _make_photometry_table(
+        star_ids=[1, 2, 3],
+        ras=[target_ra] + comp_ras,
+        decs=[target_dec] + comp_decs,
+    )
+    # The comparison table contains only the comparison stars, tens of
+    # degrees away from the target.
+    comparison_table = _make_comparison_table(
+        ras=comp_ras,
+        decs=comp_decs,
+        marker_names=["APASS comparison", "APASS comparison"],
+    )
+
+    aij_table = generate_aij_table(phot_table, comparison_table)
+
+    # The target must be labeled as a target, not a comparison star...
+    assert "rel_flux_T1" in aij_table.colnames
+    assert "rel_flux_C1" not in aij_table.colnames
+
+    # ...and the comparison stars should still be labeled as comparisons.
+    assert "rel_flux_C2" in aij_table.colnames
+    assert "rel_flux_C3" in aij_table.colnames


### PR DESCRIPTION
### The bug

`_is_comp` in `stellarphot/io/aij.py` used `SkyCoord.match_to_catalog_sky`, which always returns the *nearest* entry in the comparison table no matter how far away it is, and the returned separation `d2d` was discarded. When the comparison table contained only comparison stars (no target entry), the target star was matched to its nearest comparison star -- even tens of degrees away -- and mislabeled as a comparison star. The resulting AIJ table then had no `_T*` columns at all, which breaks anything keyed on the T/C column suffixes (AstroImageJ, the transit notebooks).

### The fix

Only trust the match if the separation is within 2 arcsec (consistent with match tolerances used elsewhere in the codebase, e.g. `comparison_utils.py` and `magnitude_transforms.py`); otherwise the star is not in the comparison table at all, so it is classified as not a comparison star.

### Tests

Added to `stellarphot/io/tests/test_aij_io.py` (written first, and the regression test confirmed failing against the old code):

- `test_generate_aij_table_mixed_target_and_comps` -- target + comps with correct marker names get `_T*` and `_C*` columns respectively.
- `test_generate_aij_table_target_not_in_comparison_table` -- comps-only comparison table with a far-away target: the target gets `_T*` columns and is not labeled as a comparison.

Fixes #595

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
