### PR TITLE
Fix incorrect units written by SourceListData.drop_x_y

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,7 +113,7 @@ Bug Fixes
   the core of the star and the corners outside the annulus. [#602]
 + ``SourceListData.drop_x_y`` now writes the NaN placeholder ``xcenter`` and
   ``ycenter`` columns with the documented ``pix`` unit instead of ``deg``,
-  which had been copied from ``drop_ra_dec``. [#620]
+  which had been copied from ``drop_ra_dec``. [#598]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,9 @@ Bug Fixes
   and ``sky_per_pix_std`` are now computed from the pixels in the annulus
   instead of from the rectangular bounding box of the annulus, which included
   the core of the star and the corners outside the annulus. [#602]
++ ``SourceListData.drop_x_y`` now writes the NaN placeholder ``xcenter`` and
+  ``ycenter`` columns with the documented ``pix`` unit instead of ``deg``,
+  which had been copied from ``drop_ra_dec``. [#620]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -1619,9 +1619,11 @@ class SourceListData(BaseEnhancedTable):
         self["dec"] = Column(data=np.full(len(self), np.nan), name="dec", unit=u.deg)
 
     def drop_x_y(self):
-        # drop image-based positionsfrom existing SourceListData structure
+        # drop image-based positions from existing SourceListData structure
         self.meta["has_x_y"] = False
-        self["xcenter"] = Column(data=np.full(len(self), np.nan), name="ra", unit=u.deg)
+        self["xcenter"] = Column(
+            data=np.full(len(self), np.nan), name="xcenter", unit=u.pix
+        )
         self["ycenter"] = Column(
-            data=np.full(len(self), np.nan), name="dec", unit=u.deg
+            data=np.full(len(self), np.nan), name="ycenter", unit=u.pix
         )

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -1231,16 +1231,26 @@ def test_sourcelist_dropping_skycoords():
     sl_test.drop_ra_dec()
     assert not sl_test.has_ra_dec
     assert sl_test.has_x_y
+    # The dropped columns should be all NaN with the documented units
+    assert sl_test["ra"].unit == u.deg
+    assert sl_test["dec"].unit == u.deg
+    assert np.isnan(sl_test["ra"]).all()
+    assert np.isnan(sl_test["dec"]).all()
 
 
 def test_sourcelist_dropping_imagecoords():
     # Create good sourcelist data instance
     sl_test = SourceListData(input_data=test_sl_data, colname_map=None)
 
-    # Drop sky coordinates
+    # Drop image coordinates
     sl_test.drop_x_y()
     assert sl_test.has_ra_dec
     assert not sl_test.has_x_y
+    # The dropped columns should be all NaN with the documented units
+    assert sl_test["xcenter"].unit == u.pix
+    assert sl_test["ycenter"].unit == u.pix
+    assert np.isnan(sl_test["xcenter"]).all()
+    assert np.isnan(sl_test["ycenter"]).all()
 
 
 def test_sourcelist_slicing():


### PR DESCRIPTION
### The bug

`SourceListData.drop_x_y` was copy-pasted from `drop_ra_dec` and kept `unit=u.deg` (and the names `ra`/`dec`, harmlessly overridden by the assignment) on the `xcenter`/`ycenter` columns it replaces with NaN. The documented unit for those columns is pixels, so after calling `drop_x_y()`, `sl["xcenter"].unit == u.deg` and any consumer doing `.to(u.pix)` breaks.

### The fix

- `drop_x_y` now writes the NaN `xcenter`/`ycenter` columns with `unit=u.pix` and matching column names.
- Extended `test_sourcelist_dropping_imagecoords` and `test_sourcelist_dropping_skycoords` to assert the column units and NaN values after the drop, not just the meta flags. The new `drop_x_y` unit assertion was verified to fail (unit was `deg`) before the fix.

Fixes #598

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
