### PR TITLE
Make sky annulus track per-image FWHM with variable apertures

### DIFF
--- a/stellarphot/photometry/photometry.py
+++ b/stellarphot/photometry/photometry.py
@@ -451,7 +451,7 @@ def single_image_photometry(
 
     # Remove all source positions too close to edges of image (where the annulus would
     # extend beyond the image boundaries).
-    padding = photometry_apertures.outer_annulus
+    padding = photometry_apertures.outer_annulus_pixels(fwhm)
     out_of_bounds = (
         (xs < padding)
         | (xs > (ccd_image.shape[1] - padding))
@@ -553,8 +553,8 @@ def single_image_photometry(
     apers = CircularAperture(aper_locs, r=photometry_apertures.radius_pixels(fwhm))
     annuli = CircularAnnulus(
         aper_locs,
-        r_in=photometry_apertures.inner_annulus,
-        r_out=photometry_apertures.outer_annulus,
+        r_in=photometry_apertures.inner_annulus_pixels(fwhm),
+        r_out=photometry_apertures.outer_annulus_pixels(fwhm),
     )
 
     # Flag sources whose aperture contains any saturated (or otherwise

--- a/stellarphot/photometry/tests/test_photometry.py
+++ b/stellarphot/photometry/tests/test_photometry.py
@@ -1127,6 +1127,18 @@ class TestAperturePhotometry:
             assert np.allclose(
                 group["aperture"].value, fwhm_multiplier * expected_fwhm, rtol=tolerance
             )
+            # The annulus should track the per-image FWHM too, not the static
+            # fwhm_estimate from the settings. See #654.
+            expected_inner = fwhm_multiplier * expected_fwhm + aperture_settings.gap
+            expected_outer = expected_inner + aperture_settings.annulus_width
+            assert np.allclose(
+                group["annulus_inner"].value, expected_inner, rtol=tolerance
+            )
+            assert np.allclose(
+                group["annulus_outer"].value, expected_outer, rtol=tolerance
+            )
+            # The aperture must never reach into its own sky annulus
+            assert np.all(group["aperture"].value < group["annulus_inner"].value)
 
     def test_invalid_path(self, photometry_settings_for_test):
         ap = AperturePhotometry(settings=photometry_settings_for_test)

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -422,16 +422,18 @@ class PhotometryApertures(BaseModelWithTableRep):
     @property
     def inner_annulus(self):
         """
-        Radius of the inner annulus in pixels.
+        Radius of the inner annulus in pixels, based on the FWHM estimate
+        in the settings.
         """
-        return self.radius_pixels(self.fwhm_estimate) + self.gap
+        return self.inner_annulus_pixels(self.fwhm_estimate)
 
     @property
     def outer_annulus(self):
         """
-        Radius of the outer annulus in pixels.
+        Radius of the outer annulus in pixels, based on the FWHM estimate
+        in the settings.
         """
-        return self.inner_annulus + self.annulus_width
+        return self.outer_annulus_pixels(self.fwhm_estimate)
 
     def radius_pixels(self, fwhm):
         """
@@ -442,6 +444,20 @@ class PhotometryApertures(BaseModelWithTableRep):
             return fwhm * self.radius
         else:
             return self.radius
+
+    def inner_annulus_pixels(self, fwhm):
+        """
+        Return the inner annulus radius in pixels for the given FWHM,
+        depending on whether the aperture is variable or not.
+        """
+        return self.radius_pixels(fwhm) + self.gap
+
+    def outer_annulus_pixels(self, fwhm):
+        """
+        Return the outer annulus radius in pixels for the given FWHM,
+        depending on whether the aperture is variable or not.
+        """
+        return self.inner_annulus_pixels(fwhm) + self.annulus_width
 
 
 class PhotometryFileSettings(BaseModelWithTableRep):

--- a/stellarphot/settings/tests/test_models.py
+++ b/stellarphot/settings/tests/test_models.py
@@ -644,6 +644,41 @@ class TestPhotometryApertureSettings:
         radius_pix = ap_set.radius_pixels(fwhm)
         assert radius_pix == pytest.approx(7.5, rel=1e-6)
 
+    @pytest.mark.parametrize(
+        "variable_aperture,radius",
+        [
+            (True, 1.5),
+            (False, 5.0),
+        ],
+    )
+    def test_annulus_pixels_methods(self, variable_aperture, radius):
+        # The annulus radii should follow the FWHM passed in, just like
+        # radius_pixels does, so that in variable-aperture mode the annulus
+        # can track the per-image FWHM. See #654.
+        settings = deepcopy(TEST_APERTURE_SETTINGS)
+        settings["variable_aperture"] = variable_aperture
+        settings["radius"] = radius
+        ap_set = PhotometryApertures(**settings)
+
+        # Deliberately different from the settings' fwhm_estimate
+        fwhm = 2 * settings["fwhm_estimate"]
+        if variable_aperture:
+            expected_inner = radius * fwhm + settings["gap"]
+        else:
+            expected_inner = radius + settings["gap"]
+        expected_outer = expected_inner + settings["annulus_width"]
+
+        assert ap_set.inner_annulus_pixels(fwhm) == pytest.approx(expected_inner)
+        assert ap_set.outer_annulus_pixels(fwhm) == pytest.approx(expected_outer)
+
+        # The properties should still be based on the settings' fwhm_estimate
+        assert ap_set.inner_annulus == pytest.approx(
+            ap_set.inner_annulus_pixels(settings["fwhm_estimate"])
+        )
+        assert ap_set.outer_annulus == pytest.approx(
+            ap_set.outer_annulus_pixels(settings["fwhm_estimate"])
+        )
+
 
 @pytest.mark.parametrize("bad_one", ["radius", "gap", "annulus_width"])
 def test_create_invalid_values(bad_one):


### PR DESCRIPTION
Fixes #654.

## The problem

With `variable_aperture=True`, `single_image_photometry` measures the FWHM of each image and scales the aperture with it, but the sky annulus (and the edge-of-image rejection padding) was always computed from the static `fwhm_estimate` in the settings. This affects **every** image photometered in variable mode, not just an initial estimate: the annulus is rebuilt per image but always from the same stale number. On any frame whose measured FWHM satisfies `radius × measured_fwhm > radius × fwhm_estimate + gap`, the aperture reaches into its own sky annulus, contaminating the background estimate — worst on exactly the bad-seeing frames variable apertures are meant to handle.

## The fix

- `PhotometryApertures` (in `stellarphot/settings/models.py`) gains `inner_annulus_pixels(fwhm)` and `outer_annulus_pixels(fwhm)` methods, mirroring the existing `radius_pixels(fwhm)`.
- The `inner_annulus` / `outer_annulus` properties now delegate to the new methods with `fwhm_estimate`, so GUI/display behavior and the fixed-aperture path are unchanged.
- `single_image_photometry` builds the `CircularAnnulus` and the edge-of-image `padding` from the new methods using the per-image FWHM already in scope. In fixed mode that FWHM *is* `fwhm_estimate`, so nothing changes there.

## Tests

Written first and confirmed failing before the production change:

- `test_annulus_pixels_methods` in `stellarphot/settings/tests/test_models.py` covers the new methods in both variable and fixed modes and checks the properties still follow `fwhm_estimate`.
- `test_photometry_variable_aperture` in `stellarphot/photometry/tests/test_photometry.py` now asserts that the `annulus_inner`/`annulus_outer` output columns track each image's measured FWHM (frames with FWHM 5, 7.5 and 10 px) and that the aperture never overlaps its own annulus. Before the fix this failed on the 7.5 and 10 px frames, exactly as the issue predicts.

Full `stellarphot/settings` + `stellarphot/photometry` suites pass (367 passed, 16 expected skips).

---
*This PR was written by Claude at @mwcraig's direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7Caue41k2785ggZeAFAhW
