### PR TITLE
Validate the variable star's own cross-match in calc_vmag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,7 +118,7 @@ Bug Fixes
   1 arcsecond in the photometry data, warning and returning ``NaN`` when it
   does not. Previously the magnitude of the nearest unrelated star was
   silently reported as the variable's when the target was absent from the
-  data. [#621]
+  data. [#599]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,11 @@ Bug Fixes
 + ``SourceListData.drop_x_y`` now writes the NaN placeholder ``xcenter`` and
   ``ycenter`` columns with the documented ``pix`` unit instead of ``deg``,
   which had been copied from ``drop_ra_dec``. [#598]
++ ``calc_vmag`` now checks that the variable star itself has a match within
+  1 arcsecond in the photometry data, warning and returning ``NaN`` when it
+  does not. Previously the magnitude of the nearest unrelated star was
+  silently reported as the variable's when the target was absent from the
+  data. [#621]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/differential_photometry/tests/test_vsx_mags.py
+++ b/stellarphot/differential_photometry/tests/test_vsx_mags.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, vstack
 from astropy.utils.data import get_pkg_data_filename
@@ -50,3 +52,35 @@ def test_multi_vmag():
 
     assert v_table["Mag"][0] == v_table["Mag"][1]
     assert v_table["StDev"][0] == v_table["StDev"][1]
+
+
+def test_vmag_target_with_no_match_warns_and_returns_nan():
+    # Regression test for #599: if the variable star is not present in
+    # star_data, calc_vmag used to silently report the magnitude of the
+    # nearest unrelated star. It should instead warn and return NaN.
+    find_var_data = get_pkg_data_filename("data/variables.fits")
+    var_stars = Table.read(find_var_data)
+    find_star_data = get_pkg_data_filename("data/2014-12-29-ey-uma-9.fits")
+    star_data = Table.read(find_star_data)
+    find_comp_data = get_pkg_data_filename("data/comp_stars.fits")
+    comp_stars = Table.read(find_comp_data)
+    comp_stars["coords"] = SkyCoord(
+        ra=comp_stars["ra"], dec=comp_stars["dec"], unit="degree"
+    )
+
+    # Move the variable star several degrees away from every star in the
+    # image so that it has no valid cross-match.
+    var_stars["coords"] = SkyCoord(
+        ra=var_stars["coords"].ra + 5 * u.degree, dec=var_stars["coords"].dec
+    )
+
+    with pytest.warns(UserWarning, match="No star within"):
+        vmag, error = calc_vmag(
+            var_stars,
+            star_data,
+            comp_stars,
+            band="Rc",
+            star_data_mag_column="mag_inst_R",
+        )
+    assert np.isnan(vmag)
+    assert np.isnan(error)

--- a/stellarphot/differential_photometry/vsx_mags.py
+++ b/stellarphot/differential_photometry/vsx_mags.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -77,10 +79,12 @@ def calc_vmag(
     Returns
     -------
     avg : float
-        Average magnitude for the variable star
+        Average magnitude for the variable star. NaN if the variable star
+        has no match within 1 arcsecond in ``star_data``.
 
     stdev : float
-        Standard deviation for variable star values
+        Standard deviation for variable star values. NaN if the variable
+        star has no match within 1 arcsecond in ``star_data``.
     """
 
     if not band:
@@ -91,6 +95,17 @@ def calc_vmag(
     var_coords = var_stars["coords"]
     star_data_coords = SkyCoord(ra=star_data["RA"], dec=star_data["Dec"])
     v_index, v_d2d, _ = var_coords.match_to_catalog_sky(star_data_coords)
+
+    # match_to_catalog_sky always returns the nearest neighbor, however far
+    # away it is, so make sure the variable star actually has a match in
+    # star_data before using its magnitude.
+    if np.any(v_d2d >= 1 * u.arcsec):
+        warnings.warn(
+            "No star within 1 arcsec of the variable star was found in "
+            "star_data, so its magnitude cannot be calculated.",
+            stacklevel=2,
+        )
+        return np.nan, np.nan
 
     rcomps = comp_stars[comp_stars["band"] == band]
 
@@ -105,9 +120,7 @@ def calc_vmag(
 
     vmag_image = star_data[v_index][star_data_mag_column]
     comp_star_mag = star_data[good_index][star_data_mag_column]
-    a_index, a_d2d, _ = comp_coords.match_to_catalog_sky(comp_coords)
-    good_a_index = a_index[good]
-    accepted_comp = rcomps[good_a_index]["mag"]
+    accepted_comp = rcomps[good]["mag"]
     new_mag = vmag_image - comp_star_mag + accepted_comp
     avg = np.nanmean(new_mag)
     stdev = np.nanstd(new_mag)


### PR DESCRIPTION
### The bug

`calc_vmag` cross-matched the variable star against `star_data` with
`match_to_catalog_sky`, assigned the separation `v_d2d`, and then never
looked at it — while the comparison stars *were* cut at 1″ a few lines
later. `match_to_catalog_sky` always returns some nearest neighbor, so if
the target star was absent from `star_data` (below the detection limit,
bad frame, wrong field), the magnitude of the nearest unrelated star was
silently reported as the variable's.

### The fix

Apply the same 1″ cut to the target's own match. If the variable star has
no star within 1″ in `star_data`, `calc_vmag` now issues a `UserWarning`
and returns `(nan, nan)` instead of a wrong number.

**Why warn + NaN rather than raise:** both in-repo callers invoke
`calc_vmag` in a loop — `calc_multi_vmag` loops over every VSX variable in
a field (some of which may legitimately be below the detection limit), and
`calculate_aavso_mags_draft.ipynb` loops over per-image groups to build a
lightcurve (the target can drop out of a single frame). Raising would
abort those whole batches for one missing match; NaN + a loud warning
keeps the batch running while making the failure visible and impossible to
mistake for a real magnitude.

Also fixes the minor point bundled in the issue: lines 108–109 matched
`comp_coords` against itself (an identity no-op) and then used the result
to index `rcomps`; replaced with direct boolean indexing (`rcomps[good]`).

Adds a regression test (`test_vmag_target_with_no_match_warns_and_returns_nan`)
that places the variable star degrees away from every star in the image
and asserts the warning and NaN return; it fails on `main` (silently
returns 14.55) and passes with this change.

Fixes #599

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
