### PR TITLE
Fix block-center offset and mask aliasing in fast_fwhm_from_image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ Bug Fixes
   ``rp1`` passbands by name instead of assuming they are the first two
   columns of the input magnitudes, and raises a clear error if either band
   is missing from the transform's ``from_system``. [#649]
++ ``fast_fwhm_from_image`` no longer places its source-fitting window 0.5
+  pixel off center (the block-reduced-image coordinates were converted back
+  to original-image pixel coordinates with an off-by-0.5 formula), and it no
+  longer mutates the caller's ``CCDData.mask`` in place when flagging pixels
+  above ``max_adu``. [#651]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/photometry/source_detection.py
+++ b/stellarphot/photometry/source_detection.py
@@ -382,6 +382,20 @@ def source_detection(
     return sl_data
 
 
+def _block_center_to_pixel(block_index, block_size):
+    """
+    Convert a block index from a block-reduced image into the pixel
+    coordinate, in the original (pre-reduction) image, of the center of
+    that block.
+
+    Block ``block_index`` in the reduced image is the average of original
+    image pixels ``block_index * block_size`` through
+    ``(block_index + 1) * block_size - 1`` (inclusive), so the center of
+    that span of pixels is ``block_size * (block_index + 0.5) - 0.5``.
+    """
+    return block_size * (block_index + 0.5) - 0.5
+
+
 def fast_fwhm_from_image(
     ccd,
     fwhm_estimate,
@@ -491,8 +505,12 @@ def fast_fwhm_from_image(
     fwhm_est_sources = block_sources[: int(1.2 * n_brightest)]
 
     # Estimate the x and y positions of the sources in the original image
-    fwhm_est_sources["xcenter"] = block_size * (fwhm_est_sources["xcenter"].value + 0.5)
-    fwhm_est_sources["ycenter"] = block_size * (fwhm_est_sources["ycenter"].value + 0.5)
+    fwhm_est_sources["xcenter"] = _block_center_to_pixel(
+        fwhm_est_sources["xcenter"].value, block_size
+    )
+    fwhm_est_sources["ycenter"] = _block_center_to_pixel(
+        fwhm_est_sources["ycenter"].value, block_size
+    )
 
     # Compute the FWHM of the sources in the original image
     # Make sure fit_shape is an odd number about 5 times the estimated fwhm
@@ -502,7 +520,9 @@ def fast_fwhm_from_image(
     # max_adu. After we do the PSF fitting, we only keep results in which there were
     # no masked pixels in the fit. As a result, stars that are too bright in the image
     # will be ignored in the event they made it through the block reduction.
-    mask = np.zeros_like(ccd.data, dtype=bool) if mask is None else mask
+    # Copy the mask (or create a new one) instead of mutating it in place so
+    # that we don't alias, and thus modify, the caller's mask array.
+    mask = np.zeros_like(data, dtype=bool) if mask is None else mask.copy()
     mask |= data > max_adu
 
     with warnings.catch_warnings():

--- a/stellarphot/photometry/tests/test_detection.py
+++ b/stellarphot/photometry/tests/test_detection.py
@@ -304,3 +304,63 @@ def test_fast_fwhm_from_image_bad_aggregate():
             max_adu=65000,
             aggregate_by="foo",
         )
+
+
+def test_fast_fwhm_from_image_does_not_mutate_input_mask():
+    # Regression test for a latent bug in fast_fwhm_from_image: the function
+    # used to do `mask |= data > max_adu` on the mask pulled directly off of
+    # the input CCDData, which mutates the caller's mask array in place.
+    expected_fwhm = 5.5
+    fake_image = FakeCCDImage(seed=SEED, fwhm=expected_fwhm)
+
+    # Build a mask with a mix of True and False entries that is unrelated to
+    # which pixels are above max_adu.
+    mask = np.zeros(fake_image.data.shape, dtype=bool)
+    mask[0, 0] = True
+    mask[0, 1] = True
+    mask[10, 10] = True
+    fake_image.mask = mask
+
+    original_mask = mask.copy()
+
+    # Set max_adu comfortably above every source's peak so source detection
+    # and FWHM fitting behave normally, then poke in a single hot pixel,
+    # away from any source and not already masked, that exceeds max_adu.
+    # This guarantees the `mask |= data > max_adu` line actually finds a
+    # new pixel to mask, regardless of the random noise realization.
+    max_adu = 5000.0
+    assert fake_image.data.max() < max_adu
+    fake_image.data[5, 5] = max_adu + 1000
+    assert not fake_image.mask[5, 5]
+
+    fast_fwhm_from_image(
+        fake_image,
+        5,
+        noise=fake_image.noise_dev,
+        max_adu=max_adu,
+        aggregate_by=None,
+    )
+
+    np.testing.assert_array_equal(fake_image.mask, original_mask)
+
+
+def test_block_center_to_pixel():
+    # Regression test for the block-center off-by-0.5 bug in
+    # fast_fwhm_from_image (stellarphot issue #606). A block of size
+    # ``block_size`` at reduced-image index ``block_index`` covers original
+    # image pixels ``block_index * block_size`` through
+    # ``(block_index + 1) * block_size - 1`` inclusive, so the center of
+    # that block, in original-image pixel coordinates, is
+    # ``block_size * (block_index + 0.5) - 0.5``, NOT
+    # ``block_size * (block_index + 0.5)``.
+    from stellarphot.photometry.source_detection import _block_center_to_pixel
+
+    for block_size in [1, 4, 8]:
+        for block_index in [0, 1, 5, 12]:
+            original_pixels = np.arange(
+                block_index * block_size, (block_index + 1) * block_size
+            )
+            expected_center = original_pixels.mean()
+            assert _block_center_to_pixel(block_index, block_size) == pytest.approx(
+                expected_center
+            )


### PR DESCRIPTION
Two fixes in `fast_fwhm_from_image` (#606 item f plus a latent bug found during the review):

- **Block-center off-by-0.5**: block-reduced coordinates were converted back to original-image pixels as `block_size * (index + 0.5)`, but block `i` spans original pixels `i·b … (i+1)·b − 1`, whose center is `b·(i + 0.5) − 0.5`. The conversion now lives in a small `_block_center_to_pixel` helper with the corrected formula. Note on testing: the bias turns out to be invisible through the public API — `fit_2dgaussian` fits x/y freely inside a 25-px window, so the recovered FWHM/centers change by only ~1e-5 px between the old and new formulas. Rather than pretend an end-to-end tolerance pins it, the formula was extracted into the helper and unit-tested exactly (the test asserts the helper matches the mean of each block's original pixel indices; it fails by exactly 0.5 against the old formula).

- **Mask aliasing**: when a mask was provided, `mask |= data > max_adu` OR-ed pixels above `max_adu` into the *caller's* `ccd.mask` in place. The mask is now copied first. New regression test passes a `CCDData`-like image with a mixed mask plus one unmasked hot pixel above `max_adu` and asserts the input mask is unchanged (it gained the hot pixel before the fix).

Both tests confirmed red before the fixes and green after; full local suite green (792 passed, 47 skipped; remote-data tests skipped as usual).

This PR was written by Claude at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEsxZvxjLqPN5PU8A14dpz
