### PR TITLE
Test-suite hardening: offline catalog fetchers, unit round-trips, GUI value flow, klims regression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,15 @@ Other Changes and Additions
   ``load_fits`` now log which of the candidate exposure keywords they
   matched in the FITS header, instead of only logging on failure to find
   one. [#652]
++ Hardened the test suite (#607): added offline (mocked) coverage of
+  ``mag_scale``/``crossmatch_APASS2VSX``, of the ``apass_dr9``,
+  ``vsx_vizier`` and ``refcat2`` catalog fetchers and the
+  ``clip_by_frame=True`` path (previously exercised only by ``remote_data``
+  tests, invisible in normal CI), and of the GUI-to-settings-file value flow
+  for the seeing-profile aperture radius widget; added explicit unit
+  assertions to the settings JSON/table round-trip tests; and pinned the
+  ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
+  test at the maximum allowed planet radius. [#653]
 
 Bug Fixes
 ^^^^^^^^^

--- a/stellarphot/gui/tests/test_seeing_profile.py
+++ b/stellarphot/gui/tests/test_seeing_profile.py
@@ -178,6 +178,28 @@ def test_seeing_profile_save_apertures(tmp_path):
     )
 
 
+def test_seeing_profile_save_writes_widget_radius_to_settings_file(tmp_path):
+    # Combines test_seeing_profile_save_apertures (save() then load() the
+    # settings file) with the radius-widget change in
+    # test_seeing_profile_save_box_title (setting di_widgets["radius"].value
+    # directly, the way the aperture-radius UI control does) to check the
+    # full GUI -> pipeline value flow: a value entered in the radius widget
+    # ends up in the saved PhotometryWorkingDirSettings.
+    os.chdir(tmp_path)
+
+    profile_widget = spf.SeeingProfileWidget(
+        camera=Camera(**TEST_CAMERA_VALUES), _testing_path=tmp_path
+    )
+
+    new_radius = profile_widget.aperture_settings.value["radius"] + 5
+    profile_widget.aperture_settings.di_widgets["radius"].value = new_radius
+
+    profile_widget.save()
+
+    settings = PhotometryWorkingDirSettings().load()
+    assert settings.photometry_apertures.radius == new_radius
+
+
 def test_seeing_profile_save_box_title(tmp_path):
     # Save box title ends with different characters depending on whether values
     # need to be saved.

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -214,6 +214,79 @@ class TestModelAgnosticActions:
         assert all(title_present)
 
 
+def test_camera_json_round_trip_preserves_units():
+    # test_model_json_tround_trip above only checks model equality, which
+    # would still pass if a value came back with a unit that is merely
+    # equivalent (rather than identical) to the original -- e.g. a gain of
+    # "2.0 electron / adu" being silently converted to some other, numerically
+    # equal, combination of units. Check the units explicitly.
+    camera = Camera(**deepcopy(TEST_CAMERA_VALUES))
+    camera2 = Camera.model_validate_json(camera.model_dump_json())
+
+    assert camera2.gain.unit == u.electron / u.adu
+    assert camera2.gain.value == 2.0
+    assert camera2.read_noise.unit == u.electron
+    assert camera2.read_noise.value == 10.0
+    assert camera2.dark_current.unit == u.electron / u.s
+    assert camera2.dark_current.value == 0.01
+    assert camera2.pixel_scale.unit == u.arcsec / u.pix
+    assert camera2.pixel_scale.value == 0.563
+    assert camera2.max_data_value.unit == u.adu
+    assert camera2.max_data_value.value == 50000.0
+    assert camera2.data_unit == u.adu
+
+
+def test_observatory_json_round_trip_preserves_units():
+    # As above, but for Observatory's latitude/longitude/elevation, which
+    # are not plain Quantity objects (Latitude/Longitude/Quantity
+    # respectively), so are worth checking on their own.
+    observatory = Observatory(**deepcopy(TEST_OBSERVATORY_SETTINGS))
+    observatory2 = Observatory.model_validate_json(observatory.model_dump_json())
+
+    assert observatory2.latitude.unit == u.degree
+    assert observatory2.latitude.value == 45.0
+    assert observatory2.longitude.unit == u.degree
+    assert observatory2.longitude.value == 43.0
+    assert observatory2.elevation.unit == u.m
+    assert observatory2.elevation.value == 311.0
+
+
+def test_camera_table_round_trip_preserves_units(tmp_path):
+    # Companion to test_camera_json_round_trip_preserves_units above, but
+    # for the table-metadata round trip (see test_model_table_round_trip).
+    camera = Camera(**deepcopy(TEST_CAMERA_VALUES))
+    table = BaseEnhancedTable({"data": [1, 2, 3]})
+    table.meta["model"] = camera
+    table_path = tmp_path / "test_table.ecsv"
+    table.write(table_path)
+    new_table = BaseEnhancedTable.read(table_path)
+    camera2 = new_table.meta["model"]
+
+    assert camera2.gain.unit == u.electron / u.adu
+    assert camera2.gain.value == 2.0
+    assert camera2.max_data_value.unit == u.adu
+    assert camera2.max_data_value.value == 50000.0
+
+
+def test_observatory_table_round_trip_preserves_units(tmp_path):
+    # Companion to test_observatory_json_round_trip_preserves_units above,
+    # but for the table-metadata round trip.
+    observatory = Observatory(**deepcopy(TEST_OBSERVATORY_SETTINGS))
+    table = BaseEnhancedTable({"data": [1, 2, 3]})
+    table.meta["model"] = observatory
+    table_path = tmp_path / "test_table.ecsv"
+    table.write(table_path)
+    new_table = BaseEnhancedTable.read(table_path)
+    observatory2 = new_table.meta["model"]
+
+    assert observatory2.latitude.unit == u.degree
+    assert observatory2.latitude.value == 45.0
+    assert observatory2.longitude.unit == u.degree
+    assert observatory2.longitude.value == 43.0
+    assert observatory2.elevation.unit == u.m
+    assert observatory2.elevation.value == 311.0
+
+
 @pytest.mark.parametrize(
     "model,settings",
     [

--- a/stellarphot/tests/test_catalogs.py
+++ b/stellarphot/tests/test_catalogs.py
@@ -295,12 +295,21 @@ def test_find_refcat2(mag_limit, mag_limit_band):
 # Offline coverage for apass_dr9, vsx_vizier and refcat2, and for the
 # clip_by_frame=True path. The behavioral tests above are marked
 # remote_data, so they do not run (and are not visible as failures) in
-# normal CI. These mock ``Vizier.query_region`` -- the network boundary
+# normal CI. These mock ``VizierClass.query_region`` -- the network boundary
 # inside ``CatalogData.from_vizier`` -- with data drawn from the same
 # fixtures the remote_data tests use, so the fetchers' own processing (id
 # generation, column renaming/mapping, tidying, magnitude-limit-passband
 # validation, frame clipping) is exercised without a network call.
+#
+# The patch target must be the *class*: ``stellarphot.core.Vizier`` is
+# astroquery's ready-made VizierClass instance, and ``from_vizier`` builds a
+# fresh instance per server by calling it, so an attribute patched onto the
+# singleton is never consulted. Each test asserts the mock was called so the
+# suite fails loudly -- rather than quietly querying the live servers -- if
+# the query path moves again.
 # ---------------------------------------------------------------------------
+
+_QUERY_REGION = "astroquery.vizier.core.VizierClass.query_region"
 
 
 def _ey_uma_header():
@@ -327,10 +336,11 @@ def test_apass_dr9_offline(mocker):
     # data in test_find_apass, so it can be fed straight back in as a mocked
     # query_region result.
     raw_apass = Table.read(get_pkg_data_filename("data/all_apass_ey_uma.ecsv"))
-    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_apass])
+    query = mocker.patch(_QUERY_REGION, return_value=[raw_apass])
 
     result = apass_dr9(_ey_uma_header(), radius=10 * u.arcmin)
 
+    assert query.called
     assert set(ra.value for ra in result["ra"]) == set(raw_apass["RAJ2000"])
     # The passbands ought to have been translated to the AAVSO standard
     # names, same regression covered for the remote_data version (#439).
@@ -344,14 +354,15 @@ def test_apass_dr9_offline_clip_by_frame(mocker):
     # the result to stars inside the frame (minus padding), i.e. that it
     # removes at least one star near the edge of this field.
     raw_apass = Table.read(get_pkg_data_filename("data/all_apass_ey_uma.ecsv"))
-    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_apass])
+    query = mocker.patch(_QUERY_REGION, return_value=[raw_apass])
     header = _ey_uma_header()
 
     unclipped = apass_dr9(header, radius=10 * u.arcmin, clip_by_frame=False)
     clipped = apass_dr9(header, radius=10 * u.arcmin, clip_by_frame=True)
 
+    assert query.call_count == 2
     assert len(clipped) < len(unclipped)
-    assert set(clipped["ra"]) <= set(unclipped["ra"])
+    assert set(clipped["ra"].value) <= set(unclipped["ra"].value)
 
 
 def test_refcat2_offline(mocker):
@@ -366,10 +377,11 @@ def test_refcat2_offline(mocker):
     # id generation just reproduces the same ids.
     raw_refcat2 = Table.read(get_pkg_data_filename("data/all_refcat2_ey_uma.ecsv"))
     raw_refcat2 = Table(raw_refcat2, masked=True)
-    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_refcat2])
+    query = mocker.patch(_QUERY_REGION, return_value=[raw_refcat2])
 
     result = refcat2(_ey_uma_header(), radius=10 * u.arcmin)
 
+    assert query.called
     assert set(ra.value for ra in result["ra"]) == set(raw_refcat2["RA_ICRS"])
     for band in ["GBP", "GRP", "GG", "SG", "SR", "SI", "SZ", "J", "H", "K"]:
         assert band in result["passband"]
@@ -412,10 +424,11 @@ def test_vsx_vizier_offline(clip, data_file, mocker):
     # rows.
     expected = Table.read(get_pkg_data_filename(data_file))
     raw_vsx = _vsx_raw_from_processed(expected)
-    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_vsx])
+    query = mocker.patch(_QUERY_REGION, return_value=[raw_vsx])
 
     actual = vsx_vizier(_ey_uma_header(), radius=0.5 * u.degree, clip_by_frame=clip)
 
+    assert query.called
     assert set(actual["OID"]) == set(expected["OID"])
 
 

--- a/stellarphot/tests/test_catalogs.py
+++ b/stellarphot/tests/test_catalogs.py
@@ -291,6 +291,134 @@ def test_find_refcat2(mag_limit, mag_limit_band):
         assert all_refcat2["id"][nearest] == EY_UMA_REFCAT2_ID
 
 
+# ---------------------------------------------------------------------------
+# Offline coverage for apass_dr9, vsx_vizier and refcat2, and for the
+# clip_by_frame=True path. The behavioral tests above are marked
+# remote_data, so they do not run (and are not visible as failures) in
+# normal CI. These mock ``Vizier.query_region`` -- the network boundary
+# inside ``CatalogData.from_vizier`` -- with data drawn from the same
+# fixtures the remote_data tests use, so the fetchers' own processing (id
+# generation, column renaming/mapping, tidying, magnitude-limit-passband
+# validation, frame clipping) is exercised without a network call.
+# ---------------------------------------------------------------------------
+
+
+def _ey_uma_header():
+    # Same WCS/header construction used by the remote_data tests above
+    # (test_vsx_results, test_find_apass, test_find_refcat2).
+    CCD_SHAPE = [2048, 3073]
+    wcs_file = get_pkg_data_filename("data/sample_wcs_ey_uma.fits")
+    with fits.open(wcs_file) as hdulist:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The WCS transformation has more",
+                category=FITSFixedWarning,
+            )
+            wcs = WCS(hdulist[0].header)
+    wcs.pixel_shape = list(reversed(CCD_SHAPE))
+    ccd = CCDData(data=np.zeros(CCD_SHAPE), wcs=wcs, unit="adu")
+    return ccd.to_hdu()[0].header
+
+
+def test_apass_dr9_offline(mocker):
+    # data/all_apass_ey_uma.ecsv holds the raw APASS DR9 Vizier response
+    # (RAJ2000/DEJ2000/Field/Vmag/... columns) used to build the "expected"
+    # data in test_find_apass, so it can be fed straight back in as a mocked
+    # query_region result.
+    raw_apass = Table.read(get_pkg_data_filename("data/all_apass_ey_uma.ecsv"))
+    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_apass])
+
+    result = apass_dr9(_ey_uma_header(), radius=10 * u.arcmin)
+
+    assert set(ra.value for ra in result["ra"]) == set(raw_apass["RAJ2000"])
+    # The passbands ought to have been translated to the AAVSO standard
+    # names, same regression covered for the remote_data version (#439).
+    for band in ["B", "V", "SG", "SR", "SI"]:
+        assert band in result["passband"]
+
+
+def test_apass_dr9_offline_clip_by_frame(mocker):
+    # clip_by_frame=True is only ever exercised by the remote_data tests, so
+    # it is invisible to normal CI. Check offline that it actually restricts
+    # the result to stars inside the frame (minus padding), i.e. that it
+    # removes at least one star near the edge of this field.
+    raw_apass = Table.read(get_pkg_data_filename("data/all_apass_ey_uma.ecsv"))
+    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_apass])
+    header = _ey_uma_header()
+
+    unclipped = apass_dr9(header, radius=10 * u.arcmin, clip_by_frame=False)
+    clipped = apass_dr9(header, radius=10 * u.arcmin, clip_by_frame=True)
+
+    assert len(clipped) < len(unclipped)
+    assert set(clipped["ra"]) <= set(unclipped["ra"])
+
+
+def test_refcat2_offline(mocker):
+    # data/all_refcat2_ey_uma.ecsv holds refcat2 rows already run through
+    # _process_refcat2 (galaxy/non-Gaia filtering plus id generation), saved
+    # before tidying. Reading it back drops the mask on e_pmRA/e_pmDE/e_Gmag
+    # (no values are actually masked, since this is already the filtered
+    # survivors), so it is restored as a masked table before being handed
+    # back to _process_refcat2 as the mocked raw response -- otherwise
+    # ``catalog["e_pmRA"].mask`` raises because the column isn't a
+    # MaskedColumn. Filtering is then a no-op (nothing left to filter) and
+    # id generation just reproduces the same ids.
+    raw_refcat2 = Table.read(get_pkg_data_filename("data/all_refcat2_ey_uma.ecsv"))
+    raw_refcat2 = Table(raw_refcat2, masked=True)
+    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_refcat2])
+
+    result = refcat2(_ey_uma_header(), radius=10 * u.arcmin)
+
+    assert set(ra.value for ra in result["ra"]) == set(raw_refcat2["RA_ICRS"])
+    for band in ["GBP", "GRP", "GG", "SG", "SR", "SI", "SZ", "J", "H", "K"]:
+        assert band in result["passband"]
+
+    # ids must be unique per star, same check as test_find_refcat2.
+    n_stars = len(set(zip(result["ra"].value, result["dec"].value, strict=True)))
+    assert len(set(result["id"])) == n_stars
+
+
+def _vsx_raw_from_processed(processed):
+    # unclipped_ey_uma_vsx.fits / clipped_ey_uma_vsx.fits hold the already
+    # *processed* output of vsx_vizier (see test_vsx_results), not the raw
+    # Vizier response. Reconstruct a plausible raw B/vsx/vsx response by
+    # undoing vsx_vizier's column renames (and dropping mag_error, which is
+    # synthesized by CatalogData rather than coming from Vizier).
+    raw = processed.copy()
+    raw.rename_column("id", "Name")
+    raw.rename_column("ra", "RAJ2000")
+    raw.rename_column("dec", "DEJ2000")
+    raw.rename_column("mag", "max")
+    raw.rename_column("passband", "n_max")
+    raw.remove_column("mag_error")
+    return raw
+
+
+@pytest.mark.parametrize(
+    "clip, data_file",
+    [
+        (False, "data/unclipped_ey_uma_vsx.fits"),
+        (True, "data/clipped_ey_uma_vsx.fits"),
+    ],
+)
+def test_vsx_vizier_offline(clip, data_file, mocker):
+    # Offline counterpart to test_vsx_results, also covering the
+    # clip_by_frame=True path (parametrized case above). Each fixture is
+    # reconstructed into its own raw input so clip_by_frame=True is exercised
+    # on data that already sits inside the frame (an idempotent, and so
+    # self-consistent, check) rather than relying on it happening to filter
+    # data captured under different server-side settings down to the same
+    # rows.
+    expected = Table.read(get_pkg_data_filename(data_file))
+    raw_vsx = _vsx_raw_from_processed(expected)
+    mocker.patch("stellarphot.core.Vizier.query_region", return_value=[raw_vsx])
+
+    actual = vsx_vizier(_ey_uma_header(), radius=0.5 * u.degree, clip_by_frame=clip)
+
+    assert set(actual["OID"]) == set(expected["OID"])
+
+
 def test_iau_designation_ids_format():
     # The designation format: acronym, a space, then J + RA and Dec in
     # degrees, RA unsigned and Dec signed per the IAU spec, zero-padded (RA

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -136,6 +136,39 @@ def test_model_light_curve_at_times_length_mismatch_raises():
     np.testing.assert_allclose(tmod.model_light_curve(), baseline)
 
 
+def test_model_light_curve_at_max_rp_bound_is_finite_and_not_flat():
+    # Regression test for the klims=(0.005, 0.6) workaround in
+    # TransitModelFit.__init__ (see the comment there). rp's own allowed
+    # range tops out at 0.5 (_default_params), but RoadRunnerModel's default
+    # klims upper bound is also 0.5, and its native evaluator misbehaves
+    # when the radius ratio k lands exactly on the klims upper limit -- an
+    # off-by-one in pytransit's boundary handling that can crash outright,
+    # and that was observed (without the workaround, i.e. constructing
+    # RoadRunnerModel with its default klims) to instead silently return a
+    # flat, transit-free light curve here. Widening klims's upper bound
+    # keeps rp's whole allowed range safely inside the precomputed table.
+    #
+    # This evaluates the model at rp's maximum bound and checks for a sane
+    # transit signature (finite values with a real dip) rather than a flat
+    # or non-finite light curve, so it fails if the klims workaround is
+    # removed or narrowed back to rp's bound.
+    tmod = _make_transit_model_with_data(
+        noise_dev=0, with_airmass=False, with_width=False, with_spp=False
+    )
+
+    assert tmod.params["rp"].max == 0.5
+    tmod.params["rp"].value = tmod.params["rp"].max
+
+    light_curve = tmod.model_light_curve()
+
+    assert np.all(np.isfinite(light_curve))
+    # A transit with rp=0.5 has real depth; the light curve must actually
+    # dip well below 1, not stay flat (which is what the unpatched klims
+    # upper bound produces).
+    assert light_curve.min() < 1.0 - 1e-3
+    assert not np.allclose(light_curve, light_curve[0])
+
+
 def test_model_light_curve_requires_times():
     # model_light_curve() is public API; if called before times are set it
     # should fail fast with a clear ValueError (mirroring fit()) rather than a

--- a/stellarphot/utils/tests/test_comparison_utils.py
+++ b/stellarphot/utils/tests/test_comparison_utils.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import SkyCoord
 from astropy.nddata import CCDData
 from astropy.table import Table
 from astropy.wcs import WCS
@@ -82,3 +83,105 @@ def test_in_field_non_square_image():
     ent = comparison_utils.in_field(apass["coords"], ccd, apass, good_stars)
 
     assert sorted(ent["id"]) == [0, 2]
+
+
+def test_crossmatch_apass_to_vsx_and_targets_reports_separations(mocker):
+    # crossmatch_APASS2VSX should report the on-sky separation between each
+    # APASS star and its nearest match in the VSX table and in the
+    # target-list (RD) table.
+    apass_raw = Table({"ra": [10.0], "dec": [20.0]})
+    mocker.patch.object(comparison_utils, "apass_dr9", return_value=apass_raw)
+
+    # VSX star offset from the APASS star by exactly 2 arcsec in declination.
+    vsx = Table({"coords": SkyCoord(ra=[10.0] * u.deg, dec=[20.0 + 2 / 3600] * u.deg)})
+    # Target-list star offset by exactly 5 arcsec in declination.
+    RD = Table({"coords": SkyCoord(ra=[10.0] * u.deg, dec=[20.0 + 5 / 3600] * u.deg)})
+
+    apass, v_angle, RD_angle = comparison_utils.crossmatch_APASS2VSX(
+        _FakeCCD(), RD, vsx
+    )
+
+    # The mocked apass_dr9 return value is used as-is (with a coords column
+    # added), so the coordinates round trip.
+    assert apass is apass_raw
+    np.testing.assert_allclose(v_angle.arcsec, [2.0], atol=1e-6)
+    np.testing.assert_allclose(RD_angle.arcsec, [5.0], atol=1e-6)
+
+
+def test_crossmatch_apass_handles_empty_vsx_list(mocker):
+    # set_up returns a plain empty list, not a Table, when no VSX variables
+    # are found (see set_up above). crossmatch_APASS2VSX must handle that
+    # falsy-but-not-a-Table value without erroring, leaving v_angle empty
+    # while still matching against a non-empty target list.
+    apass_raw = Table({"ra": [10.0], "dec": [20.0]})
+    mocker.patch.object(comparison_utils, "apass_dr9", return_value=apass_raw)
+
+    RD = Table({"coords": SkyCoord(ra=[10.0] * u.deg, dec=[20.0 + 5 / 3600] * u.deg)})
+
+    apass, v_angle, RD_angle = comparison_utils.crossmatch_APASS2VSX(_FakeCCD(), RD, [])
+
+    assert v_angle == []
+    np.testing.assert_allclose(RD_angle.arcsec, [5.0], atol=1e-6)
+
+
+def test_mag_scale_selects_passband():
+    # Only stars in the requested passband should be considered, regardless
+    # of how well their magnitude and position would otherwise qualify.
+    coords = SkyCoord(ra=[10, 11] * u.deg, dec=[20, 20] * u.deg)
+    apass = Table({"passband": ["SR", "SG"], "mag": [10.0, 10.0], "coords": coords})
+    far = u.Quantity([100, 100], u.arcsec)
+
+    _, good_stars = comparison_utils.mag_scale(10.0, apass, far, far, passband="SR")
+    np.testing.assert_array_equal(good_stars, [True, False])
+
+    _, good_stars = comparison_utils.mag_scale(10.0, apass, far, far, passband="SG")
+    np.testing.assert_array_equal(good_stars, [False, True])
+
+
+def test_mag_scale_brighter_and_dimmer_magnitude_cuts():
+    # brighter_dmag/dimmer_dmag bound how far a comparison star's magnitude
+    # may be from the target's; stars outside that window are excluded even
+    # though they are the right passband and not close to anything else.
+    cmag = 10.0
+    brighter_dmag = 0.44
+    dimmer_dmag = 0.75
+    coords = SkyCoord(ra=[10, 11, 12, 13] * u.deg, dec=[20] * 4 * u.deg)
+    apass = Table(
+        {
+            "passband": ["SR"] * 4,
+            # too bright, just inside the bright cut, just inside the dim
+            # cut, too dim.
+            "mag": [
+                cmag - brighter_dmag - 0.01,
+                cmag - brighter_dmag + 0.01,
+                cmag + dimmer_dmag - 0.01,
+                cmag + dimmer_dmag + 0.01,
+            ],
+            "coords": coords,
+        }
+    )
+    far = u.Quantity([100] * 4, u.arcsec)
+
+    _, good_stars = comparison_utils.mag_scale(
+        cmag, apass, far, far, brighter_dmag=brighter_dmag, dimmer_dmag=dimmer_dmag
+    )
+    np.testing.assert_array_equal(good_stars, [False, True, True, False])
+
+
+def test_mag_scale_excludes_stars_too_close_to_vsx_or_targets():
+    # Comparison stars within 2 arcsec of a VSX variable or a target-list
+    # star are excluded, even when passband and magnitude are otherwise fine.
+    coords = SkyCoord(ra=[10, 11, 12] * u.deg, dec=[20] * 3 * u.deg)
+    apass = Table({"passband": ["SR"] * 3, "mag": [10.0] * 3, "coords": coords})
+
+    # Star 0 is just inside the VSX exclusion radius, star 1 is just inside
+    # the target-list exclusion radius, star 2 is just outside both.
+    v_angle = u.Quantity([1.9, 100, 2.1], u.arcsec)
+    RD_angle = u.Quantity([100, 1.9, 2.1], u.arcsec)
+
+    apass_good_coord, good_stars = comparison_utils.mag_scale(
+        10.0, apass, v_angle, RD_angle
+    )
+
+    np.testing.assert_array_equal(good_stars, [False, False, True])
+    assert len(apass_good_coord) == 1


### PR DESCRIPTION
Test-only PR covering the remaining doable items on #607's checklist; no production code changes.

1. **`crossmatch_APASS2VSX` / `mag_scale` unit tests** (`test_comparison_utils.py`): mocked `apass_dr9` (same `mocker.patch.object` pattern as `test_magnitude_transforms.py`); covers separation-angle correctness, the empty-VSX-list branch, and `mag_scale`'s passband selection, brighter/dimmer cuts, and 2″ too-close exclusion.
2. **Settings round-trips with explicit unit assertions** (`test_models.py`): JSON and table-metadata round trips for `Camera` and `Observatory` now assert the exact units (`gain.unit == u.electron/u.adu`, lat/lon/elevation in degrees/meters, …) instead of relying on model equality.
3. **GUI→pipeline value flow** (`test_seeing_profile.py`): sets the radius widget's value, calls `save()`, and asserts the value lands in `PhotometryWorkingDirSettings().load().photometry_apertures.radius` — combining two existing partial tests into an end-to-end check.
4. **Offline catalog-fetcher tests** (`test_catalogs.py`): `apass_dr9`, `refcat2`, `vsx_vizier`, and the `clip_by_frame=True` path were previously covered only by `remote_data` tests, invisible in normal CI. New tests mock `Vizier.query_region` (the network boundary inside `from_vizier`) using the existing EY UMa fixtures, including a check that clipping actually shrinks the result. Verified they run and pass without `--remote-data` and hit no network.
5. **pytransit `klims` regression test** (`test_transit_model_fit.py`): evaluates the model at `rp = 0.5` (rp's max bound) and asserts a finite, genuinely-dipping light curve. Verified by direct probing that with pytransit's default `klims=(0.005, 0.5)` — i.e. with the workaround removed — the model silently returns a flat, transit-free curve at that rp, so this test really does pin the `klims=(0.005, 0.6)` workaround.

No new tests uncovered real bugs (nothing needed xfail). The elongated-PSF test item stays deferred with #603.

Full local suite: 806 passed, 47 skipped (remote-data tests skipped as usual).

This PR was written by Claude at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEsxZvxjLqPN5PU8A14dpz
