### PR TITLE
Fix silent bad output, NameError, and comp-star error consistency in AIJ relative flux code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,12 @@ Bug Fixes
 + Fixed an operator-precedence bug in ``transform_to_catalog`` that disabled
   the cross-match distance cut, letting badly matched stars bias the fitted
   transform coefficients. [#617]
++ ``calc_aij_relative_flux`` now raises an error when none of the comparison
+  stars match the photometry data, or when one or more times have no valid
+  comparison stars, instead of silently returning relative fluxes equal to
+  the raw net counts. [#618]
++ ``add_relative_flux_column`` no longer raises a ``NameError`` when the input
+  photometry data already contains a ``bjd`` column. [#618]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,17 @@ Bug Fixes
   the raw net counts. [#618]
 + ``add_relative_flux_column`` no longer raises a ``NameError`` when the input
   photometry data already contains a ``bjd`` column. [#618]
++ The relative flux error of a comparison star is now computed against the
+  same ensemble as its relative flux, with the star itself excluded from
+  both the comparison counts and the comparison error, making the reported
+  error and SNR consistent with the flux. Previously the error used the
+  full ensemble including the star itself. [#618]
++ The per-image comparison-star consistency check in
+  ``calc_aij_relative_flux`` now counts the comparison stars present in
+  each image instead of counting nonzero fluxes, so a comparison star with
+  exactly zero net counts (a legitimate measured value) no longer triggers
+  a misleading "Different number of stars in comparison sets" error, and a
+  star with zero counts now gets a finite relative flux error. [#618]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -170,7 +170,11 @@ def calc_aij_relative_flux(
         )
 
     comp_totals = comp_fluxes.groups.aggregate(np.sum)[counts_column_name]
-    comp_num_stars = comp_fluxes.groups.aggregate(np.count_nonzero)[counts_column_name]
+    # Count the comparison stars in each image by counting the rows in each
+    # group. Counting nonzero fluxes would be wrong here -- exactly zero net
+    # counts is a legitimate measured value (net counts can even be negative
+    # after sky subtraction) and must not be mistaken for a missing star.
+    comp_num_stars = np.diff(comp_fluxes.groups.indices)
     comp_errors = comp_fluxes.groups.aggregate(add_in_quadrature)[error_column_name]
 
     comp_total_vector = np.ones_like(star_data[counts_column_name])
@@ -200,16 +204,30 @@ def calc_aij_relative_flux(
         comp_total_vector[this_time] *= comp_total
         comp_error_vector[this_time] = comp_error * comp_fluxes[error_column_name].unit
 
-    relative_flux = star_data[counts_column_name] / (comp_total_vector + flux_offset)
+    # A comparison star is excluded from its own comparison ensemble: its
+    # flux is removed from the comparison total (via flux_offset) and its
+    # error is removed from the comparison error, so that the relative flux
+    # and its error are computed against the same ensemble.
+    comp_total_used = comp_total_vector + flux_offset
+    # Clip protects against tiny negative values from floating point
+    # roundoff when a single comparison star dominates the ensemble error.
+    comp_error_used = np.sqrt(
+        np.clip(
+            comp_error_vector**2 - (star_data[error_column_name] * is_comp) ** 2,
+            0,
+            None,
+        )
+    )
+
+    relative_flux = star_data[counts_column_name] / comp_total_used
     relative_flux = relative_flux.flatten()
 
-    rel_flux_error = (
-        star_data[counts_column_name]
-        / comp_total_vector
-        * np.sqrt(
-            (star_data[error_column_name] / star_data[counts_column_name]) ** 2
-            + (comp_error_vector / comp_total_vector) ** 2
-        )
+    # This is the usual error propagation for a ratio, written to avoid
+    # dividing by the star's counts so that a star with exactly zero counts
+    # gets a finite error instead of NaN.
+    rel_flux_error = np.sqrt(
+        (star_data[error_column_name] / comp_total_used) ** 2
+        + (star_data[counts_column_name] * comp_error_used / comp_total_used**2) ** 2
     )
 
     # Add these columns to table

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -287,7 +287,7 @@ def add_relative_flux_column(
     comp_bool = source_list["marker name"] == ["APASS comparison"]
     only_comp_stars = source_list[comp_bool]
     if verbose:
-        print("Adding AIJ-style relative flux columns to photomotry data")
+        print("Adding AIJ-style relative flux columns to photometry data")
     flux_table = calc_aij_relative_flux(photometry_data, only_comp_stars)
 
     flux_group = flux_table.group_by("file")

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -132,6 +132,14 @@ def calc_aij_relative_flux(
         this_comp = star_data[star_id_column] == comp
         good[this_comp] = False
 
+    if not np.any(good):
+        raise RuntimeError(
+            "No comparison stars matched the photometry data, so relative "
+            "flux cannot be calculated. Check that the comparison star "
+            "coordinates are correct and that the comparison stars have "
+            "valid data at every time in the photometry data."
+        )
+
     error_column_name = "noise_electrons"
     # Calculate comp star counts for each time
 
@@ -149,6 +157,18 @@ def calc_aij_relative_flux(
     # and convert to regular column...eventually
 
     comp_fluxes = comp_fluxes.group_by("date-obs")
+
+    # Every time in the input data must have at least one comparison star,
+    # otherwise the comparison counts at the times with no comparison stars
+    # would silently be set to 1.
+    n_times_star_data = len(np.unique(np.asarray(star_data["date-obs"].value)))
+    if len(comp_fluxes.groups) != n_times_star_data:
+        raise RuntimeError(
+            "There are one or more times in the photometry data at which "
+            "none of the comparison stars has valid data, so relative flux "
+            "cannot be calculated."
+        )
+
     comp_totals = comp_fluxes.groups.aggregate(np.sum)[counts_column_name]
     comp_num_stars = comp_fluxes.groups.aggregate(np.count_nonzero)[counts_column_name]
     comp_errors = comp_fluxes.groups.aggregate(add_in_quadrature)[error_column_name]
@@ -247,24 +267,25 @@ def add_relative_flux_column(
     if verbose:
         print("Adding AIJ-style relative flux columns to photomotry data")
     flux_table = calc_aij_relative_flux(photometry_data, only_comp_stars)
-    # Add bjd if needed
 
-    if "bjd" not in flux_table.colnames:
+    flux_group = flux_table.group_by("file")
+
+    # Add bjd if needed
+    if "bjd" not in flux_group.colnames:
         if verbose:
             print("Adding BJD column to photometry data")
         # Accumulate the BJD here
         bjds = []
 
-        flux_group = flux_table.group_by("file")
         for group in flux_group.groups:
             mean_ra = group["ra"].mean()
             mean_dec = group["dec"].mean()
             group.add_bjd_col(bjd_coordinates=SkyCoord(mean_ra, mean_dec))
             bjds.extend(group["bjd"].jd)
 
-    # Each (ephemeral) group had a BJD, this adds the column to the
-    # original table.
-    flux_group["bjd"] = Time(bjds, scale="tdb", format="jd")
+        # Each (ephemeral) group had a BJD, this adds the column to the
+        # original table.
+        flux_group["bjd"] = Time(bjds, scale="tdb", format="jd")
 
     if verbose:
         print("Writing photometry data with relative flux columns")

--- a/stellarphot/differential_photometry/aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/aij_rel_fluxes.py
@@ -97,6 +97,13 @@ def calc_aij_relative_flux(
     # Not sure this is really close enough for a good match...
     good = d2d < 1.2 * u.arcsec
 
+    if not np.any(good):
+        raise RuntimeError(
+            "No comparison stars matched the positions in the photometry "
+            "data, so relative flux cannot be calculated. Check that the "
+            "comparison star coordinates are correct."
+        )
+
     check_for_bad = Table(
         data=[star_data[star_id_column].data, good], names=["star_id", "good"]
     )
@@ -132,12 +139,21 @@ def calc_aij_relative_flux(
         this_comp = star_data[star_id_column] == comp
         good[this_comp] = False
 
-    if not np.any(good):
+    # Every time in the input data must have at least one comparison star;
+    # otherwise the comparison counts at the times with no comparison stars
+    # would silently be set to 1. Note that a comparison star that is bad at
+    # any one time is excluded as a comparison star at every time, so this
+    # also catches the case in which every comparison star has been
+    # excluded.
+    star_times = np.asarray(star_data["date-obs"].value)
+    times_with_comps = set(star_times[good])
+    if set(star_times) - times_with_comps:
         raise RuntimeError(
-            "No comparison stars matched the photometry data, so relative "
-            "flux cannot be calculated. Check that the comparison star "
-            "coordinates are correct and that the comparison stars have "
-            "valid data at every time in the photometry data."
+            "There are one or more times in the photometry data at which "
+            "none of the comparison stars has valid data, so relative flux "
+            "cannot be calculated. A comparison star is excluded from every "
+            "time if it is missing, has NaN counts, or has a mismatched "
+            "position at even one time."
         )
 
     error_column_name = "noise_electrons"
@@ -157,18 +173,6 @@ def calc_aij_relative_flux(
     # and convert to regular column...eventually
 
     comp_fluxes = comp_fluxes.group_by("date-obs")
-
-    # Every time in the input data must have at least one comparison star,
-    # otherwise the comparison counts at the times with no comparison stars
-    # would silently be set to 1.
-    n_times_star_data = len(np.unique(np.asarray(star_data["date-obs"].value)))
-    if len(comp_fluxes.groups) != n_times_star_data:
-        raise RuntimeError(
-            "There are one or more times in the photometry data at which "
-            "none of the comparison stars has valid data, so relative flux "
-            "cannot be calculated."
-        )
-
     comp_totals = comp_fluxes.groups.aggregate(np.sum)[counts_column_name]
     # Count the comparison stars in each image by counting the rows in each
     # group. Counting nonzero fluxes would be wrong here -- exactly zero net

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -257,16 +257,43 @@ def test_no_matching_comp_stars_raises_error():
         calc_aij_relative_flux(input_table, comp_star, in_place=False)
 
 
+def test_comp_stars_missing_at_one_time_raises_error():
+    # Related to #590 -- if the comparison stars have no valid data at one
+    # (or more) of the times, they are excluded as comparison stars at every
+    # time. The error in that case should explain that, rather than say that
+    # no comparison star positions matched, since the positions match just
+    # fine at the other times.
+    _, _, input_table, comp_star = _raw_photometry_table()
+    input_table.sort(["date-obs", "star_id"])
+
+    # Remove the comparison stars (stars 2, 3 and 4) from the last time,
+    # keeping the target star at that time and all of the comparison stars
+    # at the other times.
+    last_time = np.unique(input_table["date-obs"])[-1]
+    comps_at_last_time = (input_table["date-obs"] == last_time) & (
+        input_table["star_id"] != 1
+    )
+    input_table = input_table[~comps_at_last_time]
+
+    with pytest.raises(RuntimeError, match="one or more times"):
+        calc_aij_relative_flux(input_table, comp_star, in_place=False)
+
+
 # Run in a temporary directory because add_relative_flux_column writes its
 # output file to the current working directory.
 @pytest.mark.usefixtures("change_to_tmp_dir")
-def test_add_relative_flux_column_with_existing_bjd(simple_photometry_data):
-    # Regression test for #597 -- add_relative_flux_column used to raise
-    # a NameError when the input photometry data already had a bjd column.
+@pytest.mark.parametrize("bjd_already_present", [True, False])
+def test_add_relative_flux_column(simple_photometry_data, bjd_already_present):
+    # With bjd_already_present this is a regression test for #597 --
+    # add_relative_flux_column used to raise a NameError when the input
+    # photometry data already had a bjd column. Without it, the bjd column
+    # should be computed and added to the output.
     phot_data = simple_photometry_data
 
-    # The test data already has a bjd column, which triggered the bug.
+    # The test data already has a bjd column, which triggered #597.
     assert "bjd" in phot_data.colnames
+    if not bjd_already_present:
+        del phot_data["bjd"]
 
     phot_file = Path("photometry.ecsv")
     phot_data.write(phot_file)
@@ -293,15 +320,16 @@ def test_add_relative_flux_column_with_existing_bjd(simple_photometry_data):
     source_list_file = Path("source_list.ecsv")
     source_list.write(source_list_file)
 
-    # This used to raise a NameError because the grouped table was only
-    # created when the bjd column was missing.
-    add_relative_flux_column(phot_file, source_list_file)
+    # With a pre-existing bjd column this used to raise a NameError because
+    # the grouped table was only created when the bjd column was missing.
+    add_relative_flux_column(phot_file, source_list_file, verbose=True)
 
     output_file = Path("photometry-relative-flux.ecsv")
     assert output_file.exists()
 
     output_data = PhotometryData.read(output_file)
     assert "bjd" in output_data.colnames
+    assert np.all(np.isfinite(output_data["bjd"].jd))
     assert "relative_flux" in output_data.colnames
     assert np.all(np.isfinite(output_data["relative_flux"]))
     assert np.all(output_data["relative_flux"] > 0)

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -5,8 +7,11 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 
-from stellarphot import PhotometryData
-from stellarphot.differential_photometry.aij_rel_fluxes import calc_aij_relative_flux
+from stellarphot import PhotometryData, SourceListData
+from stellarphot.differential_photometry.aij_rel_fluxes import (
+    add_relative_flux_column,
+    calc_aij_relative_flux,
+)
 
 
 def _repeat(array, count):
@@ -166,3 +171,68 @@ def test_bad_comp_star(bad_thing):
         new_expected_flux[:-comparison_start],
         output_table["relative_flux"][comparison_start:],
     )
+
+
+def test_no_matching_comp_stars_raises_error():
+    # Regression test for #590 -- if none of the comparison stars match
+    # the positions in the photometry data the result used to be a silent
+    # "success" in which the comparison counts were set to 1, i.e. the
+    # relative flux was just the net counts. It should raise an error instead.
+    _, _, input_table, comp_star = _raw_photometry_table()
+
+    # Shift the comparison star positions by a degree so that none of them
+    # match the positions in the photometry table.
+    comp_star["ra"] = comp_star["ra"] + 1 * u.degree
+
+    with pytest.raises(RuntimeError, match="No comparison stars"):
+        calc_aij_relative_flux(input_table, comp_star, in_place=False)
+
+
+# Run in a temporary directory because add_relative_flux_column writes its
+# output file to the current working directory.
+@pytest.mark.usefixtures("change_to_tmp_dir")
+def test_add_relative_flux_column_with_existing_bjd(simple_photometry_data):
+    # Regression test for #597 -- add_relative_flux_column used to raise
+    # a NameError when the input photometry data already had a bjd column.
+    phot_data = simple_photometry_data
+
+    # The test data already has a bjd column, which triggered the bug.
+    assert "bjd" in phot_data.colnames
+
+    phot_file = Path("photometry.ecsv")
+    phot_data.write(phot_file)
+
+    # Make a source list from the photometry data itself so that the
+    # comparison star coordinates are guaranteed to match. Use all but the
+    # first star as comparison stars.
+    comp_ids = sorted(set(phot_data["star_id"]))[1:]
+    marker_name = [
+        "APASS comparison" if star_id in comp_ids else "TESS Target"
+        for star_id in phot_data["star_id"]
+    ]
+    source_table = Table(
+        {
+            "star_id": phot_data["star_id"],
+            "ra": phot_data["ra"],
+            "dec": phot_data["dec"],
+            "xcenter": phot_data["xcenter"],
+            "ycenter": phot_data["ycenter"],
+            "marker name": marker_name,
+        }
+    )
+    source_list = SourceListData(input_data=source_table)
+    source_list_file = Path("source_list.ecsv")
+    source_list.write(source_list_file)
+
+    # This used to raise a NameError because the grouped table was only
+    # created when the bjd column was missing.
+    add_relative_flux_column(phot_file, source_list_file)
+
+    output_file = Path("photometry-relative-flux.ecsv")
+    assert output_file.exists()
+
+    output_data = PhotometryData.read(output_file)
+    assert "bjd" in output_data.colnames
+    assert "relative_flux" in output_data.colnames
+    assert np.all(np.isfinite(output_data["relative_flux"]))
+    assert np.all(output_data["relative_flux"] > 0)

--- a/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
+++ b/stellarphot/differential_photometry/tests/test_aij_rel_fluxes.py
@@ -42,15 +42,23 @@ def _raw_photometry_table():
     comp_stars = np.array([0, 1, 1, 1])
     expected_comp_fluxes = np.sum(fluxes[1:])
 
+    # A comparison star is excluded from its own comparison ensemble, both
+    # in the comparison total and in the comparison error, so the expected
+    # values are different for each comparison star (see #605).
     comp_flux_offset = -comp_stars * fluxes
-    expected_flux_ratios = fluxes / (expected_comp_fluxes + comp_flux_offset)
+    expected_comp_flux_by_star = expected_comp_fluxes + comp_flux_offset
+    expected_flux_ratios = fluxes / expected_comp_flux_by_star
 
     comp_error_total = np.sqrt((errors[1:] ** 2).sum())
+    comp_error_by_star = np.sqrt(comp_error_total**2 - comp_stars * errors**2)
 
     expected_flux_error = (
         fluxes
-        / expected_comp_fluxes
-        * np.sqrt(errors**2 / fluxes**2 + comp_error_total**2 / expected_comp_fluxes**2)
+        / expected_comp_flux_by_star
+        * np.sqrt(
+            errors**2 / fluxes**2
+            + comp_error_by_star**2 / expected_comp_flux_by_star**2
+        )
     )
 
     raw_table = Table(
@@ -171,6 +179,67 @@ def test_bad_comp_star(bad_thing):
         new_expected_flux[:-comparison_start],
         output_table["relative_flux"][comparison_start:],
     )
+
+
+def test_comp_star_error_uses_self_excluded_ensemble():
+    # Regression test for #605 -- the error of a comparison star must be
+    # computed against the same ensemble as its relative flux, that is, with
+    # the star itself excluded from both the comparison total counts and the
+    # comparison error added in quadrature. Previously the error used the
+    # full ensemble even though the flux excluded the star itself.
+    _, _, input_table, comp_star = _raw_photometry_table()
+
+    output = calc_aij_relative_flux(input_table, comp_star, in_place=False)
+
+    # Hand-computed expectation for star 2, a comparison star whose
+    # comparison ensemble is stars 3 and 4. These values match the ones
+    # in _raw_photometry_table.
+    flux_2 = 20000.0
+    error_2 = np.sqrt(flux_2) + 50
+    comp_total = 30000.0 + 40000.0
+    comp_error = np.sqrt((np.sqrt(30000.0) + 50) ** 2 + (np.sqrt(40000.0) + 50) ** 2)
+    expected_error_2 = (
+        flux_2
+        / comp_total
+        * np.sqrt((error_2 / flux_2) ** 2 + (comp_error / comp_total) ** 2)
+    )
+
+    star_2 = output["star_id"] == 2
+    np.testing.assert_allclose(
+        output["relative_flux_error"][star_2].value, expected_error_2
+    )
+    # The SNR should be consistent with the flux and error columns.
+    np.testing.assert_allclose(
+        output["relative_flux_snr"][star_2],
+        (output["relative_flux"][star_2] / output["relative_flux_error"][star_2]),
+    )
+
+
+def test_comp_star_with_zero_flux_is_counted():
+    # Regression test for #605 -- exactly zero net counts is a legitimate
+    # measured value (net counts can even be negative after sky subtraction).
+    # The per-image consistency check used np.count_nonzero, so a comparison
+    # star with exactly zero flux in one image was miscounted as a missing
+    # star, raising a misleading "Different number of stars in comparison
+    # sets" error.
+    _, _, input_table, comp_star = _raw_photometry_table()
+    input_table.sort(["date-obs", "star_id"])
+
+    # Star 4, a comparison star, has exactly zero net counts in the
+    # last image.
+    input_table["aperture_net_cnts"][-1] = 0.0
+
+    output = calc_aij_relative_flux(input_table, comp_star, in_place=False)
+
+    # In the last image the comparison total is 20000 + 30000 + 0.
+    last_image = output["date-obs"] == np.unique(output["date-obs"])[-1]
+    target_star = last_image & (output["star_id"] == 1)
+    zero_flux_comp = last_image & (output["star_id"] == 4)
+
+    np.testing.assert_allclose(output["relative_flux"][target_star], 10000.0 / 50000.0)
+    np.testing.assert_allclose(output["relative_flux"][zero_flux_comp], 0.0)
+    # The error should be finite everywhere, including the zero-flux row.
+    assert np.all(np.isfinite(output["relative_flux_error"]))
 
 
 def test_no_matching_comp_stars_raises_error():


### PR DESCRIPTION
This PR fixes three issues in `stellarphot/differential_photometry/aij_rel_fluxes.py`: the two originally targeted bugs (#590, #597) plus the error/consistency cleanups from #605, which overlap the same lines and interact with the zero-comps guard.

### Bug 1: `calc_aij_relative_flux` silently produces garbage when no comparison stars match (#590)

The comparison total/error vectors are initialized to ones and only overwritten for times present in the grouped comparison fluxes. The existing guard (`len(set(comp_num_stars)) > 1`) does not fire when the set is *empty*, so if every comparison star fails the coordinate match (e.g. the comparison table has an RA offset) the function returned normally with `relative_flux == aperture_net_cnts` -- silently wrong output.

**Fix:** two `RuntimeError` guards, each with a message matching the condition it detects: one fires when no comparison star matches the photometry data positions at all (pointing at the coordinates), and one fires when one or more times have no surviving comparison stars (explaining that a comparison star that is missing, has NaN counts, or has a mismatched position at any one time is excluded at every time -- so this guard also covers the all-excluded case). `RuntimeError` matches the existing error convention in this function. The per-time guard compares the set of times with surviving comps against all times in the input rather than counting groups, which also avoids an astropy crash on `len(groups)` of an empty grouped table. (This is item 3 of #605, which suggested fixing it together with the items below.)

### Bug 2: `add_relative_flux_column` raises `NameError` when the table already has `bjd` (#597)

`flux_group` (and `bjds`) were assigned only inside the `if "bjd" not in flux_table.colnames:` block, but `flux_group["bjd"] = ...` and `flux_group.write(...)` ran unconditionally after it, so any photometry file that already contained a `bjd` column crashed with an unbound-variable error.

**Fix:** group the table by `file` unconditionally and move the BJD-column assignment inside the "bjd missing" branch.

### Bug 3: comparison-star error/consistency cleanups (#605)

**Item 1 -- inconsistent comp-star SNR.** For comparison-star rows, `relative_flux` self-excludes the star via `flux_offset`, but `rel_flux_error` used the *unadjusted* denominator and included the star's own error in the quadrature sum, so the flux and its error were computed against different ensembles.

**Fix:** the error for a comparison-star row now uses the same self-excluded ensemble as its relative flux -- the star's own counts are removed from the comparison total and its own error from the quadrature sum. Note that **this changes the reported errors (and SNR) of comparison-star rows.** AIJ-compatibility was considered as the alternative (documenting the old behavior as intentional), but since the flux already self-excludes, making the error follow suit is the internally consistent choice. The `"comparison counts"`/`"comparison error"` output columns still record the full-ensemble totals, AIJ style. The error propagation is also rewritten algebraically (same formula, no division by the star's own counts) so a star with zero counts gets a finite error instead of NaN.

**Item 2 -- `comp_num_stars` used `np.count_nonzero`.** A comparison star with *exactly zero* net counts -- a legitimate measured value, net counts can even be negative after sky subtraction -- was miscounted as a missing star by the per-image consistency check, raising a misleading "Different number of stars in comparison sets" error.

**Fix:** count the comparison stars present in each image (rows per group) instead of counting nonzero fluxes.

### Tests

All fixes were developed test-first (tests confirmed failing before each fix):

- `test_no_matching_comp_stars_raises_error` -- shifts all comparison star RAs by 1 degree and asserts `calc_aij_relative_flux` raises the "no comparison stars matched" error.
- `test_comp_stars_missing_at_one_time_raises_error` -- removes the comparison-star rows at one time (keeping the target row there and the comps at all other times) and asserts the "one or more times" error.
- `test_add_relative_flux_column` (parametrized over `bjd_already_present`) -- round-trips photometry data through `add_relative_flux_column` with and without a pre-existing `bjd` column (`verbose=True`), checking the output file has a finite `bjd` column and sane relative-flux columns.
- `test_comp_star_error_uses_self_excluded_ensemble` -- hand-computed self-excluded error for a comparison-star row, plus SNR consistency.
- `test_comp_star_with_zero_flux_is_counted` -- a comp star with exactly zero counts in one image is treated as a valid measurement: correct relative fluxes, finite errors, no spurious error.

The expected errors in the `_raw_photometry_table` fixture encoded the old inconsistent behavior for comparison-star rows; they are updated to the self-excluded ensemble to match the flux calculation.

Fixes #590
Fixes #597
Fixes #605

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
