### PR TITLE
Structure cleanups: drop dead module, document bottleneck, share in-frame check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,12 +13,20 @@ Other Changes and Additions
   bqplot backend provides no way to disable it. Because the new viewer stack
   requires it, stellarphot now requires Python 3.12 or later. [#584]
 + Removed ``stellarphot/utils/catalog_search.py``, an empty (0-byte) module
-  with no references anywhere in the codebase. [#xxx]
+  with no references anywhere in the codebase. [#650]
 + Added a comment to the ``bottleneck`` dependency in ``pyproject.toml``
   explaining why it is listed even though nothing imports it directly:
   astropy's ``sigma_clip``, which the photometry code calls heavily, uses it
   opportunistically to speed up its internal numpy operations when present.
-  [#xxx]
+  [#650]
++ Extracted the in-frame containment check duplicated between
+  ``CatalogData.from_vizier`` and ``stellarphot.utils.comparison_utils.in_field``
+  into a single shared helper, ``stellarphot.core.coords_in_frame``. Both call
+  sites now use the same inclusive (``>=``/``<=``) edge semantics that
+  ``from_vizier`` already used; previously ``in_field`` used strict bounds, so
+  a source landing exactly on the edge pixel of the frame now counts as
+  in-field where it previously did not. This is a deliberate, minor behavior
+  change. [#650]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,13 @@ Other Changes and Additions
   rather than a marker. Scroll-to-zoom is always on in the new viewers; the
   bqplot backend provides no way to disable it. Because the new viewer stack
   requires it, stellarphot now requires Python 3.12 or later. [#584]
++ Removed ``stellarphot/utils/catalog_search.py``, an empty (0-byte) module
+  with no references anywhere in the codebase. [#xxx]
++ Added a comment to the ``bottleneck`` dependency in ``pyproject.toml``
+  explaining why it is listed even though nothing imports it directly:
+  astropy's ``sigma_clip``, which the photometry code calls heavily, uses it
+  opportunistically to speed up its internal numpy operations when present.
+  [#xxx]
 
 Bug Fixes
 ^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ authors = [
 dependencies = [
     "astropy >=5",
     "astroquery",
-    "bottleneck",
+    "bottleneck",  # not imported directly, but astropy's sigma_clip -- called
+                   # heavily by the photometry code -- uses it opportunistically
+                   # to speed up its internal numpy operations when present
     "ccdproc",
     "lightkurve",
     "matplotlib",

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -84,10 +84,13 @@ def coords_in_frame(coords, wcs, shape, padding=0):
 
     shape : tuple of int
         Pixel shape of the image, as ``(nx, ny)`` -- the same axis order as
-        `astropy.wcs.WCS.pixel_shape`. This is a required argument, rather
-        than being read from ``wcs.pixel_shape``, because ``pixel_shape`` is
-        frequently ``None`` (it is only set if the WCS was constructed from
-        a header with ``NAXIS`` keywords, or set explicitly).
+        `astropy.wcs.WCS.pixel_shape`, and the *reverse* of the numpy
+        ``array.shape`` order ``(ny, nx)``. If you are starting from an
+        array, pass ``array.shape[::-1]``. This is a required argument,
+        rather than being read from ``wcs.pixel_shape``, because
+        ``pixel_shape`` is frequently ``None`` (it is only set if the WCS
+        was constructed from a header with ``NAXIS`` keywords, or set
+        explicitly).
 
     padding : int, optional
         Minimum number of pixels required between a coordinate and the edge

--- a/stellarphot/core.py
+++ b/stellarphot/core.py
@@ -65,6 +65,51 @@ VIZIER_SERVERS = (
 VIZIER_TIMEOUT = 30
 
 
+def coords_in_frame(coords, wcs, shape, padding=0):
+    """
+    Determine which sky coordinates fall within an image frame.
+
+    This is the shared containment check used both by
+    `CatalogData.from_vizier` (to clip a Vizier catalog to the field of
+    view) and by `stellarphot.utils.comparison_utils.in_field`.
+
+    Parameters
+    ----------
+
+    coords : `astropy.coordinates.SkyCoord`
+        Coordinates to test.
+
+    wcs : `astropy.wcs.WCS`
+        WCS solution used to convert ``coords`` to pixel positions.
+
+    shape : tuple of int
+        Pixel shape of the image, as ``(nx, ny)`` -- the same axis order as
+        `astropy.wcs.WCS.pixel_shape`. This is a required argument, rather
+        than being read from ``wcs.pixel_shape``, because ``pixel_shape`` is
+        frequently ``None`` (it is only set if the WCS was constructed from
+        a header with ``NAXIS`` keywords, or set explicitly).
+
+    padding : int, optional
+        Minimum number of pixels required between a coordinate and the edge
+        of the frame for that coordinate to be considered in-frame. Default
+        is 0.
+
+    Returns
+    -------
+
+    `numpy.ndarray` of bool
+        Boolean array, the same length as ``coords``, ``True`` for the
+        coordinates that fall within the frame (and at least ``padding``
+        pixels from its edge). Pixels exactly on the frame edge (or exactly
+        ``padding`` pixels in from it) count as in-frame.
+    """
+    nx, ny = shape
+    x, y = wcs.all_world2pix(coords.ra, coords.dec, 0)
+    in_x = (x >= padding) & (x <= nx - padding)
+    in_y = (y >= padding) & (y <= ny - padding)
+    return in_x & in_y
+
+
 def __getattr__(name):
     # PEP 562 module-level attribute access. Lazily forward the moved catalog
     # fetchers to ``stellarphot.catalogs`` so ``from stellarphot.core import
@@ -1353,10 +1398,7 @@ class CatalogData(BaseEnhancedTable):
         if clip_by_frame:
             cat_coords = SkyCoord(ra=cat["ra"], dec=cat["dec"])
             wcs = WCS(field_center)
-            x, y = wcs.all_world2pix(cat_coords.ra, cat_coords.dec, 0)
-            in_x = (x >= padding) & (x <= wcs.pixel_shape[0] - padding)
-            in_y = (y >= padding) & (y <= wcs.pixel_shape[1] - padding)
-            in_fov = in_x & in_y
+            in_fov = coords_in_frame(cat_coords, wcs, wcs.pixel_shape, padding=padding)
             cat = cat[in_fov]
 
         return cat

--- a/stellarphot/tests/test_core.py
+++ b/stellarphot/tests/test_core.py
@@ -20,6 +20,7 @@ from stellarphot.core import (
     CatalogData,
     PhotometryData,
     SourceListData,
+    coords_in_frame,
 )
 from stellarphot.settings import Camera, Observatory, PassbandMap
 
@@ -1082,6 +1083,68 @@ def test_from_vizier_with_header_no_wcs_raise_error():
 
     with pytest.raises(ValueError, match="Invalid coordinates in input"):
         CatalogData.from_vizier(header, "B/vsx/vsx", clip_by_frame=True)
+
+
+class _FakeWCS:
+    """
+    Stand-in for a WCS whose ``all_world2pix`` returns fixed pixel
+    coordinates, regardless of input. This isolates the boundary/padding
+    logic in ``coords_in_frame`` from the floating-point noise a real WCS
+    round trip (world -> pixel -> world -> pixel) introduces right at pixel
+    edges (e.g. pixel 0 round-tripping to ``-7e-12`` instead of exactly
+    ``0.0``).
+    """
+
+    # Deliberately do not set pixel_shape -- coords_in_frame must rely on
+    # the shape argument, not wcs.pixel_shape, since the latter is often
+    # None in practice.
+
+    def __init__(self, x, y):
+        self._x = np.asarray(x, dtype=float)
+        self._y = np.asarray(y, dtype=float)
+
+    def all_world2pix(self, ra, dec, origin):  # noqa: ARG002
+        return self._x, self._y
+
+
+def _fake_coords(n):
+    # coords_in_frame only reads .ra/.dec off of this to hand to
+    # all_world2pix, which _FakeWCS ignores, so the actual values don't
+    # matter -- just the length.
+    return SkyCoord(ra=np.zeros(n) * u.deg, dec=np.zeros(n) * u.deg)
+
+
+class TestCoordsInFrame:
+    def test_padding_excludes_sources_within_margin(self):
+        # x=40 is inside the image but inside the 50-pixel padding margin;
+        # x=200 is well clear of the margin. y=100 is within [50, 150] for
+        # both.
+        wcs = _FakeWCS(x=[40.0, 200.0], y=[100.0, 100.0])
+        coords = _fake_coords(2)
+
+        mask = coords_in_frame(coords, wcs, (400, 200), padding=50)
+
+        assert list(mask) == [False, True]
+
+    def test_edge_pixel_counts_as_inside(self):
+        # Corners exactly on the frame edge should be included; a point just
+        # past the edge should not.
+        wcs = _FakeWCS(x=[0.0, 400.0, 401.0], y=[0.0, 200.0, 100.0])
+        coords = _fake_coords(3)
+
+        mask = coords_in_frame(coords, wcs, (400, 200))
+
+        assert list(mask) == [True, True, False]
+
+    def test_non_square_shape_axes_are_not_swapped(self):
+        # x=300 is only valid on the wide (400-pixel) axis; if the helper
+        # swapped shape's axes this point would be incorrectly excluded.
+        wcs = _FakeWCS(x=[300.0], y=[100.0])
+        coords = _fake_coords(1)
+
+        mask = coords_in_frame(coords, wcs, (400, 200))
+
+        assert list(mask) == [True]
 
 
 class FakeVizier:

--- a/stellarphot/utils/comparison_utils.py
+++ b/stellarphot/utils/comparison_utils.py
@@ -5,6 +5,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
 from stellarphot.catalogs import apass_dr9, vsx_vizier
+from stellarphot.core import coords_in_frame
 
 __all__ = ["read_file", "set_up", "crossmatch_APASS2VSX", "mag_scale", "in_field"]
 
@@ -216,13 +217,11 @@ def in_field(apass_good_coord, ccd, apass, good_stars):
     ent : `astropy.table.Table`
         Table with APASS stars in the field of view.
     """
-    apassx, apassy = ccd.wcs.all_world2pix(apass_good_coord.ra, apass_good_coord.dec, 0)
-    # numpy image shapes are (ny, nx)
+    # numpy image shapes are (ny, nx); coords_in_frame expects (nx, ny), the
+    # same axis order as wcs.pixel_shape.
     ccdy, ccdx = ccd.shape
 
-    xin = (apassx < ccdx) & (0 < apassx)
-    yin = (apassy < ccdy) & (0 < apassy)
-    xy_in = xin & yin
+    xy_in = coords_in_frame(apass_good_coord, ccd.wcs, (ccdx, ccdy))
     nt = apass[good_stars]
     ent = nt[xy_in]
     return ent


### PR DESCRIPTION
Structure/dependency cleanups; completes #608.

- **Removed `stellarphot/utils/catalog_search.py`** — a 0-byte module with zero references repo-wide.
- **Documented the `bottleneck` dependency** in `pyproject.toml` (kept, per discussion): nothing imports it directly, but astropy's `sigma_clip` — which the photometry code calls heavily — uses it opportunistically as an accelerator. Comment matches the style of the neighboring `requests`/`regions` comments.
- **Extracted the duplicated in-frame containment check** into a shared `stellarphot.core.coords_in_frame(coords, wcs, shape, padding=0)` helper and rewired both call sites (`CatalogData.from_vizier`'s clip block and `comparison_utils.in_field`). `shape` is an explicit `(nx, ny)` argument because `wcs.pixel_shape` is frequently `None`. The helper lives in `core.py` rather than a new `utils` module because `core` importing anything from the `stellarphot.utils` package would run `utils/__init__.py → comparison_utils → catalogs → core` mid-import — a genuine circular-import failure; the `comparison_utils → core` direction is safe.

One deliberate, minor behavior change, noted in the changelog: `in_field` previously used strict bounds while `from_vizier` used inclusive ones; both now use the inclusive semantics, so a source landing exactly on the frame edge counts as in-field where `in_field` previously excluded it.

Developed test-first: new `TestCoordsInFrame` unit tests (padding margin, inclusive edges, non-square shape axis order) failed red before the helper existed and pass after; the pre-existing `test_in_field_non_square_image`, `from_vizier` clip tests, and the full local suite stay green (793 passed, 47 skipped).

This PR was written by Claude at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEsxZvxjLqPN5PU8A14dpz
