### PR TITLE
Fix NaN/saturation handling and unclipped sky stats in aperture photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,16 @@ Bug Fixes
   exactly zero net counts (a legitimate measured value) no longer triggers
   a misleading "Different number of stars in comparison sets" error, and a
   star with zero counts now gets a finite relative flux error. [#618]
++ Saturated pixels (those above the camera's maximum data value) no longer
+  silently poison the aperture sums in ``single_image_photometry``. They are
+  now masked in the photometry, and sources with saturated pixels in their
+  aperture are flagged in a new boolean ``saturated`` column and have their
+  ``aperture_net_cnts`` set to NaN. [#591]
++ A source whose centroid cannot be computed when ``use_coordinates="sky"``
+  (for example, because the source is completely saturated) no longer crashes
+  ``single_image_photometry`` -- and with it an entire multi-image run -- with
+  a ``ValueError``. The source now falls back to its WCS-derived position,
+  like sources whose centroid shifts by more than ``shift_tolerance``. [#592]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,10 @@ Bug Fixes
   ``single_image_photometry`` -- and with it an entire multi-image run -- with
   a ``ValueError``. The source now falls back to its WCS-derived position,
   like sources whose centroid shifts by more than ``shift_tolerance``. [#592]
++ With ``reject_background_outliers=False``, the reported ``sky_per_pix_med``
+  and ``sky_per_pix_std`` are now computed from the pixels in the annulus
+  instead of from the rectangular bounding box of the annulus, which included
+  the core of the star and the corners outside the annulus. [#619]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,7 +110,7 @@ Bug Fixes
 + With ``reject_background_outliers=False``, the reported ``sky_per_pix_med``
   and ``sky_per_pix_std`` are now computed from the pixels in the annulus
   instead of from the rectangular bounding box of the annulus, which included
-  the core of the star and the corners outside the annulus. [#619]
+  the core of the star and the corners outside the annulus. [#602]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -652,15 +652,17 @@ def single_image_photometry(
             "without clipping (set reject_background_outliers=True "
             "to perform clipping)."
         )
-        med_pp = []
-        std_pp = []
-        for mask in annuli.to_mask():
-            annulus_data = mask.cutout(ccd_image)
-            med_pp.append(np.median(annulus_data))
-            std_pp.append(np.std(annulus_data))
+        # Compute the median and standard deviation from the pixels in the
+        # annulus only. These used to be computed from the rectangular
+        # bounding box of the annulus, which includes the core of the star
+        # (inside the inner radius) and the corners outside the annulus,
+        # wildly inflating the reported standard deviation. See #602.
+        # ApertureStats also respects the image mask, which includes the
+        # saturated pixels marked as NaN above (#591).
+        ap_stats = ApertureStats(ccd_image, annuli, sum_method="center")
         photom["sky_per_pix_avg"] = photom["annulus_sum"] / photom["annulus_area"]
-        photom["sky_per_pix_med"] = np.array(med_pp) * ccd_image.unit / u.pixel
-        photom["sky_per_pix_std"] = np.array(std_pp) * ccd_image.unit / u.pixel
+        photom["sky_per_pix_med"] = ap_stats.median / u.pixel
+        photom["sky_per_pix_std"] = ap_stats.std / u.pixel
 
     # Compute counts using clipped stats on sky per pixel
     photom["aperture_net_cnts"] = photom["aperture_sum"].value - (

--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -236,7 +236,11 @@ def single_image_photometry(
         locations were too close to the edge of the image or to each other for
         successful aperture photometry.  If pixel (x/y) positions were used for
         the photometry, but a valid WCS header was not available for `ccd_image`,
-        the output 'ra', 'dec', and 'bjd' columns will have np.nan values
+        the output 'ra', 'dec', and 'bjd' columns will have np.nan values.
+        The output also contains a boolean 'saturated' column that is ``True``
+        for sources whose aperture contains one or more saturated (or
+        otherwise non-finite) pixels; those sources have their
+        'aperture_net_cnts' set to np.nan.
 
     dropped_sources : list
         This of the star_ids of the sources that fell outside the image or were
@@ -359,6 +363,18 @@ def single_image_photometry(
     ccd_image.data = ccd_image.data.astype(float)
     ccd_image.data[ccd_image.data > camera.max_data_value.value] = np.nan
 
+    # Add any non-finite pixels -- the saturated pixels marked as NaN above
+    # plus any NaN already present in the input -- to the image mask so that
+    # they are excluded from the aperture sums instead of turning the sums
+    # into NaN. See #591. Sources whose aperture contains any of these pixels
+    # are flagged as saturated below.
+    bad_pixels = ~np.isfinite(ccd_image.data)
+    if bad_pixels.any():
+        if ccd_image.mask is not None:
+            ccd_image.mask = ccd_image.mask | bad_pixels
+        else:
+            ccd_image.mask = bad_pixels
+
     # Extract necessary values from sourcelist structure
     star_ids = sourcelist["star_id"].value
     xs = sourcelist["xcenter"].value
@@ -464,13 +480,33 @@ def single_image_photometry(
     # and just passing the same sourcelist when calling single_image_photometry
     # on each image.
     if use_coordinates == "sky":
+        # Apply the image mask (which includes the saturated pixels marked as
+        # NaN above) by setting the masked pixels to NaN; photutils then
+        # automatically masks the non-finite values. We deliberately do not
+        # pass the mask to centroid_sources because photutils raises an error
+        # if a cutout is completely masked, while a completely saturated
+        # source should instead produce a NaN centroid and fall back to its
+        # WCS-derived position below. See #592.
+        if ccd_image.mask is not None:
+            centroid_data = np.where(ccd_image.mask, np.nan, ccd_image.data)
+        else:
+            centroid_data = ccd_image.data
         try:
-            xcen, ycen = centroid_sources(
-                ccd_image.data,
-                xs,
-                ys,
-                box_size=2 * int(photometry_apertures.radius_pixels(fwhm)) + 1,
-            )
+            with warnings.catch_warnings():
+                # photutils warns about the non-finite values it masks; that
+                # is exactly the behavior we want here, so suppress the
+                # warning.
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*Input data contains non-finite values.*",
+                    category=AstropyUserWarning,
+                )
+                xcen, ycen = centroid_sources(
+                    centroid_data,
+                    xs,
+                    ys,
+                    box_size=2 * int(photometry_apertures.radius_pixels(fwhm)) + 1,
+                )
         except NoOverlapError:
             logger.warning(
                 f"{logline} Determining new centroids failed ... "
@@ -484,7 +520,12 @@ def single_image_photometry(
 
             # The center really shouldn't move more than about the fwhm, could
             # rework this in the future to use that instead.
-            too_much_shift = (
+            # A non-finite center_diff means centroiding failed (e.g. the
+            # cutout of a completely saturated source is all NaN), so treat
+            # it like too much shift so those sources also fall back to the
+            # WCS-derived position instead of crashing the photometry with a
+            # NaN aperture position. See #592.
+            too_much_shift = ~np.isfinite(center_diff) | (
                 center_diff
                 > photometry_settings.source_location_settings.shift_tolerance
             )
@@ -514,6 +555,20 @@ def single_image_photometry(
         r_out=photometry_apertures.outer_annulus,
     )
 
+    # Flag sources whose aperture contains any saturated (or otherwise
+    # non-finite) pixels. Those pixels are excluded from the aperture sum by
+    # the mask, so the sum would silently underestimate the flux of the
+    # source. See #591.
+    if bad_pixels.any():
+        bad_pixel_photom = aperture_photometry(
+            bad_pixels.astype(float),
+            apers,
+            method=photometry_options.partial_pixel_method,
+        )
+        source_is_saturated = np.asarray(bad_pixel_photom["aperture_sum"]) > 0
+    else:
+        source_is_saturated = np.zeros(len(aper_locs), dtype=bool)
+
     # Perform the aperture photometry
     photom = aperture_photometry(
         ccd_image.data,
@@ -532,6 +587,9 @@ def single_image_photometry(
     photom["star_id"] = star_ids
     photom["ra"] = ra * u.deg
     photom["dec"] = dec * u.deg
+
+    # Flag the sources that have saturated pixels in their aperture (#591)
+    photom["saturated"] = source_is_saturated
 
     # Drop ID column from aperture_photometry()
     del photom["id"]
@@ -649,12 +707,22 @@ def single_image_photometry(
             f"{logline} Aperture net counts negative for {np.sum(bad_cnts)} " "sources."
         )
 
-    all_bads = bad_cnts | bad_fwhm
+    # Saturated pixels are excluded from the aperture sum by the mask, so the
+    # net counts of a source with saturated pixels in its aperture silently
+    # underestimate the flux of the source. Set those to NaN too. See #591.
+    if np.sum(source_is_saturated) > 0:
+        logger.warning(
+            f"{logline} {np.sum(source_is_saturated)} sources have saturated "
+            "(or otherwise non-finite) pixels in their aperture."
+        )
+
+    all_bads = bad_cnts | bad_fwhm | source_is_saturated
 
     photom["aperture_net_cnts"][all_bads] = np.nan
     logger.info(
-        f"{logline} {np.sum(all_bads)} sources with either bad FWHM fit "
-        "or bad aperture net counts had aperture_net_cnts set to NaN."
+        f"{logline} {np.sum(all_bads)} sources with either bad FWHM fit, "
+        "bad aperture net counts, or saturated pixels in their aperture "
+        "had aperture_net_cnts set to NaN."
     )
 
     # Compute instrumental magnitudes

--- a/stellarphot/photometry/source_detection.py
+++ b/stellarphot/photometry/source_detection.py
@@ -123,6 +123,15 @@ def compute_fwhm(
             mask = nan_mask
 
         cutout_xy = cutout.to_cutout_position((x, y))
+
+        # A completely masked cutout (e.g. a fully saturated source, see
+        # #591/#592) has no data to measure a FWHM from, and photutils
+        # raises an error when asked to fit it, so record NaN instead.
+        if mask.all():
+            fwhm_x.append(np.nan)
+            fwhm_y.append(np.nan)
+            continue
+
         match fit_method:
             case FwhmMethods.FIT:
                 # Make sure we get an odd fits shape

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -224,8 +224,11 @@ class TestAperturePhotometry:
                 * photometry_settings_for_test.camera.max_data_value.value
                 / fake_CCDimage.data.max()
             )
-            # For the moment, ensure the integer data is NOT larger than max_adu
-            # because until #161 is fixed then having NaN in the data will not succeed.
+            # Keep the integer data below max_adu so that no source is
+            # saturated. Saturated sources (see #161/#591) are flagged and get
+            # aperture_net_cnts set to NaN, which would break the flux
+            # comparison below; saturation itself is covered by
+            # test_aperture_photometry_flags_saturated_source.
             data = scale_factor * fake_CCDimage.data
             fake_CCDimage.data = data.astype(int)
 
@@ -434,6 +437,129 @@ class TestAperturePhotometry:
         ap_phot_exact = AperturePhotometry(settings=photometry_settings_for_test)
         phot_exact, _ = ap_phot_exact(image_file)
         assert np.all(phot_exact["aperture_sum"] != phot_center["aperture_sum"])
+
+    def test_aperture_photometry_flags_saturated_source(
+        self, tmp_path, photometry_settings_for_test
+    ):
+        # Regression test for #591 (which extends #161): a source with
+        # saturated pixels in its aperture should be explicitly flagged and
+        # have its aperture_net_cnts set to NaN, while the photometry of the
+        # other sources is unaffected.
+        fake_CCDimage = deepcopy(FAKE_CCD_IMAGE)
+        source_list = self.create_source_list()
+        source_list_file = tmp_path / "source_list.ecsv"
+        source_list.write(source_list_file, overwrite=True)
+
+        max_adu = photometry_settings_for_test.camera.max_data_value.value
+
+        # Saturate a few pixels at the center of the first source, i.e. well
+        # inside its photometry aperture.
+        saturated_source = source_list[0]
+        x_sat = int(saturated_source["xcenter"].value)
+        y_sat = int(saturated_source["ycenter"].value)
+        fake_CCDimage.data[y_sat : y_sat + 2, x_sat : x_sat + 2] = 2 * max_adu
+
+        photometry_settings_for_test.source_location_settings.source_list_file = str(
+            source_list_file
+        )
+
+        image_file = tmp_path / "fake_image.fits"
+        fake_CCDimage.write(image_file, overwrite=True)
+
+        # Also do photometry on the image without saturated pixels for
+        # comparison.
+        clean_image_file = tmp_path / "clean_image.fits"
+        deepcopy(FAKE_CCD_IMAGE).write(clean_image_file, overwrite=True)
+
+        ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
+        phot, _ = ap_phot(image_file)
+        clean_phot, _ = ap_phot(clean_image_file)
+
+        saturated_row = phot["star_id"] == saturated_source["star_id"]
+        assert saturated_row.sum() == 1
+
+        # The saturated source is flagged and its net counts are NaN rather
+        # than a silently wrong value.
+        assert np.all(phot["saturated"][saturated_row])
+        assert np.all(np.isnan(phot["aperture_net_cnts"][saturated_row].value))
+
+        # The other sources are not flagged and their results match the
+        # photometry of the image with no saturated pixels.
+        assert not np.any(phot["saturated"][~saturated_row])
+        assert np.all(np.isfinite(phot["aperture_net_cnts"][~saturated_row].value))
+        clean_saturated_row = clean_phot["star_id"] == saturated_source["star_id"]
+        np.testing.assert_allclose(
+            phot["aperture_sum"][~saturated_row].value,
+            clean_phot["aperture_sum"][~clean_saturated_row].value,
+        )
+
+    def test_saturated_source_recentroiding_falls_back_to_wcs(
+        self, tmp_path, photometry_settings_for_test
+    ):
+        # Regression test for #592: a completely saturated source used to
+        # produce a NaN centroid that escaped the shift-tolerance check and
+        # then crashed the photometry with a ValueError when the NaN position
+        # reached CircularAperture. Instead, the source position should fall
+        # back to the WCS-derived position and the source should be flagged
+        # as saturated.
+        fake_CCDimage = deepcopy(FAKE_CCD_IMAGE)
+        source_list = self.create_source_list()
+        source_list_file = tmp_path / "source_list.ecsv"
+        source_list.write(source_list_file, overwrite=True)
+
+        max_adu = photometry_settings_for_test.camera.max_data_value.value
+
+        # Completely saturate the first source over a region larger than the
+        # box used for recentroiding so that its centroid cannot be computed.
+        saturated_source = source_list[0]
+        x_sat = int(saturated_source["xcenter"].value)
+        y_sat = int(saturated_source["ycenter"].value)
+        half_width = 15
+        fake_CCDimage.data[
+            y_sat - half_width : y_sat + half_width + 1,
+            x_sat - half_width : x_sat + half_width + 1,
+        ] = (
+            2 * max_adu
+        )
+
+        photometry_settings_for_test.source_location_settings.source_list_file = str(
+            source_list_file
+        )
+        photometry_settings_for_test.source_location_settings.use_coordinates = "sky"
+
+        image_file = tmp_path / "fake_image.fits"
+        fake_CCDimage.write(image_file, overwrite=True)
+
+        ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
+
+        # This must not raise even though the saturated source has no usable
+        # centroid.
+        phot, _ = ap_phot(image_file)
+
+        saturated_row = phot["star_id"] == saturated_source["star_id"]
+        assert saturated_row.sum() == 1
+
+        # The position of the saturated source falls back to the WCS-derived
+        # position, which for this image is essentially the input position.
+        assert np.all(
+            np.abs(
+                phot["xcenter"][saturated_row].value - saturated_source["xcenter"].value
+            )
+            < 0.01
+        )
+        assert np.all(
+            np.abs(
+                phot["ycenter"][saturated_row].value - saturated_source["ycenter"].value
+            )
+            < 0.01
+        )
+
+        # The saturated source is flagged, its net counts are NaN, and the
+        # other sources are unaffected.
+        assert np.all(phot["saturated"][saturated_row])
+        assert np.all(np.isnan(phot["aperture_net_cnts"][saturated_row].value))
+        assert not np.any(phot["saturated"][~saturated_row])
+        assert np.all(np.isfinite(phot["aperture_net_cnts"][~saturated_row].value))
 
     @pytest.mark.parametrize("coords", ["sky", "pixel"])
     def test_photometry_on_directory(self, coords, photometry_settings_for_test):

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -561,6 +561,47 @@ class TestAperturePhotometry:
         assert not np.any(phot["saturated"][~saturated_row])
         assert np.all(np.isfinite(phot["aperture_net_cnts"][~saturated_row].value))
 
+    def test_sky_stats_annulus_only_without_outlier_rejection(
+        self, tmp_path, photometry_settings_for_test
+    ):
+        # Regression test for #602: with reject_background_outliers=False the
+        # sky_per_pix_med and sky_per_pix_std used to be computed from the
+        # rectangular bounding box of the annulus, which includes the bright
+        # core of the star (inside the inner radius) and the corners outside
+        # the annulus, wildly inflating the reported standard deviation. They
+        # should be computed from the pixels in the annulus only.
+        fake_CCDimage = deepcopy(FAKE_CCD_IMAGE)
+        source_list = self.create_source_list()
+        source_list_file = tmp_path / "source_list.ecsv"
+        source_list.write(source_list_file, overwrite=True)
+
+        phot_options = (
+            photometry_settings_for_test.photometry_optional_settings.model_copy()
+        )
+        phot_options.reject_background_outliers = False
+        photometry_settings_for_test.photometry_optional_settings = phot_options
+        photometry_settings_for_test.source_location_settings.source_list_file = str(
+            source_list_file
+        )
+
+        image_file = tmp_path / "fake_image.fits"
+        fake_CCDimage.write(image_file, overwrite=True)
+
+        ap_phot = AperturePhotometry(settings=photometry_settings_for_test)
+        phot, _ = ap_phot(image_file)
+
+        # The annuli contain none of the flux of these compact sources, so
+        # the sky median and standard deviation should both reflect the flat
+        # noisy background of the fake image: a median close to the mean
+        # noise level and a standard deviation close to the noise deviation
+        # (which is much smaller than the amplitude of the sources).
+        assert np.allclose(
+            phot["sky_per_pix_med"].value, fake_CCDimage.mean_noise, rtol=0.1
+        )
+        assert np.allclose(
+            phot["sky_per_pix_std"].value, fake_CCDimage.noise_dev, rtol=0.2
+        )
+
     @pytest.mark.parametrize("coords", ["sky", "pixel"])
     def test_photometry_on_directory(self, coords, photometry_settings_for_test):
         # Create list of fake CCDData objects


### PR DESCRIPTION
This PR fixes two related NaN/saturation-handling bugs in `single_image_photometry`, both stemming from pixels above the camera's `max_data_value` being set to NaN with no downstream handling, plus a bug in the sky statistics reported when background outlier rejection is turned off. It extends the earlier NaN-handling work in #161.

Fixes #591
Fixes #592
Fixes #602

## Bug 1: saturated (NaN) pixels silently poison aperture sums and are never flagged (#591)

Only the original `ccd_image.mask` was passed to `aperture_photometry`, so any source with a single saturated pixel in its aperture or annulus got an all-NaN sum, and the downstream `aperture_net_cnts < 0` check is `False` for NaN, so the source was never flagged.

**Fix:**
- The non-finite pixels (the saturated pixels marked as NaN, plus any NaN already in the input) are now added to the image mask, so they are excluded from the aperture sums and the sky statistics.
- Because the masked sum would then silently *underestimate* the flux of a saturated source, sources whose aperture contains any saturated pixel are explicitly flagged in a new boolean `saturated` column, a warning is logged, and their `aperture_net_cnts` is set to NaN following the existing convention for bad-FWHM/bad-count sources.
- The `saturated` column is documented in the `single_image_photometry` docstring, and the "until #161 is fixed" comment in the test suite has been updated.

## Bug 2: NaN centroid escapes the shift-tolerance fallback, crashing an entire multi-image run (#592)

In the `use_coordinates="sky"` path, `centroid_sources` was called without any mask, so a fully saturated source yielded a NaN centroid. `center_diff > shift_tolerance` is `False` for NaN, so the WCS fallback never fired, and the NaN position reached `CircularAperture`, raising a `ValueError` that aborted the whole multi-image run.

**Fix:**
- The (NaN-updated) image mask is now applied during centroiding. It is applied by setting masked pixels to NaN rather than by passing `mask=` to `centroid_sources`, because photutils 2.2 raises a `ValueError` for a completely masked cutout when given an explicit mask, while non-finite data is auto-masked and yields a NaN centroid — which is exactly what the fallback logic needs.
- A non-finite `center_diff` is now treated the same as "too much shift", so a source whose centroid cannot be computed falls back to its WCS-derived position instead of crashing.
- `compute_fwhm` returns NaN for a completely masked cutout instead of letting `fit_fwhm` raise.

Broader per-image try/except error handling in `multi_image_photometry` was deliberately left out to keep this change minimal; this PR only fixes the specific NaN escape paths.

## Bug 3: sky median/std computed from bounding-box pixels when `reject_background_outliers=False` (#602)

With `reject_background_outliers=False`, `sky_per_pix_med` and `sky_per_pix_std` were computed with `np.median`/`np.std` over `mask.cutout(ccd_image)` — the raw rectangular *bounding box* of the annulus, which includes the star's core (inside the inner radius) and the corner pixels outside the annulus. For the fake test image, the reported std was 32–61 counts instead of the true background deviation of 1 count. Only these two diagnostic columns were affected; `sky_per_pix_avg` (the value actually subtracted) was already computed correctly from `annulus_sum / annulus_area`.

**Fix:** use `ApertureStats` (as the `reject_background_outliers=True` branch already does, just without the sigma clip) so the median and standard deviation describe the annulus pixels only. `ApertureStats` also respects the image mask, which now includes the saturated pixels from Bug 1.

## Tests

Written test-first (each confirmed failing before its fix):
- `test_aperture_photometry_flags_saturated_source`: a source with saturated pixels in its aperture is flagged and gets NaN net counts, while the other sources' photometry is identical to that of an image with no saturated pixels.
- `test_saturated_source_recentroiding_falls_back_to_wcs`: a completely saturated source in the sky-coordinates + recentroiding path no longer crashes the run; it falls back to the WCS-derived position and is flagged.
- `test_sky_stats_annulus_only_without_outlier_rejection`: with `reject_background_outliers=False`, the reported sky median/std reflect the flat background in the annulus rather than being inflated by the stellar core.

Full `test_photometry.py` (54 tests) and `test_detection.py`/`test_profiles.py` pass locally.

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
