### PR TITLE
Add comment explaining the project URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ test = [
     "tox",
 ]
 
+# These populate the "Project links" sidebar on the PyPI page. The old
+# Homepage pointed at github.com/stellarphot/stellarphot, an org that does not
+# host this project; the code and docs live under feder-observatory instead.
 [project.urls]
 Homepage = "https://github.com/feder-observatory/stellarphot"
 Documentation = "https://stellarphot.readthedocs.io"


### PR DESCRIPTION
## Context

This PR originally fixed the out-of-date PyPI homepage URL (`github.com/stellarphot/stellarphot` → `feder-observatory/stellarphot`) and added Documentation/Repository/Issues links. Since then, **#636 merged the same URL fixes** (plus a `Changelog` link) into `main`, so the metadata is already correct.

After rebasing onto the current `main`, the remaining change is small and purely documentary.

## What this adds

A short comment above `[project.urls]` recording *why* the URLs matter and why the previous Homepage was wrong, so the mistake is less likely to recur:

```toml
# These populate the "Project links" sidebar on the PyPI page. The old
# Homepage pointed at github.com/stellarphot/stellarphot, an org that does not
# host this project; the code and docs live under feder-observatory instead.
[project.urls]
```

No URL values are changed — this sits on top of the URLs already merged in #636.

## Verification

- `pyproject.toml` parses cleanly (`tomllib.load`).
- Rebased on latest `main`; no conflicts.

Entirely optional — feel free to close if the inline note isn't wanted.