### PR TITLE
Compute BJD per row in add_bjd_col instead of NaN-ing the whole table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,11 @@ Bug Fixes
   wrong Gaia ID to most stars. Only the coordinates are uploaded to XMatch
   now, making the query much faster and less likely to fail on large
   fields. [#586]
++ ``PhotometryData.add_bjd_col`` no longer sets the BJD to NaN for the whole
+  table when a single row is missing an RA or Dec value. The BJD is now
+  computed for every row that has coordinates and only the rows without
+  coordinates are masked in the resulting time column. A warning is issued
+  when rows are skipped. [#622]
 
 1.4.15 (2024-08-16)
 -------------------

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -15,6 +15,7 @@ from astropy.io.ascii import InconsistentTableError
 from astropy.table import Column, QTable, Table, TableAttribute
 from astropy.time import Time
 from astropy.utils.decorators import lazyproperty
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from astroquery.vizier import Vizier
 
@@ -706,24 +707,38 @@ class PhotometryData(BaseEnhancedTable):
                 )
             observatory = self.observatory
 
-        if bjd_coordinates is None and (
-            np.isnan(self["ra"]).any() or np.isnan(self["dec"]).any()
-        ):
-            print(
-                "WARNING: BJD could not be computed "
-                "because some RA or Dec values are missing."
-            )
-            self["bjd"] = np.full(len(self), np.nan)
+        if bjd_coordinates is None:
+            valid_coordinates = ~(np.isnan(self["ra"]) | np.isnan(self["dec"]))
         else:
+            # Explicit coordinates were provided, so every row can be computed.
+            valid_coordinates = np.ones(len(self), dtype=bool)
+
+        n_missing = len(self) - valid_coordinates.sum()
+        if n_missing > 0:
+            warnings.warn(
+                f"BJD could not be computed for {n_missing} of {len(self)} "
+                "rows because the RA or Dec value is missing. The BJD for "
+                "those rows is masked.",
+                AstropyUserWarning,
+                stacklevel=2,
+            )
+
+        bjd = np.full(len(self), np.nan)
+
+        if valid_coordinates.any():
             # Convert times at start of each observation to TDB (Barycentric Dynamical
             # Time)
-            times = Time(self["date-obs"])
+            times = Time(self["date-obs"][valid_coordinates])
             times_tdb = times.tdb
             times_tdb.format = "jd"  # Switch to JD format
 
             # Compute light travel time corrections
             if bjd_coordinates is None:
-                sky_coords = SkyCoord(ra=self["ra"], dec=self["dec"], unit="degree")
+                sky_coords = SkyCoord(
+                    ra=self["ra"][valid_coordinates],
+                    dec=self["dec"][valid_coordinates],
+                    unit="degree",
+                )
             else:
                 sky_coords = bjd_coordinates
 
@@ -732,8 +747,19 @@ class PhotometryData(BaseEnhancedTable):
             )
             time_barycenter = times_tdb + ltt_bary
 
-            # Return BJD at midpoint of exposure at each location
-            self["bjd"] = Time(time_barycenter + self["exposure"] / 2, scale="tdb")
+            # BJD at midpoint of exposure at each location
+            bjd[valid_coordinates] = (
+                time_barycenter + self["exposure"][valid_coordinates] / 2
+            ).jd
+
+        if n_missing > 0:
+            # An astropy Time cannot hold NaN values, so rows without
+            # coordinates are masked instead. A masked Time survives an
+            # ECSV round trip, and masked entries propagate through
+            # arithmetic on the column.
+            bjd = np.ma.array(bjd, mask=~valid_coordinates)
+
+        self["bjd"] = Time(bjd, format="jd", scale="tdb")
 
     def lightcurve_for(self, target, flux_column="mag_inst", passband=None):
         """

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -10,6 +10,7 @@ from astropy.nddata import CCDData
 from astropy.table import Table, vstack
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_path
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from astropy.wcs.wcs import FITSFixedWarning
 
@@ -596,10 +597,14 @@ def test_add_bjd_col_with_missing_coordinates(feder_cg_16m, feder_passbands, fed
         assert not bjd.mask[row]
         assert abs(bjd[row].value - 2459910.775405664) * 86400 < 0.05
 
-    # A warning about the skipped row should have been issued.
-    assert any(
-        "missing" in str(warning.message).lower() for warning in recorded
-    ), "Expected a warning about rows with missing RA/Dec"
+    # Exactly one warning about the skipped row should have been issued.
+    bjd_warnings = [
+        warning
+        for warning in recorded
+        if issubclass(warning.category, AstropyUserWarning)
+        and "BJD could not be computed" in str(warning.message)
+    ]
+    assert len(bjd_warnings) == 1, "Expected a warning about rows with missing RA/Dec"
 
 
 def test_photometry_data_short_filter_name(feder_cg_16m, feder_obs):

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -548,7 +548,7 @@ def test_photometry_data(feder_cg_16m, feder_passbands, feder_obs, bjd_coordinat
         # Dec 22 30 20.77733059
         # which returned 2459910.775405664 (Uses custom IDL, astropy is SOFA checked).
         # Demand a difference of less than 1/20 of a second.
-        assert (phot_data["bjd"][0].value - 2459910.775405664) * 86400 < 0.05
+        assert abs(phot_data["bjd"][0].value - 2459910.775405664) * 86400 < 0.05
     else:
         # Do the BJD calculation based on the provided coordinates, same for
         # all strs in the image.
@@ -562,7 +562,44 @@ def test_photometry_data(feder_cg_16m, feder_passbands, feder_obs, bjd_coordinat
         # Dec 22 30 20.77733059
         # which returned 2459910.774772048 (Uses custom IDL, astropy is SOFA checked).
         # Demand a difference of less than 1/20 of a second.
-        assert (phot_data["bjd"][0].value - 2459910.774772048) * 86400 < 0.05
+        assert abs(phot_data["bjd"][0].value - 2459910.774772048) * 86400 < 0.05
+
+
+def test_add_bjd_col_with_missing_coordinates(feder_cg_16m, feder_passbands, feder_obs):
+    # Regression test for #600. A single row with missing RA/Dec should not
+    # wipe out the BJD for every row in the table -- only the row that is
+    # missing coordinates should end up without a BJD.
+    data = vstack([testphot_clean, testphot_clean, testphot_clean])
+    data["ra"][1] = np.nan
+    data["dec"][1] = np.nan
+
+    phot_data = PhotometryData(
+        observatory=feder_obs,
+        camera=feder_cg_16m,
+        passband_map=feder_passbands,
+        input_data=data,
+    )
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        phot_data.add_bjd_col()
+
+    bjd = phot_data["bjd"]
+
+    # The row with missing coordinates should have no BJD. An astropy Time
+    # cannot hold a NaN, so the missing entry is masked instead.
+    assert bjd.mask[1]
+
+    # ...while the rows with valid coordinates should have the correct BJD.
+    # The reference value is the same one used in test_photometry_data above.
+    for row in (0, 2):
+        assert not bjd.mask[row]
+        assert abs(bjd[row].value - 2459910.775405664) * 86400 < 0.05
+
+    # A warning about the skipped row should have been issued.
+    assert any(
+        "missing" in str(warning.message).lower() for warning in recorded
+    ), "Expected a warning about rows with missing RA/Dec"
 
 
 def test_photometry_data_short_filter_name(feder_cg_16m, feder_obs):


### PR DESCRIPTION
### The bug

`PhotometryData.add_bjd_col` set `bjd` to NaN for **every** row of the table if even a single row was missing an RA or Dec value, with only a `print` warning. One bad detection wiped out the BJD light curves for every star and every night in the table — particularly bad for transit timing.

### The fix

- The BJD is now computed (still vectorized, on the valid-coordinate subset) for all rows that have coordinates; only the rows that actually lack RA/Dec are left without a BJD.
- Rows without coordinates are **masked** in the resulting `Time` column rather than set to NaN: astropy `Time` refuses non-finite jd values at construction, and a NaN smuggled in via `Time` arithmetic crashes when the saved ECSV file is read back. A masked `Time` is astropy's representation of a missing time, propagates through arithmetic on the column, and survives an ECSV round trip (verified end-to-end).
- The `print` warning is replaced by an `AstropyUserWarning` reporting how many rows were skipped.

### Bundled test defect

The existing BJD regression assertions lacked `abs()`, so any too-early BJD would pass:

```python
assert (phot_data["bjd"][0].value - 2459910.775405664) * 86400 < 0.05
```

Both assertions now use `abs(...)`. They pass unchanged with `abs()` added, so no latent sign error was hiding there.

A new regression test, `test_add_bjd_col_with_missing_coordinates`, was written first (TDD) and confirmed to fail on `main` — all rows came out NaN — before the fix was applied.

Fixes #600

*This PR was written by Claude at Matt's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJqM2DtL2tmCzm6aNFVXK3
