### PR TITLE
Docs and annotation fixes from the 2026-07 code review

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
++ Documentation improvements: fixed docstring default values, expanded
+  variable-aperture photometry documentation with details on how aperture radii
+  are computed, clarified astropy Longitude wrapping behavior in the Observatory
+  class, and corrected type annotations and comments throughout the codebase. [#648]
 + The image viewers in the seeing-profile and comparison-star widgets now use
   the bqplot backend in astrowidgets (0.6 or later), and stellarphot no
   longer depends directly on ginga. In the comparison viewer, a plain click

--- a/docs/stellarphot/user_guide/doing_photometry.rst
+++ b/docs/stellarphot/user_guide/doing_photometry.rst
@@ -11,6 +11,10 @@ image at photometry time (by `~stellarphot.photometry.fast_fwhm_from_image`).
 This helps keep a consistent fraction of each star's light inside the aperture
 when the seeing varies across a night.
 
+The scaling applies only to the aperture radius: the ``gap`` between the
+aperture and the sky annulus and the ``annulus_width`` are still given in
+pixels, not in multiples of the FWHM.
+
 To enable variable-aperture photometry, check the ``variable_aperture`` box in
 the aperture settings shown by the seeing-profile widget, or set
 ``variable_aperture=True`` in your

--- a/docs/stellarphot/user_guide/doing_photometry.rst
+++ b/docs/stellarphot/user_guide/doing_photometry.rst
@@ -1,2 +1,17 @@
 Performing Aperture Photometry
 ##############################
+
+Variable-Aperture Photometry
+=============================
+
+When enabled, variable-aperture photometry adapts the aperture radius to the
+seeing in each image. The aperture radius used for an image is
+``radius`` × (image FWHM), where the FWHM is estimated from the stars in that
+image at photometry time (by `~stellarphot.photometry.fast_fwhm_from_image`).
+This helps keep a consistent fraction of each star's light inside the aperture
+when the seeing varies across a night.
+
+To enable variable-aperture photometry, check the ``variable_aperture`` box in
+the aperture settings shown by the seeing-profile widget, or set
+``variable_aperture=True`` in your
+`~stellarphot.settings.PhotometryApertures` settings.

--- a/stellarphot/gui/comparison_functions.py
+++ b/stellarphot/gui/comparison_functions.py
@@ -273,7 +273,7 @@ class ComparisonViewer:
         Bright magnitude limit for APASS stars. Defaults to 8.
 
     dim_mag_limit : float, optional
-        Dim magnitude limit for APASS stars.  Defaults to 17.
+        Dim magnitude limit for APASS stars.  Defaults to 15.
 
     targets_from_file : str, optional
         File with target information.  Defaults to None.

--- a/stellarphot/gui/transit_fitting_gui.py
+++ b/stellarphot/gui/transit_fitting_gui.py
@@ -244,6 +244,11 @@ def populate_TOI_boxes(toi, exotic_widget):
         "Target Star Dec": "coordP",
         "Orbital Period (days)": "period",
         "Orbital Period Uncertainty": "period_error",
+        # EXOTIC's field is named "Published Mid-Transit Time (BJD-UTC)" but the
+        # value is actually BJD_TDB (EXOTIC fills this from NASA Exoplanet Archive's
+        # pl_tranmid which is BJD_TDB, and compares against BJD_TDB image times
+        # without conversion). Since toi.epoch is already in TDB, passing
+        # toi.epoch.value is correct — do NOT convert to UTC here.
         "Published Mid-Transit Time (BJD-UTC)": "epoch",
         "Mid-Transit Time Uncertainty": "epoch_error",
         # Could maybe get these from TOI information, but not straightforward

--- a/stellarphot/io/tess.py
+++ b/stellarphot/io/tess.py
@@ -108,7 +108,7 @@ class TessSubmission:
 
     telescope_code: str
     filter: str
-    utc_start: int
+    utc_start: str
     tic_id: int
     planet_number: int
 

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -374,8 +374,12 @@ class PhotometryApertures(BaseModelWithTableRep):
         Field(
             default=False,  # To match the original default
             description=(
-                "Should the aperture be variable? If True, the aperture will be "
-                "calculated from the average FWHM of the stars in each image."
+                "Enable variable-aperture photometry. If True, the aperture "
+                "radius is `radius` × (image FWHM), computed from each image "
+                "using fast_fwhm_from_image. If False, the radius is simply "
+                "`radius`. Variable-aperture photometry adapts to seeing "
+                "conditions, improving photometric precision when FWHM "
+                "varies across images."
             ),
         ),
     ]
@@ -538,6 +542,14 @@ class Observatory(BaseModelWithTableRep):
     above example, but the example is given in part to show how to use sexagesimal
     notation.
 
+    Notes
+    -----
+    Astropy's `~astropy.coordinates.Longitude` class wraps negative (west)
+    longitudes into the 0–360° range. For example, −96.7° is displayed as
+    263.3°. This is evident in the examples above: the input −100.0 displays
+    as 260.0. When viewing the longitude value, keep in mind that east longitudes
+    appear as 0–180° while west longitudes appear as 180–360°.
+
     """
 
     # This ensures that just the first line of the docstring is used as the
@@ -575,7 +587,11 @@ class Observatory(BaseModelWithTableRep):
         _UnitQuantTypePydanticAnnotation,
         BeforeValidator(add_degree_to_float),
         Field(
-            description="Longitude of the observatory",
+            description=(
+                "Longitude of the observatory. Note that negative (west) "
+                "longitudes are wrapped into the 0–360° range (e.g. −96.7° "
+                "displays as 263.3°)."
+            ),
             examples=[
                 "-96.7678",
                 "-96d46m04.08s",

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -374,12 +374,8 @@ class PhotometryApertures(BaseModelWithTableRep):
         Field(
             default=False,  # To match the original default
             description=(
-                "Enable variable-aperture photometry. If True, the aperture "
-                "radius is `radius` × (image FWHM), computed from each image "
-                "using fast_fwhm_from_image. If False, the radius is simply "
-                "`radius`. Variable-aperture photometry adapts to seeing "
-                "conditions, improving photometric precision when FWHM "
-                "varies across images."
+                "If True, the aperture radius is radius × the FWHM measured "
+                "in each image; if False, radius is used as-is, in pixels."
             ),
         ),
     ]
@@ -588,9 +584,8 @@ class Observatory(BaseModelWithTableRep):
         BeforeValidator(add_degree_to_float),
         Field(
             description=(
-                "Longitude of the observatory. Note that negative (west) "
-                "longitudes are wrapped into the 0–360° range (e.g. −96.7° "
-                "displays as 263.3°)."
+                "Longitude of the observatory. West (negative) longitudes are "
+                "wrapped to 0–360°, e.g. −96.7° becomes 263.3°."
             ),
             examples=[
                 "-96.7678",

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -432,7 +432,7 @@ def transform_magnitudes(
     )
 
     # create a boolean of all of the matches that have a discrepancy of less
-    # than 5 arcseconds
+    # than 2 arcseconds
     good_match_for_transform = d2d < 2 * u.arcsecond
 
     catalog_index, d2d, _ = match_coordinates_sky(input_coords, catalog_all_coords)


### PR DESCRIPTION
Documentation/comment-only changes; no behavior changes. Completes #609 and picks up two doc-adjacent items from #606 and #607:

- `ComparisonViewer` docstring: `dim_mag_limit` default corrected to 15 (the actual default), was documented as 17 (#609).
- `transit_fitting_gui.py`: comment on the EXOTIC `"Published Mid-Transit Time (BJD-UTC)"` entry explaining that EXOTIC's field name is a misnomer — EXOTIC fills it from NEA's `pl_tranmid` (BJD_TDB) and compares against BJD_TDB image times without conversion, so passing the TDB epoch is correct and should not be "fixed" by converting to UTC (#606).
- `Observatory` docstring + longitude field description: note that astropy `Longitude` wraps negative (west) longitudes into 0–360° (e.g. −100° displays as 260°), which the existing doctest output already shows (#609).
- `variable_aperture` field description expanded (aperture radius = `radius` × per-image FWHM from `fast_fwhm_from_image`) and a short section added to the previously empty `doing_photometry.rst` stub documenting that variable-aperture photometry exists and how to enable it (#609).
- `TessSubmission.utc_start` dataclass annotation corrected from `int` to `str` (docstring and tests already treat it as a string like `"20220604"`) (#609).
- `magnitude_transforms.py`: stale comment said "less than 5 arcseconds" above the `d2d < 2 * u.arcsecond` check; the separate 5-arcsec cut below is a different mask (#607).

Verified: doctests in `stellarphot/settings/models.py` pass with `--doctest-plus`; `stellarphot/io` and `stellarphot/settings` test suites pass.

This PR was written by Claude at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEsxZvxjLqPN5PU8A14dpz
