### PR TITLE
Fix TOI.transit_time_for_observation for pre-epoch observations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ Bug Fixes
 + ``generate_aij_table`` no longer classifies a star as a comparison star based
   on an arbitrarily distant sky match; a match within a couple of arcseconds is
   now required. [#615]
++ ``TOI.transit_time_for_observation`` now returns the transit nearest the
+  observation when the observation is before the tabulated epoch; previously
+  the result could be off by up to a full period. [#616]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -374,17 +374,23 @@ class TOI(BaseModel):
             The transit times for the observations.
         """
         first_obs = obs_times[0]
-        # Three possible cases here. Either the first time is close to, but before, a
-        # transit, or it is close to, but just after a transit, or it is nowhere close
-        # to a transit.
-        # Assume that the first time is just before a transit
-        cycle_number = int((first_obs - self.epoch) / self.period + 1)
+        # Find the transit nearest the first observation time. Rounding the
+        # phase to the nearest integer gives the cycle number of that transit
+        # regardless of whether the observation is before or after the epoch.
+        # Note that int() instead of round() would truncate toward zero, which
+        # gives the wrong cycle for observations before the epoch (see #594).
+        phase = ((first_obs - self.epoch) / self.period).to_value(
+            u.dimensionless_unscaled
+        )
+        cycle_number = round(phase)
         that_transit = cycle_number * self.period + self.epoch
 
-        # Check -- is the first time closer to this transit or the one before it?
-        previous_transit = that_transit - self.period
-        if abs(first_obs - previous_transit) < abs(first_obs - that_transit):
-            that_transit = previous_transit
+        # Double-check against the neighboring transits in case of any edge
+        # cases in the rounding above.
+        for neighbor_cycle in (cycle_number - 1, cycle_number + 1):
+            neighbor_transit = neighbor_cycle * self.period + self.epoch
+            if abs(first_obs - neighbor_transit) < abs(first_obs - that_transit):
+                that_transit = neighbor_transit
 
         # Check -- are we way, way, way off from a transit?
         if abs(first_obs - that_transit) > 3 * self.duration:

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -385,13 +385,6 @@ class TOI(BaseModel):
         cycle_number = round(phase)
         that_transit = cycle_number * self.period + self.epoch
 
-        # Double-check against the neighboring transits in case of any edge
-        # cases in the rounding above.
-        for neighbor_cycle in (cycle_number - 1, cycle_number + 1):
-            neighbor_transit = neighbor_cycle * self.period + self.epoch
-            if abs(first_obs - neighbor_transit) < abs(first_obs - that_transit):
-                that_transit = neighbor_transit
-
         # Check -- are we way, way, way off from a transit?
         if abs(first_obs - that_transit) > 3 * self.duration:
             warnings.warn("Observation times are far from a transit.", stacklevel=2)

--- a/stellarphot/io/tests/test_tess.py
+++ b/stellarphot/io/tests/test_tess.py
@@ -248,17 +248,17 @@ class TestTOI:
         test_time_start = sample_toi.epoch + phase * sample_toi.period
         obs_times = test_time_start + np.linspace(0, 2) * sample_toi.duration
 
-        # Observations starting far from a transit generate a warning.
+        # Observations starting far from a transit generate a warning; the
+        # warning must be present in that case and absent otherwise.
         far_from_transit = (
             abs(phase - round(phase)) * sample_toi.period > 3 * sample_toi.duration
         )
-        if far_from_transit:
-            ctx = pytest.warns(UserWarning, match="far from a transit")
-        else:
-            ctx = warnings.catch_warnings()
-
-        with ctx:
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
             transit_time = sample_toi.transit_time_for_observation(obs_times)
+
+        far_warnings = [w for w in recorded if "far from a transit" in str(w.message)]
+        assert bool(far_warnings) == far_from_transit
 
         # The identified transit should be the one nearest the start of the
         # observations, so it can be no more than half a period away.

--- a/stellarphot/io/tests/test_tess.py
+++ b/stellarphot/io/tests/test_tess.py
@@ -236,6 +236,36 @@ class TestTOI:
             reference_midpoint.jd
         )
 
+    @pytest.mark.parametrize(
+        "phase",
+        [-2.6, -2.1, -1.9, -0.9, -0.1, 0.1, 0.9, 123.6],
+    )
+    def test_transit_time_for_observation_nearest_transit(self, sample_toi, phase):
+        # Regression test for #594: the returned transit time should be the
+        # transit nearest the first observation time even when the observation
+        # is before the tabulated epoch (negative phase).
+        expected_midpoint = sample_toi.epoch + round(phase) * sample_toi.period
+        test_time_start = sample_toi.epoch + phase * sample_toi.period
+        obs_times = test_time_start + np.linspace(0, 2) * sample_toi.duration
+
+        # Observations starting far from a transit generate a warning.
+        far_from_transit = (
+            abs(phase - round(phase)) * sample_toi.period > 3 * sample_toi.duration
+        )
+        if far_from_transit:
+            ctx = pytest.warns(UserWarning, match="far from a transit")
+        else:
+            ctx = warnings.catch_warnings()
+
+        with ctx:
+            transit_time = sample_toi.transit_time_for_observation(obs_times)
+
+        # The identified transit should be the one nearest the start of the
+        # observations, so it can be no more than half a period away.
+        half_period = 0.5 * sample_toi.period
+        assert abs((transit_time - test_time_start).to("day")) <= half_period
+        assert transit_time.jd == pytest.approx(expected_midpoint.jd)
+
 
 class TestTessPhotometrySetup:
     # Auto-use the shared change_to_tmp_dir fixture (defined in the top-level


### PR DESCRIPTION
### Bug

`TOI.transit_time_for_observation` computed the transit cycle number with

```python
cycle_number = int((first_obs - self.epoch) / self.period + 1)
```

`int()` truncates toward zero, so for observations *before* the tabulated epoch (negative phase) the two candidate cycles checked (`cycle_number` and `cycle_number - 1`) do not bracket the nearest transit. The returned midpoint could be off by up to a full period (e.g. phase -1.9 returned a transit 0.9 P away instead of the true nearest one 0.1 P away). Since this midpoint feeds the ingress/egress markers and the out-of-transit baseline mask, in-transit points could end up in the "baseline".

### Fix

Round the phase to the nearest integer to get the cycle of the nearest transit; since a transit occurs at every integer cycle, the rounded cycle is always the nearest one, for both pre- and post-epoch observations. Behavior for positive phases is unchanged.

Tests: added `test_transit_time_for_observation_nearest_transit`, parametrized over phases including -1.9 and -2.6 from the issue, asserting the returned transit is within half a period of the first observation and matches the expected cycle. Written first and confirmed failing against the old code.

Fixes #594

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3

