### PR TITLE
Fix out-of-date pyproject.toml metadata and Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ useful photometry, with a focus on variable star and exoplanet transit observati
 
 ## Installation
 
-`stellarphot` requires Python 3.10 or later.
+`stellarphot` requires Python 3.11 or later.
 
 You can install `stellarphot` with either `pip` or `conda`.  If you are interested in `stellarphot` for exoplanet transit light curves, `conda` is recommended at the moment because of an issue with installing one of the dependencies.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "hatchling.build"
 [project]
 name = "stellarphot"
 dynamic = ["version"]
-description = "A package for performing stellar photometry."
+description = "A package for performing stellar photometry aimed at variable star and exoplanet research."
 readme = "README.md"
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 requires-python = ">=3.11"
 authors = [
-    { name = "Matt Craig", email = "mattwcraig@gmail.com" },
+    { name = "The Stellarphot Team", email = "mattwcraig@gmail.com" },
 ]
 # Base install is headless/scriptable: the science + data layer only. The
 # Jupyter/ipywidgets GUI stack is an optional `[gui]` extra (see below), so
@@ -78,7 +78,7 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/stellarphot/stellarphot"
+Homepage = "https://github.com/feder-observatory/stellarphot"
 
 [tool.hatch.version]
 source = "vcs"
@@ -142,7 +142,7 @@ include = [
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311']
+target-version = ['py311', 'py312', 'py313']
 include = '\.pyi?$|\.ipynb$'
 # 'extend-exclude' excludes files or directories in addition to the defaults
 # extend-exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ test = [
 
 [project.urls]
 Homepage = "https://github.com/feder-observatory/stellarphot"
+Documentation = "https://stellarphot.readthedocs.io"
+Repository = "https://github.com/feder-observatory/stellarphot"
+Issues = "https://github.com/feder-observatory/stellarphot/issues"
+Changelog = "https://github.com/feder-observatory/stellarphot/blob/main/CHANGES.rst"
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,6 @@ exoplanet = [
     "lmfit",
     "pytransit",
 ]
-# Deprecated alias for `exoplanet`, kept for backwards compatibility. Will be
-# removed in a future release; use `stellarphot[exoplanet]` instead.
-exo_fitting = [
-    "stellarphot[exoplanet]",
-]
 # Everything a user needs for the full interactive experience.
 all = [
     "stellarphot[gui]",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.10,3.11,3.12}-test
+    py{3.11,3.12,3.13}-test
     coverage
     table_rep
     build_docs


### PR DESCRIPTION
Here are the changes I implemented:

- Fix the PyPI homepage link, which pointed at `stellarphot/stellarphot` instead of `feder-observatory/stellarphot`
- Update project description and author metadata, both stale since the early days of the project
- Bump the minimum supported Python to 3.11 and align `tool.black` target-version and `tox.ini`'s envlist with it — CI already tests 3.11-3.13, but black was still targeting py310/py311 and tox still had py3.10 in its matrix
- Switch `license` to the PEP 639 SPDX string form (`"BSD-3-Clause"`) instead of the legacy `{ text = ... }` table
- Remove the deprecated `exo_fitting` extra now that `exoplanet` has been the documented name for a full release cycle; nothing in the codebase, docs, or notebooks references the old name

This should resolve issue #630 .