### PR TITLE
Show settings-load problems in a banner in ReviewSettings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,10 +60,16 @@ Other Changes and Additions
   ``.bak2``... suffixes are used instead). Warnings raised while loading the
   settings are shown in the banner only when they are of the new
   ``stellarphot.settings.PhotometrySettingsWarning`` category, so plain
-  ``UserWarning``\\s from libraries on the load path stay out of it. Note
-  that ``ReviewSettings.current_settings`` is now a snapshot rather than a
+  ``UserWarning``\\s from libraries on the load path stay out of it.
+  ``PhotometryWorkingDirSettings.save`` suppresses repeated warnings from
+  its internal bookkeeping load, but lets ``PhotometrySettingsWarning``
+  through so a caller whose first interaction with the settings is a save
+  still sees user-actionable problems. Note that
+  ``ReviewSettings.current_settings`` is now a snapshot rather than a
   live re-read of the settings files; the snapshot is refreshed at the end
-  of widget construction and on each tab selection. [#657]
+  of widget construction and on each tab selection (refreshing is not a
+  pure read: as before this change, loading deletes a partial settings
+  file that exactly duplicates the full settings file). [#657]
 
 Bug Fixes
 ^^^^^^^^^
@@ -93,7 +99,13 @@ Bug Fixes
   same way as corrupt files instead of crashing ``ReviewSettings``. When a
   save writes full settings, the partial settings file is no longer deleted
   before the new settings file has been successfully written, so a failed
-  write cannot destroy the only copy of the partial settings. In
+  write cannot destroy the only copy of the partial settings. Settings
+  files are now written to a temporary file that atomically replaces the
+  target, so a failure partway through a write can no longer truncate an
+  existing readable settings file. The error raised for conflicting
+  partial and full settings files no longer advises deleting one of the
+  files (a save resolves the conflict and preserves the losing partial
+  settings file as ``.bak``). In
   ``ReviewSettings``, collapsing every section of an accordion no longer
   raises, selecting a tab whose setting is not saved now actually marks
   the tab as not saved, and a tab badge stuck at not-saved now recovers

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,37 +48,21 @@ Other Changes and Additions
   ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
   test at the maximum allowed planet radius. [#653]
 + ``ReviewSettings`` now shows a dismissible banner above the settings when
-  the saved settings in the working directory cannot be read or when loading
-  them generates warnings; previously such problems were silently swallowed
-  and the widget came up with defaults and no explanation. When one of the
-  settings files is readable, the widget now starts from it instead of from
-  defaults. ``PhotometryWorkingDirSettings.save`` no longer overwrites or
-  deletes a settings file whose contents could not be read, or a partial
-  settings file whose values are not carried into the full settings being
-  written (partial values the settings passed to ``save`` explicitly
-  replace are excluded -- replacing them was the point of the save); such
-  files are preserved with a ``.bak`` suffix instead, and
-  existing ``.bak`` backups are never overwritten (numbered ``.bak1``,
-  ``.bak2``... suffixes are used instead). Warnings raised while loading the
-  settings are shown in the banner only when they are of the new
-  ``stellarphot.settings.PhotometrySettingsWarning`` category, so plain
-  ``UserWarning``\\s from libraries on the load path stay out of it.
-  ``PhotometryWorkingDirSettings.save`` suppresses repeated warnings from
-  its internal bookkeeping load, but lets ``PhotometrySettingsWarning``
-  through so a caller whose first interaction with the settings is a save
-  still sees user-actionable problems (the ``ReviewSettings`` autosaves
-  suppress that pass-through, since the widget already shows the warning
-  in its banner; warnings of any other category raised during an autosave
-  are re-emitted rather than swallowed). A banner message whose underlying
-  problem is no longer reproduced by the latest reload is reworded in the
-  past tense and marked "no longer detected" instead
-  of continuing to read as a current problem, and dismissing a load-error
-  message does not suppress a later, different load error. Note that
-  ``ReviewSettings.current_settings`` is now a snapshot rather than a
-  live re-read of the settings files; the snapshot is refreshed at the end
-  of widget construction and on each tab selection (refreshing is not a
-  pure read: as before this change, loading deletes a partial settings
-  file that exactly duplicates the full settings file). [#657]
+  the saved settings in the working directory cannot be read or when
+  loading them raises a warning of the new
+  ``stellarphot.settings.PhotometrySettingsWarning`` category (other
+  warning categories stay out of the banner); previously such problems
+  were silently ignored and the widget came up with defaults and no
+  explanation. When one of the settings files is readable, the widget now
+  starts from it instead of from defaults.
+  ``PhotometryWorkingDirSettings.save`` no longer overwrites or deletes a
+  settings file whose contents could not be read, or a partial settings
+  file with values not carried into the full settings being written; such
+  files are preserved with a ``.bak`` suffix (or the next available
+  numbered ``.bak1``, ``.bak2``, ... -- existing backups are never
+  overwritten). Note that ``ReviewSettings.current_settings`` is now a
+  snapshot rather than a live re-read of the settings files, refreshed at
+  the end of widget construction and on each tab selection. [#657]
 
 Bug Fixes
 ^^^^^^^^^
@@ -103,29 +87,16 @@ Bug Fixes
   above ``max_adu``. [#651]
 + ``PhotometryWorkingDirSettings.save(partial_settings, update=True)`` no
   longer raises ``AttributeError`` when an existing full settings file
-  cannot be read. Settings files that cannot be read because of an encoding
-  or operating-system error (not just invalid JSON) are now reported the
-  same way as corrupt files instead of crashing ``ReviewSettings``. When a
-  save writes full settings, the partial settings file is no longer deleted
-  before the new settings file has been successfully written, so a failed
-  write cannot destroy the only copy of the partial settings. Settings
-  files are now written to a temporary file that atomically replaces the
-  target, so a failure partway through a write can no longer truncate an
-  existing readable settings file. The error raised for conflicting
-  partial and full settings files no longer advises deleting one of the
-  files (a save resolves the conflict and preserves the losing partial
-  settings file as ``.bak``), and the error raised by
-  ``save(partial, update=False)`` no longer claims full settings "already
-  exist" when the existing full settings file could not be read. The
-  ``full_settings_unreadable``/``partial_settings_unreadable`` properties
-  are False before ``load`` has been called, instead of reporting an
-  existing readable file as unreadable, and report the outcome of the most
-  recent ``load`` rather than the live state of the disk. In
-  ``ReviewSettings``, collapsing every section of an accordion no longer
-  raises, selecting a tab whose setting is not saved now actually marks
-  the tab as not saved, and a tab badge stuck at not-saved now recovers
-  when the setting is saved outside the widget (e.g. by another widget
-  writing the settings file). [#657]
+  cannot be read, and a settings file unreadable because of an encoding or
+  operating-system error (not just invalid JSON) is reported like a
+  corrupt file instead of crashing ``ReviewSettings``. Settings files are
+  now written to a temporary file that atomically replaces the target, and
+  the partial settings file is disposed of only after new full settings
+  are safely on disk, so a failed write can no longer truncate or destroy
+  existing settings. In ``ReviewSettings``, collapsing every section of an
+  accordion no longer raises, selecting a tab whose setting is not saved
+  now actually marks the tab as not saved, and a tab badge stuck at
+  not-saved recovers when the setting is saved outside the widget. [#657]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,12 @@ Other Changes and Additions
   ``PhotometryWorkingDirSettings.save`` suppresses repeated warnings from
   its internal bookkeeping load, but lets ``PhotometrySettingsWarning``
   through so a caller whose first interaction with the settings is a save
-  still sees user-actionable problems. Note that
+  still sees user-actionable problems (the ``ReviewSettings`` autosaves
+  suppress that pass-through, since the widget already shows the warning
+  in its banner). A banner message whose underlying problem is no longer
+  reproduced by the latest reload is marked "No longer detected" instead
+  of continuing to read as a current problem, and dismissing a load-error
+  message does not suppress a later, different load error. Note that
   ``ReviewSettings.current_settings`` is now a snapshot rather than a
   live re-read of the settings files; the snapshot is refreshed at the end
   of widget construction and on each tab selection (refreshing is not a
@@ -105,7 +110,12 @@ Bug Fixes
   existing readable settings file. The error raised for conflicting
   partial and full settings files no longer advises deleting one of the
   files (a save resolves the conflict and preserves the losing partial
-  settings file as ``.bak``). In
+  settings file as ``.bak``), and the error raised by
+  ``save(partial, update=False)`` no longer claims full settings "already
+  exist" when the existing full settings file could not be read. The
+  ``full_settings_unreadable``/``partial_settings_unreadable`` properties
+  are False before ``load`` has been called, instead of reporting an
+  existing readable file as unreadable. In
   ``ReviewSettings``, collapsing every section of an accordion no longer
   raises, selecting a tab whose setting is not saved now actually marks
   the tab as not saved, and a tab badge stuck at not-saved now recovers

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,22 +47,44 @@ Other Changes and Additions
   assertions to the settings JSON/table round-trip tests; and pinned the
   ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
   test at the maximum allowed planet radius. [#653]
-+ ``ReviewSettings`` now shows a dismissible banner above the settings when
-  the saved settings in the working directory cannot be read or when
-  loading them raises a warning of the new
++ ``ReviewSettings`` now shows a banner above the settings when the saved
+  settings in the working directory cannot be read or when loading them
+  raises a warning of the new
   ``stellarphot.settings.PhotometrySettingsWarning`` category (other
   warning categories stay out of the banner); previously such problems
   were silently ignored and the widget came up with defaults and no
-  explanation. When one of the settings files is readable, the widget now
-  starts from it instead of from defaults.
-  ``PhotometryWorkingDirSettings.save`` no longer overwrites or deletes a
-  settings file whose contents could not be read, or a partial settings
-  file with values not carried into the full settings being written; such
-  files are preserved with a ``.bak`` suffix (or the next available
-  numbered ``.bak1``, ``.bak2``, ... -- existing backups are never
-  overwritten). Note that ``ReviewSettings.current_settings`` is now a
-  snapshot rather than a live re-read of the settings files, refreshed at
-  the end of widget construction and on each tab selection. [#657]
+  explanation. Each problem is reported as a single short line, with the
+  full error behind a collapsed "Full error" disclosure. Because widget
+  construction and every save repair broken settings files
+  automatically, a problem that is still active means the files changed
+  outside the widget; the banner says so, turns amber, greys out the
+  settings below, and cannot be dismissed -- its buttons are the way
+  forward. For an unreadable settings file that is a "Set aside broken
+  file(s) and keep the values shown" button that renames the file to a
+  ``.bak`` backup and re-saves the displayed values; for settings files
+  that disagree with each other, a "Keep the values shown" button that
+  resolves the conflict the same way; and for every active problem a
+  "Reload" button for repairs made by hand. Once no problem remains --
+  including one cured by an automatic save before the user ever saw the
+  banner -- the banner turns a calm green, becomes dismissable, and
+  names the actual ``.bak`` file(s) that were created rather than
+  guessing about them. When one of the settings files is readable, the
+  widget now starts from it instead of from defaults.
+  ``PhotometryWorkingDirSettings.save`` no longer overwrites or
+  deletes a settings file whose contents could not be read, or a partial
+  settings file with values not carried into the full settings being
+  written; such files are preserved with a ``.bak`` suffix (or the next
+  available numbered ``.bak1``, ``.bak2``, ... -- existing backups are
+  never overwritten), and a save now sets aside every settings file its
+  pre-save load found unreadable, not just the file being rewritten, so
+  any save leaves the directory readable again.
+  ``PhotometryWorkingDirSettings`` also gains a public
+  ``set_aside_unreadable`` method that renames the file(s) the most
+  recent load found unreadable to ``.bak`` backups, and a read-only
+  ``backups_made`` property recording the backups an instance has
+  created. Note that ``ReviewSettings.current_settings`` is now a
+  snapshot rather than a live re-read of the settings files, refreshed
+  at the end of widget construction and on each tab selection. [#657]
 
 Bug Fixes
 ^^^^^^^^^
@@ -96,7 +118,27 @@ Bug Fixes
   existing settings. In ``ReviewSettings``, collapsing every section of an
   accordion no longer raises, selecting a tab whose setting is not saved
   now actually marks the tab as not saved, and a tab badge stuck at
-  not-saved recovers when the setting is saved outside the widget. [#657]
+  not-saved recovers when the setting is saved outside the widget. A tab
+  badge also drops back to not-saved when its setting disappears from disk,
+  and a tab marked not-saved now shows its save button as having unsaved
+  changes, with a note saying the setting is not saved in this directory,
+  so it can be fixed with a single click instead of appearing inert.
+  While a settings file is unreadable or the settings files conflict,
+  tabs are no longer stamped not-saved one by one as they are selected --
+  the banner is the sole indicator of that problem; the not-saved
+  stamping still applies when a setting is simply missing from disk.
+  A tab whose setting is chosen from saved items (camera, observatory,
+  passband map) now re-saves its displayed value when the setting
+  disappears from disk, instead of latching a not-saved badge such a tab
+  offers no save button to clear, and a tab whose displayed value is
+  invalid is prompted for a save when selected instead of pairing a
+  not-saved badge with a save bar that claims there is nothing to save.
+  A failed automatic save (e.g. in a directory that has become
+  read-only) is now reported in the banner instead of raising out of the
+  widget's observers.
+  Finally, a spurious "path given doesnt exist" warning from ipyautoui's
+  file chooser no longer appears above settings widgets in a working
+  directory that does not yet contain a source list file. [#657]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,12 @@ Other Changes and Additions
   defaults. ``PhotometryWorkingDirSettings.save`` no longer overwrites or
   deletes a settings file whose contents could not be read, or a partial
   settings file whose values are not carried into the full settings being
-  written; such files are preserved with a ``.bak`` suffix instead. Note
+  written; such files are preserved with a ``.bak`` suffix instead, and
+  existing ``.bak`` backups are never overwritten (numbered ``.bak1``,
+  ``.bak2``... suffixes are used instead). Warnings raised while loading the
+  settings are shown in the banner only when they are of the new
+  ``stellarphot.settings.PhotometrySettingsWarning`` category, so plain
+  ``UserWarning``\\s from libraries on the load path stay out of it. Note
   that ``ReviewSettings.current_settings`` is now a snapshot rather than a
   live re-read of the settings files; the snapshot is refreshed at the end
   of widget construction and on each tab selection. [#657]
@@ -85,10 +90,15 @@ Bug Fixes
   longer raises ``AttributeError`` when an existing full settings file
   cannot be read. Settings files that cannot be read because of an encoding
   or operating-system error (not just invalid JSON) are now reported the
-  same way as corrupt files instead of crashing ``ReviewSettings``. In
+  same way as corrupt files instead of crashing ``ReviewSettings``. When a
+  save writes full settings, the partial settings file is no longer deleted
+  before the new settings file has been successfully written, so a failed
+  write cannot destroy the only copy of the partial settings. In
   ``ReviewSettings``, collapsing every section of an accordion no longer
-  raises, and selecting a tab whose setting is not saved now actually marks
-  the tab as not saved. [#657]
+  raises, selecting a tab whose setting is not saved now actually marks
+  the tab as not saved, and a tab badge stuck at not-saved now recovers
+  when the setting is saved outside the widget (e.g. by another widget
+  writing the settings file). [#657]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,8 +56,9 @@ Other Changes and Additions
   deletes a settings file whose contents could not be read, or a partial
   settings file whose values are not carried into the full settings being
   written; such files are preserved with a ``.bak`` suffix instead. Note
-  that ``ReviewSettings.current_settings`` is now a snapshot as of the last
-  refresh rather than a live re-read of the settings files. [#657]
+  that ``ReviewSettings.current_settings`` is now a snapshot rather than a
+  live re-read of the settings files; the snapshot is refreshed at the end
+  of widget construction and on each tab selection. [#657]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,17 @@ Other Changes and Additions
   assertions to the settings JSON/table round-trip tests; and pinned the
   ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
   test at the maximum allowed planet radius. [#653]
++ ``ReviewSettings`` now shows a dismissible banner above the settings when
+  the saved settings in the working directory cannot be read or when loading
+  them generates warnings; previously such problems were silently swallowed
+  and the widget came up with defaults and no explanation. When one of the
+  settings files is readable, the widget now starts from it instead of from
+  defaults. ``PhotometryWorkingDirSettings.save`` no longer overwrites or
+  deletes a settings file whose contents could not be read, or a partial
+  settings file whose values are not carried into the full settings being
+  written; such files are preserved with a ``.bak`` suffix instead. Note
+  that ``ReviewSettings.current_settings`` is now a snapshot as of the last
+  refresh rather than a live re-read of the settings files. [#657]
 
 Bug Fixes
 ^^^^^^^^^
@@ -69,6 +80,14 @@ Bug Fixes
   to original-image pixel coordinates with an off-by-0.5 formula), and it no
   longer mutates the caller's ``CCDData.mask`` in place when flagging pixels
   above ``max_adu``. [#651]
++ ``PhotometryWorkingDirSettings.save(partial_settings, update=True)`` no
+  longer raises ``AttributeError`` when an existing full settings file
+  cannot be read. Settings files that cannot be read because of an encoding
+  or operating-system error (not just invalid JSON) are now reported the
+  same way as corrupt files instead of crashing ``ReviewSettings``. In
+  ``ReviewSettings``, collapsing every section of an accordion no longer
+  raises, and selecting a tab whose setting is not saved now actually marks
+  the tab as not saved. [#657]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,8 +68,10 @@ Other Changes and Additions
   through so a caller whose first interaction with the settings is a save
   still sees user-actionable problems (the ``ReviewSettings`` autosaves
   suppress that pass-through, since the widget already shows the warning
-  in its banner). A banner message whose underlying problem is no longer
-  reproduced by the latest reload is marked "No longer detected" instead
+  in its banner; warnings of any other category raised during an autosave
+  are re-emitted rather than swallowed). A banner message whose underlying
+  problem is no longer reproduced by the latest reload is reworded in the
+  past tense and marked "no longer detected" instead
   of continuing to read as a current problem, and dismissing a load-error
   message does not suppress a later, different load error. Note that
   ``ReviewSettings.current_settings`` is now a snapshot rather than a
@@ -117,7 +119,8 @@ Bug Fixes
   exist" when the existing full settings file could not be read. The
   ``full_settings_unreadable``/``partial_settings_unreadable`` properties
   are False before ``load`` has been called, instead of reporting an
-  existing readable file as unreadable. In
+  existing readable file as unreadable, and report the outcome of the most
+  recent ``load`` rather than the live state of the disk. In
   ``ReviewSettings``, collapsing every section of an accordion no longer
   raises, selecting a tab whose setting is not saved now actually marks
   the tab as not saved, and a tab badge stuck at not-saved now recovers

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,9 @@ Other Changes and Additions
   defaults. ``PhotometryWorkingDirSettings.save`` no longer overwrites or
   deletes a settings file whose contents could not be read, or a partial
   settings file whose values are not carried into the full settings being
-  written; such files are preserved with a ``.bak`` suffix instead, and
+  written (partial values the settings passed to ``save`` explicitly
+  replace are excluded -- replacing them was the point of the save); such
+  files are preserved with a ``.bak`` suffix instead, and
   existing ``.bak`` backups are never overwritten (numbered ``.bak1``,
   ``.bak2``... suffixes are used instead). Warnings raised while loading the
   settings are shown in the banner only when they are of the new

--- a/ignore-words.txt
+++ b/ignore-words.txt
@@ -2,3 +2,4 @@ TOI
 toi
 LIVETIME
 lightyear
+doesnt

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -23,6 +23,7 @@ from stellarphot.settings import (
     PartialPhotometrySettings,
     PassbandMap,
     PhotometryRunSettings,
+    PhotometrySettingsWarning,
     PhotometryWorkingDirSettings,
     SavedSettings,
 )
@@ -964,13 +965,14 @@ class ReviewSettings(ipw.VBox):
         current = []
         try:
             with warnings.catch_warnings(record=True) as recorded:
-                # Settings problems are reported as UserWarning; internal
-                # deprecation noise from pydantic/astropy on the load path
-                # should not reach a user-facing banner. A dedicated warning
-                # category may replace this when settings-migration work
-                # lands, see issue #656.
+                # Only PhotometrySettingsWarning -- the category for
+                # user-actionable problems with saved settings files -- is
+                # recorded for display. Plain UserWarnings from libraries on
+                # the load path (e.g. pydantic serializer warnings, astropy's
+                # AstropyUserWarning) deliberately stay out of the banner,
+                # along with deprecation and other internal noise.
                 warnings.simplefilter("ignore")
-                warnings.simplefilter("always", UserWarning)
+                warnings.simplefilter("always", PhotometrySettingsWarning)
                 loaded = wd_settings.load()
         except ValueError as e:
             # load() parses both files before raising, so whichever of these
@@ -1012,14 +1014,10 @@ class ReviewSettings(ipw.VBox):
 
                 # A file is unreadable, as opposed to merely conflicting with
                 # its counterpart, exactly when it exists on disk but load()
-                # left the corresponding in-memory attribute as None.
-                unreadable_full = (
-                    wd_settings.settings_file.exists() and wd_settings.settings is None
-                )
-                unreadable_partial = (
-                    wd_settings.partial_settings_file.exists()
-                    and wd_settings.partial_settings is None
-                )
+                # left the corresponding in-memory attribute as None -- which
+                # is what these properties report after the load() above.
+                unreadable_full = wd_settings.full_settings_unreadable
+                unreadable_partial = wd_settings.partial_settings_unreadable
                 if unreadable_full or unreadable_partial:
                     names = []
                     if unreadable_full:
@@ -1121,10 +1119,12 @@ class ReviewSettings(ipw.VBox):
         """
         Observer for the tab or accordion selection.
         """
-        # Once the user has clicked on the tab, the status badge for the
-        # tab should just be the badge for the widget it holds, if the
-        # widget has a badge. Otherwise, compare the widget value to the
-        # saved value to determine the badge.
+        # Once the user has clicked on the tab, the status badge for the tab
+        # should be the badge for the widget it holds when that badge reports
+        # a positive status. A badge of None or NOT_SAVED is instead
+        # re-derived by comparing the widget value to the saved value, so a
+        # badge latched at NOT_SAVED can recover when the setting gets saved
+        # by something other than this widget's own observers.
 
         # Get the index
         new_selected = change["new"]
@@ -1134,27 +1134,48 @@ class ReviewSettings(ipw.VBox):
         if new_selected is None:
             return
 
-        setting_badge = self._setting_widgets[new_selected].badge
-        if setting_badge is not None:
+        setting_widget = self._setting_widgets[new_selected]
+        setting_badge = setting_widget.badge
+
+        # A ChooseOrMakeNew that is making a new item or editing one manages
+        # its own badge through _choose_existing_observer; a disk comparison
+        # here would report the still-saved on-disk value as SAVED while the
+        # user is mid-edit, so trust its badge unconditionally.
+        chooser = setting_widget._widget
+        mid_interaction = isinstance(chooser, ChooseOrMakeNew) and (
+            chooser._making_new or chooser._editing
+        )
+        if setting_badge is not None and (
+            mid_interaction or setting_badge != SaveStatus.SETTING_NOT_SAVED
+        ):
             self.badges[new_selected] = setting_badge
         else:
-            # Check whether the setting is saved or not
-            setting_widget = self._setting_widgets[new_selected]
-
+            # A badge of None or NOT_SAVED is re-derived from disk rather
+            # than trusted, so a save made outside this widget's own
+            # observers (e.g. by another widget writing the settings file)
+            # is picked up.
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
-
             disk_value = getattr(self._refresh(), snake_name)
             if disk_value is None:
                 # The setting is not saved
                 setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
             else:
-                # Set the badge to saved if it has been saved.
-                value_from_widget = setting_widget._autoui_widget.model.model_validate(
-                    setting_widget._autoui_widget.value
-                )
-
-                if disk_value == value_from_widget:
-                    setting_widget.badge = SaveStatus.SETTING_IS_SAVED
+                try:
+                    value_from_widget = (
+                        setting_widget._autoui_widget.model.model_validate(
+                            setting_widget._autoui_widget.value
+                        )
+                    )
+                except ValidationError:
+                    # The widget holds an incomplete/invalid value; whatever
+                    # is on disk, it does not match what is displayed.
+                    setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
+                else:
+                    # A valid widget value that differs from disk deliberately
+                    # leaves the badge unchanged, as before this re-derivation
+                    # existed.
+                    if disk_value == value_from_widget:
+                        setting_widget.badge = SaveStatus.SETTING_IS_SAVED
 
         self._container.titles = self._make_titles()
 

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -843,7 +843,9 @@ class ReviewSettings(ipw.VBox):
                 widget = ui_generator(setting)
                 val_to_set = widget
 
-            _add_saving_to_widget(widget)
+            _add_saving_to_widget(
+                widget, warning_already_shown=self._banner_shows_warning
+            )
             name = to_snake(setting.__name__)
             plain_name = " ".join(name.split("_"))
             self._plain_names.append(plain_name)
@@ -1225,6 +1227,16 @@ class ReviewSettings(ipw.VBox):
             self._banner_html.value = ""
             self._banner.layout.display = "none"
 
+    def _banner_shows_warning(self, message):
+        """
+        True when a warning with this message text is displayed in the
+        banner, or was displayed and dismissed by the user. Used by the
+        autosave plumbing to decide whether a ``PhotometrySettingsWarning``
+        intercepted during a save has already been surfaced to the user.
+        """
+        key = html.escape(message)
+        return key in self._banner_messages or key in self._dismissed
+
     def _dismiss_banner(self, _=None):
         """
         Dismiss every message currently shown, hiding the banner. There is
@@ -1329,7 +1341,7 @@ class ReviewSettings(ipw.VBox):
         return observer
 
 
-def _add_saving_to_widget(setting_widget):
+def _add_saving_to_widget(setting_widget, warning_already_shown=None):
     """
     Add an observer to a widget that autosaves the settings for that widget to
     the working directory.
@@ -1338,7 +1350,20 @@ def _add_saving_to_widget(setting_widget):
     ----------
     setting_widget : ChooseOrMakeNew
         The widget to add the observer to.
+
+    warning_already_shown : callable, optional
+        Called with the message text of a `PhotometrySettingsWarning`
+        intercepted during an autosave; returns True when that warning is
+        already displayed to the user (e.g. in the
+        `~stellarphot.gui.ReviewSettings` banner), in which case the
+        warning is not re-emitted. By default no warning is considered
+        shown, so every intercepted warning is re-emitted.
     """
+    if warning_already_shown is None:
+
+        def warning_already_shown(_message):
+            return False
+
     wd_settings = PhotometryWorkingDirSettings()
 
     # Define name here so that it is available in the save_wd function. Its
@@ -1362,18 +1387,23 @@ def _add_saving_to_widget(setting_widget):
             # which always outranks a filter set by an outer caller.
             # Recording intercepts it regardless of nesting.
             wd_settings.save(pps, update=True)
-        # Recording swallows every warning raised during the save, but only
-        # PhotometrySettingsWarning is covered by the banner; anything else
-        # raised while saving (e.g. a serialization or file warning) still
-        # belongs to the caller, so re-emit it under the ambient filters.
+        # Recording swallows every warning raised during the save; re-emit
+        # everything under the ambient filters except a
+        # PhotometrySettingsWarning the user has already been shown. In
+        # particular, a PhotometrySettingsWarning raised on the save path
+        # -- which the banner never records, since it only collects
+        # warnings from its own loads -- is re-emitted, not silenced.
         for warning in recorded:
-            if not issubclass(warning.category, PhotometrySettingsWarning):
-                warnings.warn_explicit(
-                    warning.message,
-                    warning.category,
-                    warning.filename,
-                    warning.lineno,
-                )
+            if issubclass(
+                warning.category, PhotometrySettingsWarning
+            ) and warning_already_shown(str(warning.message)):
+                continue
+            warnings.warn_explicit(
+                warning.message,
+                warning.category,
+                warning.filename,
+                warning.lineno,
+            )
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -1,6 +1,7 @@
 # Some settings require custom widgets to be displayed in the GUI. These are defined in
 # this module.
 
+import warnings
 from enum import StrEnum
 
 import ipywidgets as ipw
@@ -761,15 +762,21 @@ class ReviewSettings(ipw.VBox):
     4. Creating a new one of those saveable settings also saves it to the working
        directory settings.
 
+    If the saved settings in the working directory cannot be read, or reading them
+    generates warnings, a banner describing the problem is displayed above the
+    settings.
     """
 
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        # Banner for messages about problems loading saved settings. It is
+        # hidden unless there is a message to show.
+        self._banner = ipw.HTML()
+        self._banner.layout.display = "none"
+        self._banner_messages = []
+
         # Get a copy of whatever settings may have already been saved.
-        try:
-            self._current_settings = PhotometryWorkingDirSettings().load()
-        except ValueError:
-            self._current_settings = PartialPhotometrySettings()
+        self._current_settings = self._load_working_dir_settings()
 
         self._setting_widgets = []
         self._plain_names = []
@@ -865,7 +872,7 @@ class ReviewSettings(ipw.VBox):
         self._container.children = self._setting_widgets
         self._container.titles = self._make_titles()
 
-        self.children = [self._container]
+        self.children = [self._banner, self._container]
 
         # Set up an observer to run when a tab is selected
         self._container.observe(self._observe_tab_selection, names="selected_index")
@@ -888,12 +895,54 @@ class ReviewSettings(ipw.VBox):
         """
         The current settings in the widget.
         """
-        try:
-            self._current_settings = PhotometryWorkingDirSettings().load()
-        except ValueError:
-            self._current_settings = PartialPhotometrySettings()
-
+        self._current_settings = self._load_working_dir_settings()
         return self._current_settings
+
+    def _load_working_dir_settings(self):
+        """
+        Load settings from the working directory, routing any warnings the load
+        generates, and any failure to read an existing settings file, into the
+        banner instead of silently discarding them.
+        """
+        wd_settings = PhotometryWorkingDirSettings()
+        messages = []
+        try:
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always")
+                loaded = wd_settings.load()
+            messages.extend(str(warning.message) for warning in recorded)
+        except ValueError as e:
+            loaded = PartialPhotometrySettings()
+            settings_file_exists = (
+                wd_settings.settings_file.exists()
+                or wd_settings.partial_settings_file.exists()
+            )
+            if settings_file_exists:
+                messages.append(
+                    "Unable to read the saved settings in this directory, so "
+                    f"none of the values below come from them. The error was: {e} "
+                    "To keep the old file, make a copy of it before saving any "
+                    "settings here."
+                )
+        self._banner_messages = messages
+        self._update_banner()
+        return loaded
+
+    def _update_banner(self):
+        """
+        Show the banner if there are messages, hide it if there are none.
+        """
+        if self._banner_messages:
+            content = "".join(f"<p>⚠️ {msg}</p>" for msg in self._banner_messages)
+            self._banner.value = (
+                "<div style='border: 2px solid #ffc107; border-radius: 4px; "
+                "background-color: #fff3cd; color: #664d03; "
+                f"padding: 0.25em 1em;'>{content}</div>"
+            )
+            self._banner.layout.display = "flex"
+        else:
+            self._banner.value = ""
+            self._banner.layout.display = "none"
 
     def _observe_tab_selection(self, change):
         """

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -782,7 +782,11 @@ class ReviewSettings(ipw.VBox):
         self._banner_dismiss.on_click(self._dismiss_banner)
         self._banner = ipw.HBox(
             [self._banner_html, self._banner_dismiss],
-            layout=ipw.Layout(align_items="center"),
+            layout=ipw.Layout(
+                align_items="center",
+                border="2px solid #ffc107",
+                padding="0.25em 1em",
+            ),
         )
         self._banner.layout.display = "none"
         self._banner_messages = []
@@ -960,11 +964,7 @@ class ReviewSettings(ipw.VBox):
         ]
         if messages:
             content = "".join(f"<p>⚠️ {msg}</p>" for msg in messages)
-            self._banner_html.value = (
-                "<div style='border: 2px solid #ffc107; border-radius: 4px; "
-                "background-color: #fff3cd; color: #664d03; "
-                f"padding: 0.25em 1em;'>{content}</div>"
-            )
+            self._banner_html.value = content
             self._banner.layout.display = "flex"
         else:
             self._banner_html.value = ""

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -770,10 +770,23 @@ class ReviewSettings(ipw.VBox):
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Banner for messages about problems loading saved settings. It is
-        # hidden unless there is a message to show.
-        self._banner = ipw.HTML()
+        # hidden unless there is a message to show, and can be dismissed
+        # with its close button. Dismissed messages stay dismissed even
+        # though the settings are reloaded on every tab selection.
+        self._banner_html = ipw.HTML(layout=ipw.Layout(flex="1 1 auto"))
+        self._banner_dismiss = ipw.Button(
+            description="✕",
+            tooltip="Dismiss this message",
+            layout=ipw.Layout(width="2.5em"),
+        )
+        self._banner_dismiss.on_click(self._dismiss_banner)
+        self._banner = ipw.HBox(
+            [self._banner_html, self._banner_dismiss],
+            layout=ipw.Layout(align_items="center"),
+        )
         self._banner.layout.display = "none"
         self._banner_messages = []
+        self._dismissed_messages = set()
 
         # Get a copy of whatever settings may have already been saved.
         self._current_settings = self._load_working_dir_settings()
@@ -918,31 +931,51 @@ class ReviewSettings(ipw.VBox):
                 or wd_settings.partial_settings_file.exists()
             )
             if settings_file_exists:
-                messages.append(
+                # The full error can run to dozens of lines for a pydantic
+                # ValidationError, so only its first line is shown; the rest
+                # goes into a collapsed details element.
+                error_lines = str(e).splitlines()
+                message = (
                     "Unable to read the saved settings in this directory, so "
-                    f"none of the values below come from them. The error was: {e} "
+                    f"none of the values below come from them ({error_lines[0]}). "
                     "To keep the old file, make a copy of it before saving any "
                     "settings here."
                 )
+                if detail := " ".join(error_lines[1:]):
+                    message += (
+                        f"<details><summary>Full error</summary>{detail}</details>"
+                    )
+                messages.append(message)
         self._banner_messages = messages
         self._update_banner()
         return loaded
 
     def _update_banner(self):
         """
-        Show the banner if there are messages, hide it if there are none.
+        Show the banner if there are messages that have not been dismissed,
+        hide it otherwise.
         """
-        if self._banner_messages:
-            content = "".join(f"<p>⚠️ {msg}</p>" for msg in self._banner_messages)
-            self._banner.value = (
+        messages = [
+            msg for msg in self._banner_messages if msg not in self._dismissed_messages
+        ]
+        if messages:
+            content = "".join(f"<p>⚠️ {msg}</p>" for msg in messages)
+            self._banner_html.value = (
                 "<div style='border: 2px solid #ffc107; border-radius: 4px; "
                 "background-color: #fff3cd; color: #664d03; "
                 f"padding: 0.25em 1em;'>{content}</div>"
             )
             self._banner.layout.display = "flex"
         else:
-            self._banner.value = ""
+            self._banner_html.value = ""
             self._banner.layout.display = "none"
+
+    def _dismiss_banner(self, _=None):
+        """
+        Hide the currently displayed messages until a new one arrives.
+        """
+        self._dismissed_messages.update(self._banner_messages)
+        self._update_banner()
 
     def _observe_tab_selection(self, change):
         """
@@ -955,6 +988,11 @@ class ReviewSettings(ipw.VBox):
 
         # Get the index
         new_selected = change["new"]
+
+        # An accordion reports a selection of None when every section is
+        # collapsed; there is nothing to update in that case.
+        if new_selected is None:
+            return
 
         setting_badge = self._setting_widgets[new_selected].badge
         if setting_badge is not None:

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -807,8 +807,10 @@ class ReviewSettings(ipw.VBox):
         )
         self._banner.layout.display = "none"
         # ``_banner_messages`` maps a stable key (``_LOAD_ERROR_KEY``, or a
-        # warning's own text) to the composed HTML shown for it; insertion
-        # order is display order. ``_banner_fingerprints`` maps that same
+        # warning's own text) to a pair of composed HTML variants: the
+        # active wording, and the past-tense wording used once the latest
+        # reload no longer reproduces the problem. Insertion order is
+        # display order. ``_banner_fingerprints`` maps that same
         # key to a fingerprint of the specific incident currently shown
         # under it, so a key being reused for a genuinely new incident can
         # be told apart from a reworded repeat of one already dismissed.
@@ -1039,6 +1041,16 @@ class ReviewSettings(ipw.VBox):
                     "There is a problem with the saved settings in this "
                     f"directory ({first_line})."
                 )
+                # Past-tense variant shown once a later refresh no longer
+                # reproduces the problem. It drops the claim about where the
+                # displayed values came from (stale by then) and reports the
+                # .bak rename as a possible outcome rather than a promise,
+                # since the cure may equally have been a hand-edit.
+                resolved_message = (
+                    "A problem with the saved settings in this directory "
+                    f"({first_line}) is no longer detected as of the "
+                    "latest reload."
+                )
                 # Report which file, if either, the displayed values came
                 # from. Both files are parsed before load() raises, so a
                 # non-None attribute here means that file really was read.
@@ -1052,9 +1064,8 @@ class ReviewSettings(ipw.VBox):
                     message += " None of the values below come from the saved settings."
 
                 # A file is unreadable, as opposed to merely conflicting with
-                # its counterpart, exactly when it exists on disk but load()
-                # left the corresponding in-memory attribute as None -- which
-                # is what these properties report after the load() above.
+                # its counterpart, exactly when it existed on disk but could
+                # not be parsed -- which load() records in these properties.
                 unreadable_full = wd_settings.full_settings_unreadable
                 unreadable_partial = wd_settings.partial_settings_unreadable
                 if unreadable_full or unreadable_partial:
@@ -1069,10 +1080,24 @@ class ReviewSettings(ipw.VBox):
                         joined_names = names[0]
                         joined_baks = f"{names[0]}.bak"
                         replace_clause = "if a save needs to replace it, it"
+                        resolved_clause = (
+                            f" If a save replaced {joined_names}, its "
+                            "original content was preserved as "
+                            f"{joined_baks} (or the next available numbered "
+                            "backup); it may instead have been fixed or "
+                            "removed outside this widget."
+                        )
                     else:
                         joined_names = " and ".join(names)
                         joined_baks = " and ".join(f"{name}.bak" for name in names)
                         replace_clause = "if a save needs to replace them, they"
+                        resolved_clause = (
+                            f" If a save replaced {joined_names}, their "
+                            "original content was preserved as "
+                            f"{joined_baks} (or the next available numbered "
+                            "backups); they may instead have been fixed or "
+                            "removed outside this widget."
+                        )
                     # The .bak rename happens only when a save actually
                     # replaces that specific file -- a partial-settings save
                     # leaves an unreadable full settings file in place -- so
@@ -1083,6 +1108,7 @@ class ReviewSettings(ipw.VBox):
                         f"preserved as {joined_baks} (or the next available "
                         "numbered backup if that name is already taken)."
                     )
+                    resolved_message += resolved_clause
                 else:
                     # Both files were readable. For a ValueError that means
                     # the conflicting-values case (the unreadable-file
@@ -1101,18 +1127,28 @@ class ReviewSettings(ipw.VBox):
                             f"will be preserved as {partial_name}.bak (or the "
                             "next available numbered backup)."
                         )
+                        resolved_message += (
+                            " If a save resolved the conflict, the "
+                            "conflicting partial settings file was preserved "
+                            f"as {partial_name}.bak (or the next available "
+                            "numbered backup)."
+                        )
 
                 if detail := "\n".join(error_lines[1:]):
-                    message += (
+                    details_html = (
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
+                    message += details_html
+                    resolved_message += details_html
                 # The fingerprint is the full error text, not the displayed
                 # first line: pydantic first lines are generic ("1 validation
                 # error for ..."), so two different corruptions of the same
                 # file can share one, and a dismissal must not carry over
                 # from one to the other.
-                current.append((_LOAD_ERROR_KEY, html.escape(str(e)), message))
+                current.append(
+                    (_LOAD_ERROR_KEY, html.escape(str(e)), message, resolved_message)
+                )
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
@@ -1120,9 +1156,17 @@ class ReviewSettings(ipw.VBox):
         # and its own fingerprint.
         for warning in recorded:
             warning_text = html.escape(str(warning.message))
-            current.append((warning_text, warning_text, warning_text))
+            current.append(
+                (
+                    warning_text,
+                    warning_text,
+                    warning_text,
+                    "<em>No longer detected as of the latest reload:</em> "
+                    f"{warning_text}",
+                )
+            )
 
-        current_keys = {key for key, _, _ in current}
+        current_keys = {key for key, *_ in current}
         # A dismissal is remembered only for as long as its key keeps being
         # produced, so it cannot grow without bound with stale entries; if a
         # problem goes away and later recurs, showing it again is correct.
@@ -1131,7 +1175,7 @@ class ReviewSettings(ipw.VBox):
             for key, fingerprint in self._dismissed.items()
             if key in current_keys
         }
-        for key, fingerprint, msg in current:
+        for key, fingerprint, msg, resolved_msg in current:
             dismissed_fingerprint = self._dismissed.get(key)
             if dismissed_fingerprint is not None:
                 if dismissed_fingerprint == fingerprint:
@@ -1142,7 +1186,7 @@ class ReviewSettings(ipw.VBox):
                 del self._dismissed[key]
             # Assignment updates an already-shown key in place instead of
             # appending a duplicate.
-            self._banner_messages[key] = msg
+            self._banner_messages[key] = (msg, resolved_msg)
             self._banner_fingerprints[key] = fingerprint
 
         # A sticky message whose key this refresh no longer produces is
@@ -1160,19 +1204,20 @@ class ReviewSettings(ipw.VBox):
         """
         Show the banner if there are any (sticky, un-dismissed) messages,
         hide it otherwise. A message whose key is in ``self._resolved_keys``
-        is marked as no longer detected instead of as an active problem.
+        is shown using its past-tense resolved variant instead of its
+        active wording, so the banner does not keep asserting a problem the
+        latest reload no longer reproduces.
         """
         if self._banner_messages:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
             content = "".join(
                 (
-                    "<div>✓ <em>No longer detected as of the latest "
-                    f"reload:</em> {msg}</div>"
+                    f"<div>✓ {resolved_msg}</div>"
                     if key in self._resolved_keys
                     else f"<div>⚠️ {msg}</div>"
                 )
-                for key, msg in self._banner_messages.items()
+                for key, (msg, resolved_msg) in self._banner_messages.items()
             )
             self._banner_html.value = content
             self._banner.layout.display = "flex"
@@ -1308,16 +1353,27 @@ def _add_saving_to_widget(setting_widget):
             # editing one
             return
         # We have a validated setting so save it.
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings(record=True) as recorded:
             # The widget already shows PhotometrySettingsWarning in its
             # banner via its own load, so save()'s bookkeeping load must not
             # also print it once per autosaved setting. A plain filter
             # cannot suppress it here: save()'s own nested catch_warnings
             # sets PhotometrySettingsWarning to "default" after this point,
             # which always outranks a filter set by an outer caller.
-            # Recording (and discarding) intercepts it regardless of
-            # nesting.
+            # Recording intercepts it regardless of nesting.
             wd_settings.save(pps, update=True)
+        # Recording swallows every warning raised during the save, but only
+        # PhotometrySettingsWarning is covered by the banner; anything else
+        # raised while saving (e.g. a serialization or file warning) still
+        # belongs to the caller, so re-emit it under the ambient filters.
+        for warning in recorded:
+            if not issubclass(warning.category, PhotometrySettingsWarning):
+                warnings.warn_explicit(
+                    warning.message,
+                    warning.category,
+                    warning.filename,
+                    warning.lineno,
+                )
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -790,7 +790,13 @@ class ReviewSettings(ipw.VBox):
             ),
         )
         self._banner.layout.display = "none"
-        self._banner_messages = []
+        # Maps a stable message key (the first line of a load error, or a
+        # warning's text) to the composed HTML shown for it; insertion order
+        # is display order. Keying on the stable part of the message lets a
+        # refresh that rewords the same underlying problem update its entry
+        # in place, and lets a dismissal survive the rewording.
+        # ``_dismissed_messages`` holds the keys of dismissed messages.
+        self._banner_messages = {}
         self._dismissed_messages = set()
 
         # Get a copy of whatever settings may have already been saved.
@@ -899,6 +905,14 @@ class ReviewSettings(ipw.VBox):
         for idx, widget in enumerate(self._setting_widgets):
             widget.observe(self._observe_badge_change(idx), names="badge")
 
+        # Construction itself may have changed what is on disk -- default-
+        # constructible settings were autosaved above, and setting a
+        # ChooseOrMakeNew value triggers its save observer -- so refresh
+        # once more so that current_settings (and the banner) reflect the
+        # post-construction state instead of the pre-save snapshot taken at
+        # the top of this method.
+        self._refresh()
+
     def _make_titles(self):
         """
         Make titles from badges and plain titles.
@@ -930,12 +944,21 @@ class ReviewSettings(ipw.VBox):
         generates, and any failure to read an existing settings file, into the
         banner instead of silently discarding them.
 
-        Banner messages are sticky: once shown, a message stays in
-        ``self._banner_messages`` until the user dismisses it, even if a later
-        refresh no longer produces it (e.g. an automatic save during widget
-        construction renames the offending file to ``.bak``, curing the
-        problem before the user ever saw the banner). Messages are never
-        removed here; only ``_dismiss_banner`` removes them.
+        Banner messages are keyed by the stable part of the message -- the
+        first line of the load error, or the warning text -- rather than by
+        the full composed text, because the sentences composed around that
+        stable part can change between refreshes for the same underlying
+        problem (e.g. an autosave during widget construction writes a
+        readable partial file, changing which fallback sentence applies).
+        When a refresh reproduces an already-shown key, its wording is
+        updated in place instead of a near-duplicate being appended.
+
+        Banner messages are also sticky: once shown, an entry stays in
+        ``self._banner_messages`` until the user dismisses it, even if a
+        later refresh no longer produces its key (e.g. an automatic save
+        during widget construction renames the offending file to ``.bak``,
+        curing the problem before the user ever saw the banner). Entries are
+        never removed here; only ``_dismiss_banner`` removes them.
         """
         wd_settings = PhotometryWorkingDirSettings()
         current = []
@@ -967,19 +990,23 @@ class ReviewSettings(ipw.VBox):
                 # ValidationError, so only its first line is shown; the rest
                 # goes into a collapsed details element.
                 error_lines = str(e).splitlines()
-                fallback_found = (
-                    wd_settings.settings is not None
-                    or wd_settings.partial_settings is not None
-                )
+                # The first line of the error is stable across refreshes even
+                # when the sentences composed around it change, so it serves
+                # as the identity key for this message.
+                message_key = html.escape(error_lines[0])
                 message = (
                     "There is a problem with the saved settings in this "
-                    f"directory ({html.escape(error_lines[0])})."
+                    f"directory ({message_key})."
                 )
-                if fallback_found:
-                    message += (
-                        " The values below come from the settings that "
-                        "could still be read."
-                    )
+                # Report which file, if either, the displayed values came
+                # from. Both files are parsed before load() raises, so a
+                # non-None attribute here means that file really was read.
+                # The full settings win when both were readable (the
+                # conflicting-values case below).
+                if wd_settings.settings is not None:
+                    message += " The values below come from the full settings file."
+                elif wd_settings.partial_settings is not None:
+                    message += " The values below come from the partial settings file."
                 else:
                     message += " None of the values below come from the saved settings."
 
@@ -1004,12 +1031,19 @@ class ReviewSettings(ipw.VBox):
                     if len(names) == 1:
                         joined_names = names[0]
                         joined_baks = f"{names[0]}.bak"
+                        replace_clause = "if a save needs to replace it, it"
                     else:
                         joined_names = " and ".join(names)
                         joined_baks = " and ".join(f"{name}.bak" for name in names)
+                        replace_clause = "if a save needs to replace them, they"
+                    # The .bak rename happens only when a save actually
+                    # replaces that specific file -- a partial-settings save
+                    # leaves an unreadable full settings file in place -- so
+                    # promise it only for a file a save needs to replace.
                     message += (
-                        f" If settings are saved here, {joined_names} will be "
-                        f"preserved as {joined_baks} rather than overwritten."
+                        f" If settings are saved here, {joined_names} will "
+                        f"not be overwritten; {replace_clause} will first be "
+                        f"preserved as {joined_baks}."
                     )
                 else:
                     # Both files were readable, so this is the conflicting-
@@ -1017,9 +1051,9 @@ class ReviewSettings(ipw.VBox):
                     # misleading here.
                     partial_name = html.escape(wd_settings.partial_settings_file.name)
                     message += (
-                        " If full settings are saved here, the conflicting "
-                        f"partial settings file will be preserved as "
-                        f"{partial_name}.bak."
+                        " Saving full settings here will resolve the "
+                        "conflict; the conflicting partial settings file "
+                        f"will be preserved as {partial_name}.bak."
                     )
 
                 if detail := "\n".join(error_lines[1:]):
@@ -1027,23 +1061,29 @@ class ReviewSettings(ipw.VBox):
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                current.append(message)
-        # Extend outside the try/except so warnings are reported even when
-        # load() raises after emitting them; ``recorded`` stays bound because
-        # catch_warnings exits normally during exception propagation.
-        current.extend(html.escape(str(warning.message)) for warning in recorded)
+                current.append((message_key, message))
+        # Add the warnings outside the try/except so they are reported even
+        # when load() raises after emitting them; ``recorded`` stays bound
+        # because catch_warnings exits normally during exception propagation.
+        # A warning's text is stable across refreshes, so it is its own key.
+        for warning in recorded:
+            warning_text = html.escape(str(warning.message))
+            current.append((warning_text, warning_text))
 
-        # Dismissal is remembered only for as long as a message keeps being
-        # produced. Prune it down to messages still in ``current`` so it
+        # Dismissal is remembered only for as long as a message's key keeps
+        # being produced. Prune it down to keys still in ``current`` so it
         # cannot grow without bound with stale entries; if a problem goes
         # away and later recurs, showing it again (undismissed) is correct.
-        self._dismissed_messages &= set(current)
-        for message in current:
-            if (
-                message not in self._banner_messages
-                and message not in self._dismissed_messages
-            ):
-                self._banner_messages.append(message)
+        self._dismissed_messages &= {key for key, _ in current}
+        for key, msg in current:
+            if key in self._dismissed_messages:
+                continue
+            # Assignment both adds a new message and updates the wording of
+            # an already-shown one in place (dict insertion order keeps its
+            # display position), so a reworded message never appears as a
+            # near-duplicate alongside its older self. Keys absent from
+            # ``current`` are deliberately left alone -- see the docstring.
+            self._banner_messages[key] = msg
         self._update_banner()
         return loaded
 
@@ -1055,7 +1095,9 @@ class ReviewSettings(ipw.VBox):
         if self._banner_messages:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
-            content = "".join(f"<div>⚠️ {msg}</div>" for msg in self._banner_messages)
+            content = "".join(
+                f"<div>⚠️ {msg}</div>" for msg in self._banner_messages.values()
+            )
             self._banner_html.value = content
             self._banner.layout.display = "flex"
         else:
@@ -1069,8 +1111,10 @@ class ReviewSettings(ipw.VBox):
         # Button.on_click invokes handlers with the button instance as the
         # only argument, which is unused here; the =None default lets the
         # method also be called directly with no argument.
+        # Iterating the messages dict yields its keys, which is exactly what
+        # the dismissed set stores.
         self._dismissed_messages.update(self._banner_messages)
-        self._banner_messages = []
+        self._banner_messages = {}
         self._update_banner()
 
     def _observe_tab_selection(self, change):

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -3,6 +3,7 @@
 
 import html
 import warnings
+from dataclasses import dataclass
 from enum import StrEnum
 
 import ipywidgets as ipw
@@ -757,6 +758,26 @@ class SettingWithTitle(ipw.VBox):
 _LOAD_ERROR_KEY = "__settings-load-error__"
 
 
+@dataclass
+class _BannerEntry:
+    """
+    One message shown in the `ReviewSettings` banner.
+    """
+
+    # Identifies the specific incident shown under a key: the load error's
+    # full escaped text, or a warning's own text. A key can outlive the
+    # incident that first produced it, so a dismissal is honored only while
+    # the fingerprint matches the one that was dismissed.
+    fingerprint: str
+    # Composed, already-escaped HTML for the message, in its active wording.
+    message: str
+    # True when the most recent refresh no longer reproduces the problem;
+    # the message is then shown with a "no longer detected" prefix instead
+    # of being removed, so the user still learns e.g. that a file was set
+    # aside as .bak.
+    resolved: bool = False
+
+
 class ReviewSettings(ipw.VBox):
     """
     Widget to preview the saved settings in the working directory. It displays one
@@ -806,22 +827,12 @@ class ReviewSettings(ipw.VBox):
             ),
         )
         self._banner.layout.display = "none"
-        # ``_banner_messages`` maps a stable key (``_LOAD_ERROR_KEY``, or a
-        # warning's own text) to a pair of composed HTML variants: the
-        # active wording, and the past-tense wording used once the latest
-        # reload no longer reproduces the problem. Insertion order is
-        # display order. ``_banner_fingerprints`` maps that same
-        # key to a fingerprint of the specific incident currently shown
-        # under it, so a key being reused for a genuinely new incident can
-        # be told apart from a reworded repeat of one already dismissed.
-        # ``_dismissed`` maps a dismissed key to the fingerprint it was
-        # dismissed at. ``_resolved_keys`` holds keys whose problem the most
-        # recent refresh no longer reproduces, but whose message is still
-        # shown -- see ``_update_banner``.
-        self._banner_messages = {}
-        self._banner_fingerprints = {}
+        # ``_banner_entries`` maps a stable key (``_LOAD_ERROR_KEY``, or a
+        # warning's own text) to a `_BannerEntry`; insertion order is
+        # display order. ``_dismissed`` maps a dismissed key to the
+        # fingerprint it was dismissed at.
+        self._banner_entries = {}
         self._dismissed = {}
-        self._resolved_keys = set()
 
         # Get a copy of whatever settings may have already been saved.
         self._refresh()
@@ -843,9 +854,7 @@ class ReviewSettings(ipw.VBox):
                 widget = ui_generator(setting)
                 val_to_set = widget
 
-            _add_saving_to_widget(
-                widget, warning_already_shown=self._banner_shows_warning
-            )
+            _add_saving_to_widget(widget)
             name = to_snake(setting.__name__)
             plain_name = " ".join(name.split("_"))
             self._plain_names.append(plain_name)
@@ -959,7 +968,7 @@ class ReviewSettings(ipw.VBox):
     def _refresh(self):
         """
         Reload the settings from the working directory, updating the banner
-        with any problems the load encounters, and return the result.
+        with any problems the load encounters.
 
         Note that the underlying load is not a pure read: it deletes a
         partial settings file that exactly duplicates the full settings
@@ -967,7 +976,6 @@ class ReviewSettings(ipw.VBox):
         effect.
         """
         self._current_settings = self._load_working_dir_settings()
-        return self._current_settings
 
     def _load_working_dir_settings(self):
         """
@@ -995,13 +1003,12 @@ class ReviewSettings(ipw.VBox):
         incident, which is shown normally.
 
         Banner messages are also sticky: once shown, an entry stays in
-        ``self._banner_messages`` until the user dismisses it, even if a
+        ``self._banner_entries`` until the user dismisses it, even if a
         later refresh no longer produces its key (e.g. an automatic save
         during widget construction renames the offending file to ``.bak``,
         curing the problem before the user ever saw the banner). Such
-        entries are marked in ``self._resolved_keys`` instead of being
-        removed; only ``_dismiss_banner`` removes entries from
-        ``self._banner_messages``.
+        entries are marked resolved instead of being removed -- see
+        ``_update_banner`` -- and only ``_dismiss_banner`` removes them.
         """
         wd_settings = PhotometryWorkingDirSettings()
         current = []
@@ -1043,16 +1050,6 @@ class ReviewSettings(ipw.VBox):
                     "There is a problem with the saved settings in this "
                     f"directory ({first_line})."
                 )
-                # Past-tense variant shown once a later refresh no longer
-                # reproduces the problem. It drops the claim about where the
-                # displayed values came from (stale by then) and reports the
-                # .bak rename as a possible outcome rather than a promise,
-                # since the cure may equally have been a hand-edit.
-                resolved_message = (
-                    "A problem with the saved settings in this directory "
-                    f"({first_line}) is no longer detected as of the "
-                    "latest reload."
-                )
                 # Report which file, if either, the displayed values came
                 # from. Both files are parsed before load() raises, so a
                 # non-None attribute here means that file really was read.
@@ -1078,28 +1075,13 @@ class ReviewSettings(ipw.VBox):
                         names.append(
                             html.escape(wd_settings.partial_settings_file.name)
                         )
-                    if len(names) == 1:
-                        joined_names = names[0]
-                        joined_baks = f"{names[0]}.bak"
-                        replace_clause = "if a save needs to replace it, it"
-                        resolved_clause = (
-                            f" If a save replaced {joined_names}, its "
-                            "original content was preserved as "
-                            f"{joined_baks} (or the next available numbered "
-                            "backup); it may instead have been fixed or "
-                            "removed outside this widget."
-                        )
-                    else:
-                        joined_names = " and ".join(names)
-                        joined_baks = " and ".join(f"{name}.bak" for name in names)
-                        replace_clause = "if a save needs to replace them, they"
-                        resolved_clause = (
-                            f" If a save replaced {joined_names}, their "
-                            "original content was preserved as "
-                            f"{joined_baks} (or the next available numbered "
-                            "backups); they may instead have been fixed or "
-                            "removed outside this widget."
-                        )
+                    joined_names = " and ".join(names)
+                    joined_baks = " and ".join(f"{name}.bak" for name in names)
+                    replace_clause = (
+                        "if a save needs to replace them, they"
+                        if len(names) > 1
+                        else "if a save needs to replace it, it"
+                    )
                     # The .bak rename happens only when a save actually
                     # replaces that specific file -- a partial-settings save
                     # leaves an unreadable full settings file in place -- so
@@ -1110,7 +1092,6 @@ class ReviewSettings(ipw.VBox):
                         f"preserved as {joined_baks} (or the next available "
                         "numbered backup if that name is already taken)."
                     )
-                    resolved_message += resolved_clause
                 else:
                     # Both files were readable. For a ValueError that means
                     # the conflicting-values case (the unreadable-file
@@ -1129,28 +1110,18 @@ class ReviewSettings(ipw.VBox):
                             f"will be preserved as {partial_name}.bak (or the "
                             "next available numbered backup)."
                         )
-                        resolved_message += (
-                            " If a save resolved the conflict, the "
-                            "conflicting partial settings file was preserved "
-                            f"as {partial_name}.bak (or the next available "
-                            "numbered backup)."
-                        )
 
                 if detail := "\n".join(error_lines[1:]):
-                    details_html = (
+                    message += (
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                    message += details_html
-                    resolved_message += details_html
                 # The fingerprint is the full error text, not the displayed
                 # first line: pydantic first lines are generic ("1 validation
                 # error for ..."), so two different corruptions of the same
                 # file can share one, and a dismissal must not carry over
                 # from one to the other.
-                current.append(
-                    (_LOAD_ERROR_KEY, html.escape(str(e)), message, resolved_message)
-                )
+                current.append((_LOAD_ERROR_KEY, html.escape(str(e)), message))
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
@@ -1158,15 +1129,7 @@ class ReviewSettings(ipw.VBox):
         # and its own fingerprint.
         for warning in recorded:
             warning_text = html.escape(str(warning.message))
-            current.append(
-                (
-                    warning_text,
-                    warning_text,
-                    warning_text,
-                    "<em>No longer detected as of the latest reload:</em> "
-                    f"{warning_text}",
-                )
-            )
+            current.append((warning_text, warning_text, warning_text))
 
         current_keys = {key for key, *_ in current}
         # A dismissal is remembered only for as long as its key keeps being
@@ -1177,7 +1140,7 @@ class ReviewSettings(ipw.VBox):
             for key, fingerprint in self._dismissed.items()
             if key in current_keys
         }
-        for key, fingerprint, msg, resolved_msg in current:
+        for key, fingerprint, msg in current:
             dismissed_fingerprint = self._dismissed.get(key)
             if dismissed_fingerprint is not None:
                 if dismissed_fingerprint == fingerprint:
@@ -1188,16 +1151,15 @@ class ReviewSettings(ipw.VBox):
                 del self._dismissed[key]
             # Assignment updates an already-shown key in place instead of
             # appending a duplicate.
-            self._banner_messages[key] = (msg, resolved_msg)
-            self._banner_fingerprints[key] = fingerprint
+            self._banner_entries[key] = _BannerEntry(
+                fingerprint=fingerprint, message=msg
+            )
 
-        # A sticky message whose key this refresh no longer produces is
-        # marked resolved rather than removed; a recurrence un-resolves it.
-        for key in self._banner_messages:
-            if key in current_keys:
-                self._resolved_keys.discard(key)
-            else:
-                self._resolved_keys.add(key)
+        # A sticky entry whose key this refresh no longer produces is marked
+        # resolved rather than removed; a recurrence un-resolves it (the
+        # assignment above recreates the entry with resolved=False).
+        for key, entry in self._banner_entries.items():
+            entry.resolved = key not in current_keys
 
         self._update_banner()
         return loaded
@@ -1205,37 +1167,29 @@ class ReviewSettings(ipw.VBox):
     def _update_banner(self):
         """
         Show the banner if there are any (sticky, un-dismissed) messages,
-        hide it otherwise. A message whose key is in ``self._resolved_keys``
-        is shown using its past-tense resolved variant instead of its
-        active wording, so the banner does not keep asserting a problem the
-        latest reload no longer reproduces.
+        hide it otherwise. A resolved message -- one whose problem the
+        latest reload no longer reproduces -- is shown with a "no longer
+        detected" prefix, so the banner does not keep asserting a stale
+        problem while the user still learns e.g. that a file was set aside
+        as ``.bak``.
         """
-        if self._banner_messages:
+        if self._banner_entries:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
             content = "".join(
                 (
-                    f"<div>✓ {resolved_msg}</div>"
-                    if key in self._resolved_keys
-                    else f"<div>⚠️ {msg}</div>"
+                    "<div>✓ <em>No longer detected as of the latest "
+                    f"reload:</em> {entry.message}</div>"
+                    if entry.resolved
+                    else f"<div>⚠️ {entry.message}</div>"
                 )
-                for key, (msg, resolved_msg) in self._banner_messages.items()
+                for entry in self._banner_entries.values()
             )
             self._banner_html.value = content
             self._banner.layout.display = "flex"
         else:
             self._banner_html.value = ""
             self._banner.layout.display = "none"
-
-    def _banner_shows_warning(self, message):
-        """
-        True when a warning with this message text is displayed in the
-        banner, or was displayed and dismissed by the user. Used by the
-        autosave plumbing to decide whether a ``PhotometrySettingsWarning``
-        intercepted during a save has already been surfaced to the user.
-        """
-        key = html.escape(message)
-        return key in self._banner_messages or key in self._dismissed
 
     def _dismiss_banner(self, _=None):
         """
@@ -1244,11 +1198,9 @@ class ReviewSettings(ipw.VBox):
         messages at once, including any that arrived after the one the
         user meant to dismiss.
         """
-        for key in self._banner_messages:
-            self._dismissed[key] = self._banner_fingerprints.get(key, key)
-        self._banner_messages = {}
-        self._banner_fingerprints = {}
-        self._resolved_keys = set()
+        for key, entry in self._banner_entries.items():
+            self._dismissed[key] = entry.fingerprint
+        self._banner_entries = {}
         self._update_banner()
 
     def _observe_tab_selection(self, change):
@@ -1347,7 +1299,7 @@ class ReviewSettings(ipw.VBox):
         return observer
 
 
-def _add_saving_to_widget(setting_widget, warning_already_shown=None):
+def _add_saving_to_widget(setting_widget):
     """
     Add an observer to a widget that autosaves the settings for that widget to
     the working directory.
@@ -1356,20 +1308,7 @@ def _add_saving_to_widget(setting_widget, warning_already_shown=None):
     ----------
     setting_widget : ChooseOrMakeNew
         The widget to add the observer to.
-
-    warning_already_shown : callable, optional
-        Called with the message text of a `PhotometrySettingsWarning`
-        intercepted during an autosave; returns True when that warning is
-        already displayed to the user (e.g. in the
-        `~stellarphot.gui.ReviewSettings` banner), in which case the
-        warning is not re-emitted. By default no warning is considered
-        shown, so every intercepted warning is re-emitted.
     """
-    if warning_already_shown is None:
-
-        def warning_already_shown(_message):
-            return False
-
     wd_settings = PhotometryWorkingDirSettings()
 
     # Define name here so that it is available in the save_wd function. Its
@@ -1383,33 +1322,15 @@ def _add_saving_to_widget(setting_widget, warning_already_shown=None):
             # This can happen while making a new item, or while in the process of
             # editing one
             return
-        # We have a validated setting so save it.
-        with warnings.catch_warnings(record=True) as recorded:
-            # The widget already shows PhotometrySettingsWarning in its
-            # banner via its own load, so save()'s bookkeeping load must not
-            # also print it once per autosaved setting. A plain filter
-            # cannot suppress it here: save()'s own nested catch_warnings
-            # sets PhotometrySettingsWarning to "default" after this point,
-            # which always outranks a filter set by an outer caller.
-            # Recording intercepts it regardless of nesting.
+        # We have a validated setting so save it. The ReviewSettings banner
+        # is the display channel for PhotometrySettingsWarning, and these
+        # autosaves fire once per setting, so the warning save() re-emits
+        # from its bookkeeping load is silenced here rather than printed
+        # once per autosaved setting. Other warning categories are
+        # unaffected.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PhotometrySettingsWarning)
             wd_settings.save(pps, update=True)
-        # Recording swallows every warning raised during the save; re-emit
-        # everything under the ambient filters except a
-        # PhotometrySettingsWarning the user has already been shown. In
-        # particular, a PhotometrySettingsWarning raised on the save path
-        # -- which the banner never records, since it only collects
-        # warnings from its own loads -- is re-emitted, not silenced.
-        for warning in recorded:
-            if issubclass(
-                warning.category, PhotometrySettingsWarning
-            ) and warning_already_shown(str(warning.message)):
-                continue
-            warnings.warn_explicit(
-                warning.message,
-                warning.category,
-                warning.filename,
-                warning.lineno,
-            )
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -1257,10 +1257,12 @@ class ReviewSettings(ipw.VBox):
         """
         # Once the user has clicked on the tab, the status badge for the tab
         # should be the badge for the widget it holds when that badge reports
-        # a positive status. A badge of None or NOT_SAVED is instead
-        # re-derived by comparing the widget value to the saved value, so a
-        # badge latched at NOT_SAVED can recover when the setting gets saved
-        # by something other than this widget's own observers.
+        # a positive status and the setting still exists on disk. A badge of
+        # None or NOT_SAVED is instead re-derived by comparing the widget
+        # value to the saved value, so a badge latched at NOT_SAVED can
+        # recover when the setting gets saved by something other than this
+        # widget's own observers -- and a positive badge whose setting has
+        # disappeared from disk drops back to NOT_SAVED.
 
         new_selected = change["new"]
 
@@ -1293,20 +1295,24 @@ class ReviewSettings(ipw.VBox):
             # its badge on the next value change anyway.
             if setting_badge is not None:
                 self.badges[new_selected] = setting_badge
-        elif setting_badge is not None and (
-            setting_badge != SaveStatus.SETTING_NOT_SAVED
-        ):
-            self.badges[new_selected] = setting_badge
         else:
-            # A badge of None or NOT_SAVED is re-derived from the snapshot
-            # refreshed above rather than trusted, so a save made outside
-            # this widget's own observers (e.g. by another widget writing
-            # the settings file) is picked up.
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
             disk_value = getattr(self.current_settings, snake_name)
             if disk_value is None:
+                # No saved value on disk: even a positive badge is stale
+                # here (e.g. the settings file was deleted outside this
+                # widget) -- the mirror image of the latched-NOT_SAVED
+                # recovery below.
                 setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
+            elif setting_badge is not None and (
+                setting_badge != SaveStatus.SETTING_NOT_SAVED
+            ):
+                self.badges[new_selected] = setting_badge
             else:
+                # A badge of None or NOT_SAVED is re-derived from the
+                # snapshot refreshed above rather than trusted, so a save
+                # made outside this widget's own observers (e.g. by another
+                # widget writing the settings file) is picked up.
                 try:
                     value_from_widget = (
                         setting_widget._autoui_widget.model.model_validate(

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -929,9 +929,16 @@ class ReviewSettings(ipw.VBox):
         Load settings from the working directory, routing any warnings the load
         generates, and any failure to read an existing settings file, into the
         banner instead of silently discarding them.
+
+        Banner messages are sticky: once shown, a message stays in
+        ``self._banner_messages`` until the user dismisses it, even if a later
+        refresh no longer produces it (e.g. an automatic save during widget
+        construction renames the offending file to ``.bak``, curing the
+        problem before the user ever saw the banner). Messages are never
+        removed here; only ``_dismiss_banner`` removes them.
         """
         wd_settings = PhotometryWorkingDirSettings()
-        messages = []
+        current = []
         try:
             with warnings.catch_warnings(record=True) as recorded:
                 # Settings problems are reported as UserWarning; internal
@@ -943,7 +950,14 @@ class ReviewSettings(ipw.VBox):
                 warnings.simplefilter("always", UserWarning)
                 loaded = wd_settings.load()
         except ValueError as e:
-            loaded = PartialPhotometrySettings()
+            # load() parses both files before raising, so whichever of these
+            # is not None was actually readable and can be used as a
+            # fallback instead of falling all the way back to empty settings.
+            loaded = (
+                wd_settings.settings
+                or wd_settings.partial_settings
+                or PartialPhotometrySettings()
+            )
             settings_file_exists = (
                 wd_settings.settings_file.exists()
                 or wd_settings.partial_settings_file.exists()
@@ -953,40 +967,95 @@ class ReviewSettings(ipw.VBox):
                 # ValidationError, so only its first line is shown; the rest
                 # goes into a collapsed details element.
                 error_lines = str(e).splitlines()
+                fallback_found = (
+                    wd_settings.settings is not None
+                    or wd_settings.partial_settings is not None
+                )
                 message = (
                     "There is a problem with the saved settings in this "
-                    "directory, so none of the values below come from them "
-                    f"({html.escape(error_lines[0])}). "
-                    "If saving settings here would overwrite a file that "
-                    "could not be read, that file is renamed with a .bak "
-                    "extension first."
+                    f"directory ({html.escape(error_lines[0])})."
                 )
+                if fallback_found:
+                    message += (
+                        " The values below come from the settings that "
+                        "could still be read."
+                    )
+                else:
+                    message += " None of the values below come from the saved settings."
+
+                # A file is unreadable, as opposed to merely conflicting with
+                # its counterpart, exactly when it exists on disk but load()
+                # left the corresponding in-memory attribute as None.
+                unreadable_full = (
+                    wd_settings.settings_file.exists() and wd_settings.settings is None
+                )
+                unreadable_partial = (
+                    wd_settings.partial_settings_file.exists()
+                    and wd_settings.partial_settings is None
+                )
+                if unreadable_full or unreadable_partial:
+                    names = []
+                    if unreadable_full:
+                        names.append(html.escape(wd_settings.settings_file.name))
+                    if unreadable_partial:
+                        names.append(
+                            html.escape(wd_settings.partial_settings_file.name)
+                        )
+                    if len(names) == 1:
+                        joined_names = names[0]
+                        joined_baks = f"{names[0]}.bak"
+                    else:
+                        joined_names = " and ".join(names)
+                        joined_baks = " and ".join(f"{name}.bak" for name in names)
+                    message += (
+                        f" If settings are saved here, {joined_names} will be "
+                        f"preserved as {joined_baks} rather than overwritten."
+                    )
+                else:
+                    # Both files were readable, so this is the conflicting-
+                    # values case; the unreadable-file wording above would be
+                    # misleading here.
+                    partial_name = html.escape(wd_settings.partial_settings_file.name)
+                    message += (
+                        " If full settings are saved here, the conflicting "
+                        f"partial settings file will be preserved as "
+                        f"{partial_name}.bak."
+                    )
+
                 if detail := "\n".join(error_lines[1:]):
                     message += (
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                messages.append(message)
+                current.append(message)
         # Extend outside the try/except so warnings are reported even when
         # load() raises after emitting them; ``recorded`` stays bound because
         # catch_warnings exits normally during exception propagation.
-        messages.extend(html.escape(str(warning.message)) for warning in recorded)
-        self._banner_messages = messages
+        current.extend(html.escape(str(warning.message)) for warning in recorded)
+
+        # Dismissal is remembered only for as long as a message keeps being
+        # produced. Prune it down to messages still in ``current`` so it
+        # cannot grow without bound with stale entries; if a problem goes
+        # away and later recurs, showing it again (undismissed) is correct.
+        self._dismissed_messages &= set(current)
+        for message in current:
+            if (
+                message not in self._banner_messages
+                and message not in self._dismissed_messages
+            ):
+                self._banner_messages.append(message)
         self._update_banner()
         return loaded
 
     def _update_banner(self):
         """
-        Show the banner if there are messages that have not been dismissed,
+        Show the banner if there are any (sticky, un-dismissed) messages,
         hide it otherwise.
         """
-        messages = [
-            msg for msg in self._banner_messages if msg not in self._dismissed_messages
-        ]
-        if messages:
+        if self._banner_messages:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
-            content = "".join(f"<div>⚠️ {msg}</div>" for msg in messages)
+            content = "".join(f"<div>⚠️ {msg}</div>" for msg in self._banner_messages)
             self._banner_html.value = content
             self._banner.layout.display = "flex"
         else:
@@ -1001,6 +1070,7 @@ class ReviewSettings(ipw.VBox):
         # only argument, which is unused here; the =None default lets the
         # method also be called directly with no argument.
         self._dismissed_messages.update(self._banner_messages)
+        self._banner_messages = []
         self._update_banner()
 
     def _observe_tab_selection(self, change):

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -863,9 +863,10 @@ class ReviewSettings(ipw.VBox):
     settings. While a load error is active -- which, since construction and
     every save cure such problems automatically, means the settings files
     changed outside this widget -- the settings below the banner are greyed
-    out and the banner's buttons are the only way forward; once the problem
-    is resolved (or when there are only warnings) the banner turns a calm
-    green and can be dismissed with its close button.
+    out and the banner's buttons are the only way forward, though the tabs
+    can still be browsed to inspect the values those buttons would save;
+    once the problem is resolved (or when there are only warnings) the
+    banner turns a calm green and can be dismissed with its close button.
     """
 
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
@@ -1389,10 +1390,11 @@ class ReviewSettings(ipw.VBox):
         While a load error is active -- which, since construction and every
         save cure such problems automatically, means the settings changed
         outside this widget -- the banner is modal: the settings below are
-        greyed out and inert, the dismiss button is hidden, and the
-        banner's own buttons (which of them depends on the kind of error)
-        are the only affordance. Once every entry is resolved, or when only
-        warnings remain, the banner turns a calm green and is dismissable.
+        greyed out and inert (though the tabs stay navigable for
+        inspection), the dismiss button is hidden, and the banner's own
+        buttons (which of them depends on the kind of error) are the only
+        affordance. Once every entry is resolved, or when only warnings
+        remain, the banner turns a calm green and is dismissable.
 
         A resolved message -- one whose problem the latest reload no longer
         reproduces -- is kept visible in a resolved wording, so the banner
@@ -1428,15 +1430,26 @@ class ReviewSettings(ipw.VBox):
         self._banner_reload.layout.display = "" if error_active else "none"
         self._banner_dismiss.layout.display = "none" if error_active else ""
 
-        # Grey out and disable the settings while an error is active. The
-        # container does not exist yet during the refresh at the top of
-        # __init__; the refresh at the end of construction re-runs this.
+        # The settings file name is per-instance, so the keep button's
+        # label can only name the conflict's winning file here, once the
+        # loading instance exists.
+        if active_kind == "conflict":
+            self._banner_keep.description = (
+                f"Keep the values from {self._wd_settings.settings_file.name}"
+            )
+
+        # Grey out and disable the settings panes while an error is
+        # active, leaving the tab bar (or accordion titles) live so the
+        # user can browse the values the banner's buttons offer to save.
+        # The container does not exist yet during the refresh at the top
+        # of __init__; the refresh at the end of construction re-runs this.
         container = getattr(self, "_container", None)
         if container is not None:
-            if error_active:
-                container.add_class(_INERT_CLASS)
-            else:
-                container.remove_class(_INERT_CLASS)
+            for pane in container.children:
+                if error_active:
+                    pane.add_class(_INERT_CLASS)
+                else:
+                    pane.remove_class(_INERT_CLASS)
 
     def _dismiss_banner(self, _=None):
         """
@@ -1621,10 +1634,10 @@ class ReviewSettings(ipw.VBox):
 
         # While a load error is active, the on-disk state is broken rather
         # than missing: the banner is the sole indicator of that, and the
-        # settings below it are greyed out. Badges are never re-derived
-        # from the broken (fallback) snapshot. The CSS inertness is an
-        # affordance only -- programmatic selection bypasses it -- so this
-        # early return is the real guard.
+        # settings below it are greyed out, though the tabs themselves stay
+        # navigable so the user can inspect the values the banner offers to
+        # save. Badges are never re-derived from the broken (fallback)
+        # snapshot, so this early return is the real guard.
         if self._load_error_active:
             return
 

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -1,6 +1,7 @@
 # Some settings require custom widgets to be displayed in the GUI. These are defined in
 # this module.
 
+import html
 import warnings
 from enum import StrEnum
 
@@ -793,7 +794,7 @@ class ReviewSettings(ipw.VBox):
         self._dismissed_messages = set()
 
         # Get a copy of whatever settings may have already been saved.
-        self._current_settings = self._load_working_dir_settings()
+        self._refresh()
 
         self._setting_widgets = []
         self._plain_names = []
@@ -910,7 +911,15 @@ class ReviewSettings(ipw.VBox):
     @property
     def current_settings(self):
         """
-        The current settings in the widget.
+        The settings as of the last refresh; a snapshot rather than a live
+        read from disk.
+        """
+        return self._current_settings
+
+    def _refresh(self):
+        """
+        Reload the settings from the working directory, updating the banner
+        with any problems the load encounters, and return the result.
         """
         self._current_settings = self._load_working_dir_settings()
         return self._current_settings
@@ -925,9 +934,14 @@ class ReviewSettings(ipw.VBox):
         messages = []
         try:
             with warnings.catch_warnings(record=True) as recorded:
-                warnings.simplefilter("always")
+                # Settings problems are reported as UserWarning; internal
+                # deprecation noise from pydantic/astropy on the load path
+                # should not reach a user-facing banner. A dedicated warning
+                # category may replace this when settings-migration work
+                # lands, see issue #656.
+                warnings.simplefilter("ignore")
+                warnings.simplefilter("always", UserWarning)
                 loaded = wd_settings.load()
-            messages.extend(str(warning.message) for warning in recorded)
         except ValueError as e:
             loaded = PartialPhotometrySettings()
             settings_file_exists = (
@@ -941,15 +955,21 @@ class ReviewSettings(ipw.VBox):
                 error_lines = str(e).splitlines()
                 message = (
                     "Unable to read the saved settings in this directory, so "
-                    f"none of the values below come from them ({error_lines[0]}). "
-                    "To keep the old file, make a copy of it before saving any "
-                    "settings here."
+                    "none of the values below come from them "
+                    f"({html.escape(error_lines[0])}). "
+                    "When settings are saved here, the unreadable file is "
+                    "renamed with a .bak extension rather than overwritten."
                 )
-                if detail := " ".join(error_lines[1:]):
+                if detail := "\n".join(error_lines[1:]):
                     message += (
-                        f"<details><summary>Full error</summary>{detail}</details>"
+                        "<details><summary>Full error</summary>"
+                        f"<pre>{html.escape(detail)}</pre></details>"
                     )
                 messages.append(message)
+        # Extend outside the try/except so warnings are reported even when
+        # load() raises after emitting them; ``recorded`` stays bound because
+        # catch_warnings exits normally during exception propagation.
+        messages.extend(html.escape(str(warning.message)) for warning in recorded)
         self._banner_messages = messages
         self._update_banner()
         return loaded
@@ -963,7 +983,9 @@ class ReviewSettings(ipw.VBox):
             msg for msg in self._banner_messages if msg not in self._dismissed_messages
         ]
         if messages:
-            content = "".join(f"<p>⚠️ {msg}</p>" for msg in messages)
+            # A div rather than a p because a message may contain a details
+            # element, which is not allowed inside a p.
+            content = "".join(f"<div>⚠️ {msg}</div>" for msg in messages)
             self._banner_html.value = content
             self._banner.layout.display = "flex"
         else:
@@ -974,6 +996,9 @@ class ReviewSettings(ipw.VBox):
         """
         Hide the currently displayed messages until a new one arrives.
         """
+        # Button.on_click invokes handlers with the button instance as the
+        # only argument, which is unused here; the =None default lets the
+        # method also be called directly with no argument.
         self._dismissed_messages.update(self._banner_messages)
         self._update_banner()
 
@@ -1003,7 +1028,7 @@ class ReviewSettings(ipw.VBox):
 
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
 
-            disk_value = getattr(self.current_settings, snake_name)
+            disk_value = getattr(self._refresh(), snake_name)
             if disk_value is None:
                 # The setting is not saved
                 setting_widget = SaveStatus.SETTING_NOT_SAVED

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -85,7 +85,7 @@ class ChooseOrMakeNew(ipw.VBox):
 
         # Descriptive title
         self._title = ipw.HTML(
-            value=(f"Choose a {self._display_name} " "or make a new one")
+            value=(f"Choose a {self._display_name} or make a new one")
         )
 
         self._choose_detail_container = ipw.HBox(layout={"width": DEFAULT_BUTTON_WIDTH})
@@ -742,12 +742,10 @@ class SettingWithTitle(ipw.VBox):
             self.badge = SaveStatus.SETTING_IS_SAVED
 
 
-# Identity key for the single load-error banner message. A fixed key --
-# rather than one derived from the error text -- lets a refresh that
-# raises a different error for the same incident (e.g. an autosave cured
-# one of two unreadable files) update the message in place instead of
-# appending a near-duplicate. Deliberately not plausible warning text,
-# since warning messages are their own keys in the same dict.
+# Fixed identity key for the (at most one) load-error banner message, so
+# that a refresh which reworks the message for the same incident updates it
+# in place rather than appending a near-duplicate. Not plausible warning
+# text, since a warning is keyed on its own text in the same dict.
 _LOAD_ERROR_KEY = "__settings-load-error__"
 
 
@@ -800,16 +798,20 @@ class ReviewSettings(ipw.VBox):
             ),
         )
         self._banner.layout.display = "none"
-        # Maps a stable message key (``_LOAD_ERROR_KEY`` for the (at most
-        # one) load-error message, or a warning's own text) to the composed
-        # HTML shown for it; insertion order is display order. The load
-        # error uses a fixed key, rather than one derived from the error
-        # text, so a refresh that raises a differently-worded error for the
-        # same incident updates the entry in place instead of appending a
-        # near-duplicate, and so a dismissal survives the rewording.
-        # ``_dismissed_messages`` holds the keys of dismissed messages.
+        # ``_banner_messages`` maps a stable key (``_LOAD_ERROR_KEY``, or a
+        # warning's own text) to the composed HTML shown for it; insertion
+        # order is display order. ``_banner_fingerprints`` maps that same
+        # key to a fingerprint of the specific incident currently shown
+        # under it, so a key being reused for a genuinely new incident can
+        # be told apart from a reworded repeat of one already dismissed.
+        # ``_dismissed`` maps a dismissed key to the fingerprint it was
+        # dismissed at. ``_resolved_keys`` holds keys whose problem the most
+        # recent refresh no longer reproduces, but whose message is still
+        # shown -- see ``_update_banner``.
         self._banner_messages = {}
-        self._dismissed_messages = set()
+        self._banner_fingerprints = {}
+        self._dismissed = {}
+        self._resolved_keys = set()
 
         # Get a copy of whatever settings may have already been saved.
         self._refresh()
@@ -973,12 +975,21 @@ class ReviewSettings(ipw.VBox):
         reproduces an already-shown key, its wording is updated in place
         instead of a near-duplicate being appended.
 
+        Because a key can outlive the incident it first named, each entry in
+        ``current`` also carries a fingerprint (the load error's escaped
+        first line, or a warning's own text). A dismissed key stays
+        dismissed only while its fingerprint matches what was dismissed; a
+        different fingerprint under the same key means a new, unrelated
+        incident, which is shown normally.
+
         Banner messages are also sticky: once shown, an entry stays in
         ``self._banner_messages`` until the user dismisses it, even if a
         later refresh no longer produces its key (e.g. an automatic save
         during widget construction renames the offending file to ``.bak``,
-        curing the problem before the user ever saw the banner). Entries are
-        never removed here; only ``_dismiss_banner`` removes them.
+        curing the problem before the user ever saw the banner). Such
+        entries are marked in ``self._resolved_keys`` instead of being
+        removed; only ``_dismiss_banner`` removes entries from
+        ``self._banner_messages``.
         """
         wd_settings = PhotometryWorkingDirSettings()
         current = []
@@ -1057,7 +1068,8 @@ class ReviewSettings(ipw.VBox):
                     message += (
                         f" If settings are saved here, {joined_names} will "
                         f"not be overwritten; {replace_clause} will first be "
-                        f"preserved as {joined_baks}."
+                        f"preserved as {joined_baks} (or the next available "
+                        "numbered backup if that name is already taken)."
                     )
                 else:
                     # Both files were readable, so this is the conflicting-
@@ -1067,7 +1079,8 @@ class ReviewSettings(ipw.VBox):
                     message += (
                         " Saving full settings here will resolve the "
                         "conflict; the conflicting partial settings file "
-                        f"will be preserved as {partial_name}.bak."
+                        f"will be preserved as {partial_name}.bak (or the "
+                        "next available numbered backup)."
                     )
 
                 if detail := "\n".join(error_lines[1:]):
@@ -1075,42 +1088,67 @@ class ReviewSettings(ipw.VBox):
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                current.append((_LOAD_ERROR_KEY, message))
+                current.append((_LOAD_ERROR_KEY, first_line, message))
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
-        # A warning's text is stable across refreshes, so it is its own key.
+        # A warning's text is stable across refreshes, so it is its own key
+        # and its own fingerprint.
         for warning in recorded:
             warning_text = html.escape(str(warning.message))
-            current.append((warning_text, warning_text))
+            current.append((warning_text, warning_text, warning_text))
 
-        # Dismissal is remembered only for as long as a message's key keeps
-        # being produced. Prune it down to keys still in ``current`` so it
-        # cannot grow without bound with stale entries; if a problem goes
-        # away and later recurs, showing it again (undismissed) is correct.
-        self._dismissed_messages &= {key for key, _ in current}
-        for key, msg in current:
-            if key in self._dismissed_messages:
-                continue
-            # Assignment both adds a new message and updates the wording of
-            # an already-shown one in place (dict insertion order keeps its
-            # display position), so a reworded message never appears as a
-            # near-duplicate alongside its older self. Keys absent from
-            # ``current`` are deliberately left alone -- see the docstring.
+        current_keys = {key for key, _, _ in current}
+        # A dismissal is remembered only for as long as its key keeps being
+        # produced, so it cannot grow without bound with stale entries; if a
+        # problem goes away and later recurs, showing it again is correct.
+        self._dismissed = {
+            key: fingerprint
+            for key, fingerprint in self._dismissed.items()
+            if key in current_keys
+        }
+        for key, fingerprint, msg in current:
+            dismissed_fingerprint = self._dismissed.get(key)
+            if dismissed_fingerprint is not None:
+                if dismissed_fingerprint == fingerprint:
+                    # Same incident as the one dismissed.
+                    continue
+                # A different incident reusing this key -- e.g. a second
+                # file has now gone bad -- so it is shown again.
+                del self._dismissed[key]
+            # Assignment updates an already-shown key in place instead of
+            # appending a duplicate.
             self._banner_messages[key] = msg
+            self._banner_fingerprints[key] = fingerprint
+
+        # A sticky message whose key this refresh no longer produces is
+        # marked resolved rather than removed; a recurrence un-resolves it.
+        for key in self._banner_messages:
+            if key in current_keys:
+                self._resolved_keys.discard(key)
+            else:
+                self._resolved_keys.add(key)
+
         self._update_banner()
         return loaded
 
     def _update_banner(self):
         """
         Show the banner if there are any (sticky, un-dismissed) messages,
-        hide it otherwise.
+        hide it otherwise. A message whose key is in ``self._resolved_keys``
+        is marked as no longer detected instead of as an active problem.
         """
         if self._banner_messages:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
             content = "".join(
-                f"<div>⚠️ {msg}</div>" for msg in self._banner_messages.values()
+                (
+                    "<div>✓ <em>No longer detected as of the latest "
+                    f"reload:</em> {msg}</div>"
+                    if key in self._resolved_keys
+                    else f"<div>⚠️ {msg}</div>"
+                )
+                for key, msg in self._banner_messages.items()
             )
             self._banner_html.value = content
             self._banner.layout.display = "flex"
@@ -1125,13 +1163,11 @@ class ReviewSettings(ipw.VBox):
         messages at once, including any that arrived after the one the
         user meant to dismiss.
         """
-        # Button.on_click invokes handlers with the button instance as the
-        # only argument, which is unused here; the =None default lets the
-        # method also be called directly with no argument.
-        # Iterating the messages dict yields its keys, which is exactly what
-        # the dismissed set stores.
-        self._dismissed_messages.update(self._banner_messages)
+        for key in self._banner_messages:
+            self._dismissed[key] = self._banner_fingerprints.get(key, key)
         self._banner_messages = {}
+        self._banner_fingerprints = {}
+        self._resolved_keys = set()
         self._update_banner()
 
     def _observe_tab_selection(self, change):
@@ -1145,7 +1181,6 @@ class ReviewSettings(ipw.VBox):
         # badge latched at NOT_SAVED can recover when the setting gets saved
         # by something other than this widget's own observers.
 
-        # Get the index
         new_selected = change["new"]
 
         # An accordion reports a selection of None when every section is
@@ -1176,7 +1211,6 @@ class ReviewSettings(ipw.VBox):
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
             disk_value = getattr(self._refresh(), snake_name)
             if disk_value is None:
-                # The setting is not saved
                 setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
             else:
                 try:
@@ -1237,7 +1271,16 @@ def _add_saving_to_widget(setting_widget):
             # editing one
             return
         # We have a validated setting so save it.
-        wd_settings.save(pps, update=True)
+        with warnings.catch_warnings(record=True):
+            # The widget already shows PhotometrySettingsWarning in its
+            # banner via its own load, so save()'s bookkeeping load must not
+            # also print it once per autosaved setting. A plain filter
+            # cannot suppress it here: save()'s own nested catch_warnings
+            # sets PhotometrySettingsWarning to "default" after this point,
+            # which always outranks a filter set by an outer caller.
+            # Recording (and discarding) intercepts it regardless of
+            # nesting.
+            wd_settings.save(pps, update=True)
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -742,6 +742,15 @@ class SettingWithTitle(ipw.VBox):
             self.badge = SaveStatus.SETTING_IS_SAVED
 
 
+# Identity key for the single load-error banner message. A fixed key --
+# rather than one derived from the error text -- lets a refresh that
+# raises a different error for the same incident (e.g. an autosave cured
+# one of two unreadable files) update the message in place instead of
+# appending a near-duplicate. Deliberately not plausible warning text,
+# since warning messages are their own keys in the same dict.
+_LOAD_ERROR_KEY = "__settings-load-error__"
+
+
 class ReviewSettings(ipw.VBox):
     """
     Widget to preview the saved settings in the working directory. It displays one
@@ -778,7 +787,7 @@ class ReviewSettings(ipw.VBox):
         self._banner_html = ipw.HTML(layout=ipw.Layout(flex="1 1 auto"))
         self._banner_dismiss = ipw.Button(
             description="✕",
-            tooltip="Dismiss this message",
+            tooltip="Dismiss these messages",
             layout=ipw.Layout(width="2.5em"),
         )
         self._banner_dismiss.on_click(self._dismiss_banner)
@@ -791,11 +800,13 @@ class ReviewSettings(ipw.VBox):
             ),
         )
         self._banner.layout.display = "none"
-        # Maps a stable message key (the first line of a load error, or a
-        # warning's text) to the composed HTML shown for it; insertion order
-        # is display order. Keying on the stable part of the message lets a
-        # refresh that rewords the same underlying problem update its entry
-        # in place, and lets a dismissal survive the rewording.
+        # Maps a stable message key (``_LOAD_ERROR_KEY`` for the (at most
+        # one) load-error message, or a warning's own text) to the composed
+        # HTML shown for it; insertion order is display order. The load
+        # error uses a fixed key, rather than one derived from the error
+        # text, so a refresh that raises a differently-worded error for the
+        # same incident updates the entry in place instead of appending a
+        # near-duplicate, and so a dismissal survives the rewording.
         # ``_dismissed_messages`` holds the keys of dismissed messages.
         self._banner_messages = {}
         self._dismissed_messages = set()
@@ -935,6 +946,11 @@ class ReviewSettings(ipw.VBox):
         """
         Reload the settings from the working directory, updating the banner
         with any problems the load encounters, and return the result.
+
+        Note that the underlying load is not a pure read: it deletes a
+        partial settings file that exactly duplicates the full settings
+        file, so a refresh can tidy the working directory as a side
+        effect.
         """
         self._current_settings = self._load_working_dir_settings()
         return self._current_settings
@@ -945,14 +961,17 @@ class ReviewSettings(ipw.VBox):
         generates, and any failure to read an existing settings file, into the
         banner instead of silently discarding them.
 
-        Banner messages are keyed by the stable part of the message -- the
-        first line of the load error, or the warning text -- rather than by
-        the full composed text, because the sentences composed around that
-        stable part can change between refreshes for the same underlying
-        problem (e.g. an autosave during widget construction writes a
-        readable partial file, changing which fallback sentence applies).
-        When a refresh reproduces an already-shown key, its wording is
-        updated in place instead of a near-duplicate being appended.
+        At most one load-error message can exist per refresh, so it is keyed
+        by the fixed ``_LOAD_ERROR_KEY`` rather than by anything derived
+        from the error text; a warning is keyed by its own (stable) text.
+        Keying the load error on a fixed value, rather than on the error
+        text, matters because the sentences composed around it -- and even
+        which file is reported as unreadable -- can change between refreshes
+        for the same underlying incident (e.g. an autosave during widget
+        construction renames one bad file to ``.bak``, so a later refresh
+        raises an error about the *other* file instead). When a refresh
+        reproduces an already-shown key, its wording is updated in place
+        instead of a near-duplicate being appended.
 
         Banner messages are also sticky: once shown, an entry stays in
         ``self._banner_messages`` until the user dismisses it, even if a
@@ -992,13 +1011,10 @@ class ReviewSettings(ipw.VBox):
                 # ValidationError, so only its first line is shown; the rest
                 # goes into a collapsed details element.
                 error_lines = str(e).splitlines()
-                # The first line of the error is stable across refreshes even
-                # when the sentences composed around it change, so it serves
-                # as the identity key for this message.
-                message_key = html.escape(error_lines[0])
+                first_line = html.escape(error_lines[0])
                 message = (
                     "There is a problem with the saved settings in this "
-                    f"directory ({message_key})."
+                    f"directory ({first_line})."
                 )
                 # Report which file, if either, the displayed values came
                 # from. Both files are parsed before load() raises, so a
@@ -1059,7 +1075,7 @@ class ReviewSettings(ipw.VBox):
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                current.append((message_key, message))
+                current.append((_LOAD_ERROR_KEY, message))
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
@@ -1104,7 +1120,10 @@ class ReviewSettings(ipw.VBox):
 
     def _dismiss_banner(self, _=None):
         """
-        Hide the currently displayed messages until a new one arrives.
+        Dismiss every message currently shown, hiding the banner. There is
+        no per-message dismissal: the single close button clears all
+        messages at once, including any that arrived after the one the
+        user meant to dismiss.
         """
         # Button.on_click invokes handlers with the button instance as the
         # only argument, which is unused here; the =None default lets the

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -954,11 +954,12 @@ class ReviewSettings(ipw.VBox):
                 # goes into a collapsed details element.
                 error_lines = str(e).splitlines()
                 message = (
-                    "Unable to read the saved settings in this directory, so "
-                    "none of the values below come from them "
+                    "There is a problem with the saved settings in this "
+                    "directory, so none of the values below come from them "
                     f"({html.escape(error_lines[0])}). "
-                    "When settings are saved here, the unreadable file is "
-                    "renamed with a .bak extension rather than overwritten."
+                    "If saving settings here would overwrite a file that "
+                    "could not be read, that file is renamed with a .bak "
+                    "extension first."
                 )
                 if detail := "\n".join(error_lines[1:]):
                     message += (
@@ -1031,7 +1032,7 @@ class ReviewSettings(ipw.VBox):
             disk_value = getattr(self._refresh(), snake_name)
             if disk_value is None:
                 # The setting is not saved
-                setting_widget = SaveStatus.SETTING_NOT_SAVED
+                setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
             else:
                 # Set the badge to saved if it has been saved.
                 value_from_widget = setting_widget._autoui_widget.model.model_validate(

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -202,6 +202,14 @@ class ChooseOrMakeNew(ipw.VBox):
         return self._item_widget.model(**self._item_widget.value)
 
     @property
+    def is_mid_interaction(self):
+        """
+        True while the user is making a new item or editing an existing one,
+        i.e. while the displayed value may not match anything saved.
+        """
+        return self._making_new or self._editing
+
+    @property
     def display_details(self):
         """
         Whether the details box is displayed. Returns the value of the details checkbox
@@ -711,7 +719,7 @@ class SettingWithTitle(ipw.VBox):
         """
         # Unless we are making a new item or editing an item then what is displayed
         # is saved.
-        if not self._widget._making_new and not self._widget._editing:
+        if not self._widget.is_mid_interaction:
             self.badge = SaveStatus.SETTING_IS_SAVED
         else:
             self.badge = SaveStatus.SETTING_NOT_SAVED
@@ -976,8 +984,8 @@ class ReviewSettings(ipw.VBox):
         instead of a near-duplicate being appended.
 
         Because a key can outlive the incident it first named, each entry in
-        ``current`` also carries a fingerprint (the load error's escaped
-        first line, or a warning's own text). A dismissed key stays
+        ``current`` also carries a fingerprint (the load error's full
+        escaped text, or a warning's own text). A dismissed key stays
         dismissed only while its fingerprint matches what was dismissed; a
         different fingerprint under the same key means a new, unrelated
         incident, which is shown normally.
@@ -1004,10 +1012,14 @@ class ReviewSettings(ipw.VBox):
                 warnings.simplefilter("ignore")
                 warnings.simplefilter("always", PhotometrySettingsWarning)
                 loaded = wd_settings.load()
-        except ValueError as e:
+        except (ValueError, OSError) as e:
             # load() parses both files before raising, so whichever of these
             # is not None was actually readable and can be used as a
             # fallback instead of falling all the way back to empty settings.
+            # OSError can escape load() when tidying a duplicate partial
+            # settings file fails (e.g. in a read-only directory); it is
+            # reported like any other load problem instead of crashing
+            # widget construction.
             loaded = (
                 wd_settings.settings
                 or wd_settings.partial_settings
@@ -1072,23 +1084,35 @@ class ReviewSettings(ipw.VBox):
                         "numbered backup if that name is already taken)."
                     )
                 else:
-                    # Both files were readable, so this is the conflicting-
-                    # values case; the unreadable-file wording above would be
-                    # misleading here.
-                    partial_name = html.escape(wd_settings.partial_settings_file.name)
-                    message += (
-                        " Saving full settings here will resolve the "
-                        "conflict; the conflicting partial settings file "
-                        f"will be preserved as {partial_name}.bak (or the "
-                        "next available numbered backup)."
-                    )
+                    # Both files were readable. For a ValueError that means
+                    # the conflicting-values case (the unreadable-file
+                    # wording above would be misleading); an OSError instead
+                    # means the load failed while tidying the files (e.g.
+                    # deleting a duplicate partial settings file in a
+                    # read-only directory), where conflict advice would be
+                    # misleading, so no advice is added.
+                    if isinstance(e, ValueError):
+                        partial_name = html.escape(
+                            wd_settings.partial_settings_file.name
+                        )
+                        message += (
+                            " Saving full settings here will resolve the "
+                            "conflict; the conflicting partial settings file "
+                            f"will be preserved as {partial_name}.bak (or the "
+                            "next available numbered backup)."
+                        )
 
                 if detail := "\n".join(error_lines[1:]):
                     message += (
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                current.append((_LOAD_ERROR_KEY, first_line, message))
+                # The fingerprint is the full error text, not the displayed
+                # first line: pydantic first lines are generic ("1 validation
+                # error for ..."), so two different corruptions of the same
+                # file can share one, and a dismissal must not carry over
+                # from one to the other.
+                current.append((_LOAD_ERROR_KEY, html.escape(str(e)), message))
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
@@ -1183,6 +1207,12 @@ class ReviewSettings(ipw.VBox):
 
         new_selected = change["new"]
 
+        # Reload from disk on every selection change so the snapshot and
+        # the banner stay current even when the selected tab's badge needs
+        # no re-deriving below (e.g. a settings file corrupted after
+        # construction while every tab reads as saved).
+        self._refresh()
+
         # An accordion reports a selection of None when every section is
         # collapsed; there is nothing to update in that case.
         if new_selected is None:
@@ -1196,20 +1226,27 @@ class ReviewSettings(ipw.VBox):
         # here would report the still-saved on-disk value as SAVED while the
         # user is mid-edit, so trust its badge unconditionally.
         chooser = setting_widget._widget
-        mid_interaction = isinstance(chooser, ChooseOrMakeNew) and (
-            chooser._making_new or chooser._editing
+        mid_interaction = (
+            isinstance(chooser, ChooseOrMakeNew) and chooser.is_mid_interaction
         )
-        if setting_badge is not None and (
-            mid_interaction or setting_badge != SaveStatus.SETTING_NOT_SAVED
+        if mid_interaction:
+            # Mid-interaction, even a badge of None is not re-derived from
+            # disk -- the comparison could report the still-saved on-disk
+            # value as SAVED while the user is mid-edit. The chooser sets
+            # its badge on the next value change anyway.
+            if setting_badge is not None:
+                self.badges[new_selected] = setting_badge
+        elif setting_badge is not None and (
+            setting_badge != SaveStatus.SETTING_NOT_SAVED
         ):
             self.badges[new_selected] = setting_badge
         else:
-            # A badge of None or NOT_SAVED is re-derived from disk rather
-            # than trusted, so a save made outside this widget's own
-            # observers (e.g. by another widget writing the settings file)
-            # is picked up.
+            # A badge of None or NOT_SAVED is re-derived from the snapshot
+            # refreshed above rather than trusted, so a save made outside
+            # this widget's own observers (e.g. by another widget writing
+            # the settings file) is picked up.
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
-            disk_value = getattr(self._refresh(), snake_name)
+            disk_value = getattr(self.current_settings, snake_name)
             if disk_value is None:
                 setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
             else:

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -671,6 +671,12 @@ class SaveStatus(StrEnum):
     SETTING_SHOULD_BE_REVIEWED = "🔆"
 
 
+# Shown beside the save button of a setting that is not in the saved settings
+# for this directory, so that a tab badged SETTING_NOT_SAVED says how to fix
+# itself instead of just reporting a problem.
+SAVE_PROMPT_MESSAGE = "<i>not saved in this directory — click save to add it</i>"
+
+
 class SettingWithTitle(ipw.VBox):
     """
     Class that adds a title to a setting widget made by ipyautoui and
@@ -750,12 +756,60 @@ class SettingWithTitle(ipw.VBox):
         else:
             self.badge = SaveStatus.SETTING_IS_SAVED
 
+    def prompt_save(self):
+        """
+        Ask the save button bar to advertise that this setting needs saving.
+
+        The status light next to the save button reports whether the *form*
+        has been edited since the last save, so it happily says "SAFE" while
+        the setting is missing from the working directory entirely -- which
+        contradicts a SETTING_NOT_SAVED badge and makes the enabled save
+        button look inert. Setting ``unsaved_changes`` puts the light in its
+        "changes since last save" state and points at the button that fixes
+        things.
+        """
+        if isinstance(self._widget, ChooseOrMakeNew):
+            # A ChooseOrMakeNew is fixed by picking or making an item in its
+            # dropdown, not by a save button -- one it keeps hidden while an
+            # existing item is displayed. Its ``unsaved_changes`` observer is
+            # _choose_existing_observer, which derives the badge from
+            # is_mid_interaction and so could report SAVED here.
+            return
+        self._autoui_widget.savebuttonbar.unsaved_changes = True
+        self._autoui_widget.savebuttonbar.message.value = SAVE_PROMPT_MESSAGE
+
+    def clear_save_prompt(self):
+        """
+        Undo `prompt_save`, for a setting that is on disk again.
+        """
+        if isinstance(self._widget, ChooseOrMakeNew):
+            return
+        self._autoui_widget.savebuttonbar.unsaved_changes = False
+        # Only our own prompt is cleared; a genuine "changes saved: ..." or
+        # "UI reverted to last save" from ipyautoui stays put.
+        if self._autoui_widget.savebuttonbar.message.value == SAVE_PROMPT_MESSAGE:
+            self._autoui_widget.savebuttonbar.message.value = ""
+
 
 # Fixed identity key for the (at most one) load-error banner message, so
 # that a refresh which reworks the message for the same incident updates it
 # in place rather than appending a near-duplicate. Not plausible warning
 # text, since a warning is keyed on its own text in the same dict.
 _LOAD_ERROR_KEY = "__settings-load-error__"
+
+# CSS class (and the style sheet that gives it meaning) applied to the
+# settings container while a load error is active: the tabs are greyed out
+# and inert, making the banner's buttons the only affordance. The greying
+# is an affordance only -- programmatic changes bypass CSS -- so the
+# selection observer separately refuses to re-derive badges while an error
+# is active.
+_INERT_CLASS = "stellarphot-settings-inert"
+_INERT_CSS = f"<style>.{_INERT_CLASS} {{pointer-events: none; opacity: 0.5;}}</style>"
+
+# Banner border colors: amber while a load error is unresolved, a calm
+# light green once every problem is resolved or only warnings remain.
+_ERROR_BORDER = "2px solid #ffc107"
+_CALM_BORDER = "2px solid #a3cfbb"
 
 
 @dataclass
@@ -764,17 +818,21 @@ class _BannerEntry:
     One message shown in the `ReviewSettings` banner.
     """
 
-    # Identifies the specific incident shown under a key: the load error's
-    # full escaped text, or a warning's own text. A key can outlive the
-    # incident that first produced it, so a dismissal is honored only while
-    # the fingerprint matches the one that was dismissed.
-    fingerprint: str
+    # What kind of incident this entry reports; drives which banner
+    # buttons are shown while the entry is active and how its resolved
+    # wording is composed. One of "unreadable", "conflict", "oserror",
+    # or "warning".
+    kind: str
     # Composed, already-escaped HTML for the message, in its active wording.
     message: str
+    # Paths (relative to the working directory) the incident is about;
+    # used to look up -- and purge -- recorded backups when composing the
+    # resolved wording.
+    files: tuple = ()
     # True when the most recent refresh no longer reproduces the problem;
-    # the message is then shown with a "no longer detected" prefix instead
-    # of being removed, so the user still learns e.g. that a file was set
-    # aside as .bak.
+    # the message is then shown in a resolved wording instead of being
+    # removed, so the user still learns e.g. that a file was set aside
+    # as .bak.
     resolved: bool = False
 
 
@@ -802,46 +860,115 @@ class ReviewSettings(ipw.VBox):
 
     If the saved settings in the working directory cannot be read, or reading them
     generates warnings, a banner describing the problem is displayed above the
-    settings.
+    settings. While a load error is active -- which, since construction and
+    every save cure such problems automatically, means the settings files
+    changed outside this widget -- the settings below the banner are greyed
+    out and the banner's buttons are the only way forward; once the problem
+    is resolved (or when there are only warnings) the banner turns a calm
+    green and can be dismissed with its close button.
     """
 
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Banner for messages about problems loading saved settings. It is
-        # hidden unless there is a message to show, and can be dismissed
-        # with its close button. Dismissed messages stay dismissed even
-        # though the settings are reloaded on every tab selection.
+        # hidden unless there is a message to show. Which of its buttons
+        # are visible -- and whether it can be dismissed at all -- depends
+        # on the state of the entries; see _update_banner.
         self._banner_html = ipw.HTML(layout=ipw.Layout(flex="1 1 auto"))
         self._banner_dismiss = ipw.Button(
             description="✕",
             tooltip="Dismiss these messages",
-            layout=ipw.Layout(width="2.5em"),
+            # Sizing the button to its label rather than to a fixed width:
+            # JupyterLab's button padding eats most of a 2.5em box, so the
+            # glyph overflows and CSS text-overflow appends an ellipsis,
+            # making the ✕ look like it has a period after it. flex keeps the
+            # button from shrinking when the message beside it is long.
+            layout=ipw.Layout(width="auto", flex="0 0 auto"),
         )
         self._banner_dismiss.on_click(self._dismiss_banner)
+        # One-click fix for an unreadable settings file: rename it to .bak
+        # and re-save the values the widget is showing. Only shown while an
+        # unreadable-file load error is active -- visibility is managed by
+        # _update_banner.
+        self._banner_fix = ipw.Button(
+            description="Set aside broken file(s) and keep the values shown",
+            tooltip=(
+                "Rename the unreadable settings file(s) to a .bak backup "
+                "and save the values currently displayed below"
+            ),
+            button_style="warning",
+            layout=ipw.Layout(width="auto", flex="0 0 auto"),
+        )
+        self._banner_fix.layout.display = "none"
+        self._banner_fix.on_click(self._fix_unreadable_files)
+        # Resolution for a full/partial conflict: save the displayed values
+        # (which come from the full settings file), preserving the losing
+        # partial file as a .bak backup. Only shown while a conflict is
+        # active.
+        self._banner_keep = ipw.Button(
+            description="Keep the values shown",
+            tooltip=(
+                "Save the values currently displayed below, resolving the "
+                "conflict; the conflicting partial settings file is kept "
+                "as a .bak backup"
+            ),
+            button_style="warning",
+            layout=ipw.Layout(width="auto", flex="0 0 auto"),
+        )
+        self._banner_keep.layout.display = "none"
+        self._banner_keep.on_click(self._keep_displayed_values)
+        # Reload the settings from disk -- the repair-by-hand path, and the
+        # only resolution for a load failure nothing in the banner can fix
+        # (e.g. a read-only directory). Shown while any load error is
+        # active.
+        self._banner_reload = ipw.Button(
+            description="Reload",
+            tooltip="Reload the settings from the working directory",
+            button_style="warning",
+            layout=ipw.Layout(width="auto", flex="0 0 auto"),
+        )
+        self._banner_reload.layout.display = "none"
+        self._banner_reload.on_click(self._reload)
         self._banner = ipw.HBox(
-            [self._banner_html, self._banner_dismiss],
+            [
+                self._banner_html,
+                self._banner_fix,
+                self._banner_keep,
+                self._banner_reload,
+                self._banner_dismiss,
+            ],
             layout=ipw.Layout(
                 align_items="center",
-                border="2px solid #ffc107",
+                border=_ERROR_BORDER,
                 padding="0.25em 1em",
             ),
         )
         self._banner.layout.display = "none"
         # ``_banner_entries`` maps a stable key (``_LOAD_ERROR_KEY``, or a
         # warning's own text) to a `_BannerEntry`; insertion order is
-        # display order. ``_dismissed`` maps a dismissed key to the
-        # fingerprint it was dismissed at.
+        # display order. ``_dismissed`` is the set of dismissed keys.
         self._banner_entries = {}
-        self._dismissed = {}
+        self._dismissed = set()
+        # ``_backups_made`` accumulates, across refreshes, the backups the
+        # save machinery reports having made (original path -> backup
+        # path), so resolved banner messages can name the actual .bak
+        # file. ``_saver`` is the PhotometryWorkingDirSettings instance
+        # every save goes through; created below, after the early refresh.
+        self._backups_made = {}
+        self._saver = None
 
         # Get a copy of whatever settings may have already been saved.
         self._refresh()
 
         self._setting_widgets = []
         self._plain_names = []
-        self.badges = []
 
         self._settings = settings
+
+        # One shared instance for every save this widget makes, so the
+        # backups those saves create are recorded somewhere the banner can
+        # find them (see _collect_backups).
+        self._saver = PhotometryWorkingDirSettings()
 
         for setting in settings:
             # Track whether we are using the ChooseOrMakeNew or not
@@ -854,7 +981,11 @@ class ReviewSettings(ipw.VBox):
                 widget = ui_generator(setting)
                 val_to_set = widget
 
-            _add_saving_to_widget(widget)
+            _add_saving_to_widget(
+                widget,
+                wd_settings=self._saver,
+                on_save_error=self._note_save_failure,
+            )
             name = to_snake(setting.__name__)
             plain_name = " ".join(name.split("_"))
             self._plain_names.append(plain_name)
@@ -881,8 +1012,11 @@ class ReviewSettings(ipw.VBox):
                         f"by editing your saved {name} settings or by deleting the "
                         "working directory settings."
                     ) from e
-                # Add symbol to title to indicate that the setting needs review
-                self.badges.append(SaveStatus.SETTING_SHOULD_BE_REVIEWED)
+                # Add symbol to title to indicate that the setting needs
+                # review. The widget's badge is the single source of truth;
+                # this explicit write lands after the save side effects
+                # above, so it wins over whatever those observers set.
+                self._setting_widgets[-1].badge = SaveStatus.SETTING_SHOULD_BE_REVIEWED
 
             elif is_choose_or_make_new:
                 if len(widget._choose_existing.options) > 1:
@@ -894,10 +1028,12 @@ class ReviewSettings(ipw.VBox):
                     default_item = val_to_set.value
                     val_to_set.value = None
                     val_to_set.value = default_item
-                    self.badges.append(SaveStatus.SETTING_SHOULD_BE_REVIEWED)
+                    self._setting_widgets[-1].badge = (
+                        SaveStatus.SETTING_SHOULD_BE_REVIEWED
+                    )
                 else:
                     # This setting needs to be made, not reviewed
-                    self.badges.append(SaveStatus.SETTING_NOT_SAVED)
+                    self._setting_widgets[-1].badge = SaveStatus.SETTING_NOT_SAVED
             else:
                 # We got here because there was not a setting saved in the working
                 # directory, and this is not a ChooseOrMakeNew, which might have
@@ -913,15 +1049,14 @@ class ReviewSettings(ipw.VBox):
                 except ValidationError:  # pragma: no cover
                     # This should never happen with the code base as of 2024-06-27 but
                     # might in the future.
-                    self.badges.append(SaveStatus.SETTING_NOT_SAVED)
+                    self._setting_widgets[-1].badge = SaveStatus.SETTING_NOT_SAVED
                 else:
                     # This setting can be made from default values, so we save it to the
                     # working directory.
                     val_to_set.savebuttonbar.bn_save.click()
-                    self.badges.append(SaveStatus.SETTING_SHOULD_BE_REVIEWED)
-
-        # Check that everything is consistent....
-        assert len(self.badges) == len(self._plain_names)
+                    self._setting_widgets[-1].badge = (
+                        SaveStatus.SETTING_SHOULD_BE_REVIEWED
+                    )
 
         if style == "tabs":
             self._container = ipw.Tab()
@@ -931,21 +1066,27 @@ class ReviewSettings(ipw.VBox):
         self._container.children = self._setting_widgets
         self._container.titles = self._make_titles()
 
-        self.children = [self._banner, self._container]
+        # The style sheet that lets _update_banner grey out and disable the
+        # settings container while a load error is active.
+        self._inert_style = ipw.HTML(_INERT_CSS)
+        self.children = [self._inert_style, self._banner, self._container]
 
         # Set up an observer to run when a tab is selected
         self._container.observe(self._observe_tab_selection, names="selected_index")
 
         # Set up observer for each of the widget badges
-        for idx, widget in enumerate(self._setting_widgets):
-            widget.observe(self._observe_badge_change(idx), names="badge")
+        for widget in self._setting_widgets:
+            widget.observe(self._observe_badge_change, names="badge")
 
         # Construction itself may have changed what is on disk -- default-
         # constructible settings were autosaved above, and setting a
         # ChooseOrMakeNew value triggers its save observer -- so refresh
         # once more so that current_settings (and the banner) reflect the
         # post-construction state instead of the pre-save snapshot taken at
-        # the top of this method.
+        # the top of this method. This refresh also harvests the backups
+        # those construction-time saves recorded on self._saver, so a
+        # problem cured during construction is reported with the actual
+        # .bak name.
         self._refresh()
 
     def _make_titles(self):
@@ -956,6 +1097,15 @@ class ReviewSettings(ipw.VBox):
             f"{badge} {plain}"
             for badge, plain in zip(self.badges, self._plain_names, strict=True)
         ]
+
+    @property
+    def badges(self):
+        """
+        The badge of each setting widget, in display order. The widgets
+        themselves are the single source of truth; this is a read-only
+        view of their badges.
+        """
+        return [widget.badge for widget in self._setting_widgets]
 
     @property
     def current_settings(self):
@@ -977,6 +1127,36 @@ class ReviewSettings(ipw.VBox):
         """
         self._current_settings = self._load_working_dir_settings()
 
+    def _collect_backups(self):
+        """
+        Merge the backups recorded by the load-side and save-side
+        `PhotometryWorkingDirSettings` instances into ``_backups_made``,
+        which survives the per-refresh rebinding of ``_wd_settings``.
+        Every instance builds its paths relative to ``Path(".")``, so the
+        keys from different instances merge correctly.
+        """
+        for source in (
+            getattr(self, "_wd_settings", None),
+            getattr(self, "_saver", None),
+        ):
+            if source is not None:
+                self._backups_made.update(source.backups_made)
+                # Drain the source once harvested: ``_backups_made`` is the
+                # single accumulator. Re-merging an already-harvested record
+                # on a later refresh would resurrect entries the
+                # new-incident purge dropped and let an old record from one
+                # instance overwrite a newer backup made through the other.
+                source._backups_made.clear()
+
+    @property
+    def _load_error_active(self):
+        """
+        True while the banner holds an unresolved load-error entry, i.e.
+        while the on-disk settings are broken rather than merely missing.
+        """
+        entry = self._banner_entries.get(_LOAD_ERROR_KEY)
+        return entry is not None and not entry.resolved
+
     def _load_working_dir_settings(self):
         """
         Load settings from the working directory, routing any warnings the load
@@ -995,13 +1175,6 @@ class ReviewSettings(ipw.VBox):
         reproduces an already-shown key, its wording is updated in place
         instead of a near-duplicate being appended.
 
-        Because a key can outlive the incident it first named, each entry in
-        ``current`` also carries a fingerprint (the load error's full
-        escaped text, or a warning's own text). A dismissed key stays
-        dismissed only while its fingerprint matches what was dismissed; a
-        different fingerprint under the same key means a new, unrelated
-        incident, which is shown normally.
-
         Banner messages are also sticky: once shown, an entry stays in
         ``self._banner_entries`` until the user dismisses it, even if a
         later refresh no longer produces its key (e.g. an automatic save
@@ -1010,6 +1183,10 @@ class ReviewSettings(ipw.VBox):
         entries are marked resolved instead of being removed -- see
         ``_update_banner`` -- and only ``_dismiss_banner`` removes them.
         """
+        # Harvest backup records before this refresh rebinds
+        # self._wd_settings below, or they would be lost with the old
+        # instance.
+        self._collect_backups()
         wd_settings = PhotometryWorkingDirSettings()
         current = []
         try:
@@ -1041,26 +1218,7 @@ class ReviewSettings(ipw.VBox):
                 or wd_settings.partial_settings_file.exists()
             )
             if settings_file_exists:
-                # The full error can run to dozens of lines for a pydantic
-                # ValidationError, so only its first line is shown; the rest
-                # goes into a collapsed details element.
                 error_lines = str(e).splitlines()
-                first_line = html.escape(error_lines[0])
-                message = (
-                    "There is a problem with the saved settings in this "
-                    f"directory ({first_line})."
-                )
-                # Report which file, if either, the displayed values came
-                # from. Both files are parsed before load() raises, so a
-                # non-None attribute here means that file really was read.
-                # The full settings win when both were readable (the
-                # conflicting-values case below).
-                if wd_settings.settings is not None:
-                    message += " The values below come from the full settings file."
-                elif wd_settings.partial_settings is not None:
-                    message += " The values below come from the partial settings file."
-                else:
-                    message += " None of the values below come from the saved settings."
 
                 # A file is unreadable, as opposed to merely conflicting with
                 # its counterpart, exactly when it existed on disk but could
@@ -1068,91 +1226,99 @@ class ReviewSettings(ipw.VBox):
                 unreadable_full = wd_settings.full_settings_unreadable
                 unreadable_partial = wd_settings.partial_settings_unreadable
                 if unreadable_full or unreadable_partial:
-                    names = []
+                    files = []
                     if unreadable_full:
-                        names.append(html.escape(wd_settings.settings_file.name))
+                        files.append(wd_settings.settings_file)
                     if unreadable_partial:
-                        names.append(
-                            html.escape(wd_settings.partial_settings_file.name)
-                        )
-                    joined_names = " and ".join(names)
-                    joined_baks = " and ".join(f"{name}.bak" for name in names)
-                    replace_clause = (
-                        "if a save needs to replace them, they"
-                        if len(names) > 1
-                        else "if a save needs to replace it, it"
+                        files.append(wd_settings.partial_settings_file)
+                    joined_names = " and ".join(html.escape(f.name) for f in files)
+                    file_word = "files" if len(files) > 1 else "file"
+                    # Construction and every save cure unreadable files
+                    # automatically, so an *active* error provably means
+                    # the file changed outside this widget.
+                    message = (
+                        f"The settings {file_word} {joined_names} changed "
+                        "outside this widget and could not be read."
                     )
-                    # The .bak rename happens only when a save actually
-                    # replaces that specific file -- a partial-settings save
-                    # leaves an unreadable full settings file in place -- so
-                    # promise it only for a file a save needs to replace.
-                    message += (
-                        f" If settings are saved here, {joined_names} will "
-                        f"not be overwritten; {replace_clause} will first be "
-                        f"preserved as {joined_baks} (or the next available "
-                        "numbered backup if that name is already taken)."
+                    kind = "unreadable"
+                elif isinstance(e, ValueError):
+                    # Both files were readable, so this is the
+                    # conflicting-values case. The partial settings file is
+                    # the one preserved as .bak when a save resolves the
+                    # conflict, so it is the file this incident is about.
+                    full_name = html.escape(wd_settings.settings_file.name)
+                    partial_name = html.escape(wd_settings.partial_settings_file.name)
+                    message = (
+                        f"The files {full_name} and {partial_name} changed "
+                        "outside this widget and now disagree; the values "
+                        f"shown come from {full_name}."
                     )
+                    kind = "conflict"
+                    files = [wd_settings.partial_settings_file]
                 else:
-                    # Both files were readable. For a ValueError that means
-                    # the conflicting-values case (the unreadable-file
-                    # wording above would be misleading); an OSError instead
-                    # means the load failed while tidying the files (e.g.
-                    # deleting a duplicate partial settings file in a
-                    # read-only directory), where conflict advice would be
-                    # misleading, so no advice is added.
-                    if isinstance(e, ValueError):
-                        partial_name = html.escape(
-                            wd_settings.partial_settings_file.name
-                        )
-                        message += (
-                            " Saving full settings here will resolve the "
-                            "conflict; the conflicting partial settings file "
-                            f"will be preserved as {partial_name}.bak (or the "
-                            "next available numbered backup)."
-                        )
+                    # OSError with both files readable: the load failed
+                    # while deleting the partial settings file, which it
+                    # only does when that file is an exact duplicate of the
+                    # full settings file (e.g. in a read-only directory).
+                    full_name = html.escape(wd_settings.settings_file.name)
+                    partial_name = html.escape(wd_settings.partial_settings_file.name)
+                    message = (
+                        f"The file {partial_name} is an exact duplicate of "
+                        f"{full_name} but could not be deleted. It is safe "
+                        "to delete by hand; make this directory writable "
+                        "or delete the file, then click Reload."
+                    )
+                    kind = "oserror"
+                    files = []
 
-                if detail := "\n".join(error_lines[1:]):
+                # The full error is long -- dozens of lines for a pydantic
+                # ValidationError -- so all of it, first line included,
+                # goes into a collapsed details element.
+                if detail := "\n".join(error_lines):
                     message += (
                         "<details><summary>Full error</summary>"
                         f"<pre>{html.escape(detail)}</pre></details>"
                     )
-                # The fingerprint is the full error text, not the displayed
-                # first line: pydantic first lines are generic ("1 validation
-                # error for ..."), so two different corruptions of the same
-                # file can share one, and a dismissal must not carry over
-                # from one to the other.
-                current.append((_LOAD_ERROR_KEY, html.escape(str(e)), message))
+                current.append((_LOAD_ERROR_KEY, kind, message, tuple(files)))
         # Add the warnings outside the try/except so they are reported even
         # when load() raises after emitting them; ``recorded`` stays bound
         # because catch_warnings exits normally during exception propagation.
-        # A warning's text is stable across refreshes, so it is its own key
-        # and its own fingerprint.
+        # A warning's text is stable across refreshes, so it is its own key.
         for warning in recorded:
             warning_text = html.escape(str(warning.message))
-            current.append((warning_text, warning_text, warning_text))
+            current.append((warning_text, "warning", warning_text, ()))
+
+        # Retain the instance that performed this load: its unreadable
+        # flags identify the files an active load error is about, which
+        # the banner's fix button consults, and its backup records are
+        # harvested by the next refresh.
+        self._wd_settings = wd_settings
 
         current_keys = {key for key, *_ in current}
         # A dismissal is remembered only for as long as its key keeps being
         # produced, so it cannot grow without bound with stale entries; if a
         # problem goes away and later recurs, showing it again is correct.
-        self._dismissed = {
-            key: fingerprint
-            for key, fingerprint in self._dismissed.items()
-            if key in current_keys
-        }
-        for key, fingerprint, msg in current:
-            dismissed_fingerprint = self._dismissed.get(key)
-            if dismissed_fingerprint is not None:
-                if dismissed_fingerprint == fingerprint:
-                    # Same incident as the one dismissed.
-                    continue
-                # A different incident reusing this key -- e.g. a second
-                # file has now gone bad -- so it is shown again.
-                del self._dismissed[key]
+        self._dismissed &= current_keys
+        for key, kind, msg, files in current:
+            if key in self._dismissed:
+                # Only warnings can be dismissed while still active, and a
+                # warning's text is stable, so a dismissed key that is
+                # still produced is the same incident. Keep it dismissed.
+                continue
+            previous = self._banner_entries.get(key)
+            if key == _LOAD_ERROR_KEY and (previous is None or previous.resolved):
+                # A fresh incident: a backup recorded before this problem
+                # was detected cannot be what cures it, so drop any stale
+                # records for the files involved lest a resolved message
+                # later name a backup that predates the problem.
+                for path in files:
+                    self._backups_made.pop(path, None)
             # Assignment updates an already-shown key in place instead of
             # appending a duplicate.
             self._banner_entries[key] = _BannerEntry(
-                fingerprint=fingerprint, message=msg
+                kind=kind,
+                message=msg,
+                files=files,
             )
 
         # A sticky entry whose key this refresh no longer produces is marked
@@ -1164,32 +1330,113 @@ class ReviewSettings(ipw.VBox):
         self._update_banner()
         return loaded
 
+    def _compose_resolved_text(self, entry):
+        """
+        Compose the wording for a resolved entry from what is actually
+        known: backups recorded for the entry's files are named exactly;
+        with no recorded backup the problem is reported as no longer
+        detected, with no speculation about how it was cured (the user may
+        simply have repaired or removed the file by hand).
+        """
+        if entry.kind == "unreadable":
+            moved = {
+                path: self._backups_made[path]
+                for path in entry.files
+                if path in self._backups_made
+            }
+            if moved:
+                originals = " and ".join(html.escape(p.name) for p in moved)
+                backups = " and ".join(html.escape(p.name) for p in moved.values())
+                was_were = "originals were" if len(moved) > 1 else "original was"
+                return (
+                    f"There was a problem with {originals}; "
+                    f"the {was_were} saved as {backups}."
+                )
+            names = " and ".join(html.escape(p.name) for p in entry.files)
+            return f"A problem with {names} is no longer detected."
+        if entry.kind == "conflict":
+            full_name = html.escape(self._wd_settings.settings_file.name)
+            partial_name = html.escape(self._wd_settings.partial_settings_file.name)
+            text = (
+                f"The files {full_name} and {partial_name} disagreed; "
+                "the conflict has been resolved"
+            )
+            backup = next(
+                (
+                    self._backups_made[path]
+                    for path in entry.files
+                    if path in self._backups_made
+                ),
+                None,
+            )
+            if backup is not None:
+                text += (
+                    ", and the conflicting partial file was saved as "
+                    f"{html.escape(backup.name)}."
+                )
+            else:
+                text += "."
+            return text
+        # Warnings and OSError entries resolve generically.
+        return (
+            "<em>No longer detected as of the latest reload:</em> " f"{entry.message}"
+        )
+
     def _update_banner(self):
         """
-        Show the banner if there are any (sticky, un-dismissed) messages,
-        hide it otherwise. A resolved message -- one whose problem the
-        latest reload no longer reproduces -- is shown with a "no longer
-        detected" prefix, so the banner does not keep asserting a stale
-        problem while the user still learns e.g. that a file was set aside
-        as ``.bak``.
+        Render the banner from the current entries.
+
+        While a load error is active -- which, since construction and every
+        save cure such problems automatically, means the settings changed
+        outside this widget -- the banner is modal: the settings below are
+        greyed out and inert, the dismiss button is hidden, and the
+        banner's own buttons (which of them depends on the kind of error)
+        are the only affordance. Once every entry is resolved, or when only
+        warnings remain, the banner turns a calm green and is dismissable.
+
+        A resolved message -- one whose problem the latest reload no longer
+        reproduces -- is kept visible in a resolved wording, so the banner
+        does not keep asserting a stale problem while the user still
+        learns e.g. that a file was set aside as ``.bak``.
         """
+        error_entry = self._banner_entries.get(_LOAD_ERROR_KEY)
+        error_active = error_entry is not None and not error_entry.resolved
+
         if self._banner_entries:
             # A div rather than a p because a message may contain a details
             # element, which is not allowed inside a p.
-            content = "".join(
-                (
-                    "<div>✓ <em>No longer detected as of the latest "
-                    f"reload:</em> {entry.message}</div>"
-                    if entry.resolved
-                    else f"<div>⚠️ {entry.message}</div>"
-                )
-                for entry in self._banner_entries.values()
-            )
-            self._banner_html.value = content
+            parts = []
+            for entry in self._banner_entries.values():
+                if entry.resolved:
+                    parts.append(f"<div>✓ {self._compose_resolved_text(entry)}</div>")
+                else:
+                    parts.append(f"<div>⚠️ {entry.message}</div>")
+            self._banner_html.value = "".join(parts)
             self._banner.layout.display = "flex"
+            self._banner.layout.border = _ERROR_BORDER if error_active else _CALM_BORDER
         else:
             self._banner_html.value = ""
             self._banner.layout.display = "none"
+
+        # Which buttons apply depends on the kind of active error; none of
+        # them apply to a resolved entry or a warnings-only banner, and an
+        # active error cannot be dismissed -- resolving it is the only way
+        # forward.
+        active_kind = error_entry.kind if error_active else None
+        self._banner_fix.layout.display = "" if active_kind == "unreadable" else "none"
+        self._banner_keep.layout.display = "" if active_kind == "conflict" else "none"
+        self._banner_reload.layout.display = "" if error_active else "none"
+        self._banner_dismiss.layout.display = "none" if error_active else ""
+
+        # Grey out and disable the settings while an error is active. The
+        # container does not exist yet during the refresh at the top of
+        # __init__; the refresh at the end of construction re-runs this.
+        container = getattr(self, "_container", None)
+        if container is not None:
+            if error_active:
+                container.add_class(_INERT_CLASS)
+            else:
+                container.remove_class(_INERT_CLASS)
 
     def _dismiss_banner(self, _=None):
         """
@@ -1197,24 +1444,167 @@ class ReviewSettings(ipw.VBox):
         no per-message dismissal: the single close button clears all
         messages at once, including any that arrived after the one the
         user meant to dismiss.
+
+        Only an entry that is still active -- with the dismiss button
+        hidden while a load error is active, that means a warning -- is
+        recorded as dismissed. A resolved entry is simply removed, so a
+        recurrence of the underlying problem is always shown fresh.
         """
         for key, entry in self._banner_entries.items():
-            self._dismissed[key] = entry.fingerprint
+            if not entry.resolved:
+                self._dismissed.add(key)
+            # The entry's story is over; its backup records must not leak
+            # into some future incident's resolved wording.
+            for path in entry.files:
+                self._backups_made.pop(path, None)
         self._banner_entries = {}
         self._update_banner()
+
+    def _note_save_failure(self, e, lead):
+        """
+        Route a failed save or rename (e.g. a read-only directory) into
+        the banner instead of letting it raise out of a click handler or
+        observer.
+
+        Parameters
+        ----------
+        e : OSError
+            The exception describing the failure.
+        lead : str
+            Plain-text lead-in for the message, e.g. "The displayed
+            values could not be saved".
+        """
+        first_line = html.escape(str(e).splitlines()[0])
+        message = (
+            f"{lead} ({first_line}); check that this directory and its "
+            "files are writable."
+        )
+        entry = self._banner_entries.get(_LOAD_ERROR_KEY)
+        if entry is None:
+            self._banner_entries[_LOAD_ERROR_KEY] = _BannerEntry(
+                kind="oserror", message=message
+            )
+        else:
+            # Reuse the existing entry (keeping its kind, so e.g. the fix
+            # button stays available for a retry after the user makes the
+            # directory writable). Transient by design: the next refresh
+            # recomposes the standard active wording.
+            entry.message = message
+            entry.resolved = False
+        self._update_banner()
+
+    def _fix_unreadable_files(self, _=None):
+        """
+        Set aside the settings file(s) the last load found unreadable, save
+        the values currently displayed so the directory loads cleanly
+        again, and refresh so the banner reports the outcome -- naming the
+        actual backups from the records the save machinery keeps.
+        """
+        try:
+            self._wd_settings.set_aside_unreadable()
+        except OSError as e:
+            self._note_save_failure(
+                e, "The broken settings file(s) could not be set aside"
+            )
+            return
+        self._save_displayed_values()
+        self._refresh()
+
+    def _keep_displayed_values(self, _=None):
+        """
+        Resolve a full/partial conflict by saving the values currently
+        displayed -- which came from the full settings file -- so the
+        losing partial settings file is preserved as a .bak backup.
+        """
+        self._save_displayed_values()
+        self._refresh()
+
+    def _reload(self, _=None):
+        """
+        Reload the settings from disk. When the user has repaired or
+        removed the problem file(s) by hand, this resolves the banner and
+        un-greys the settings.
+        """
+        self._refresh()
+
+    def _save_displayed_values(self):
+        """
+        Save the values currently displayed in the setting widgets to the
+        working directory in one aggregate save, skipping any widget whose
+        value is incomplete or invalid.
+        """
+        values = {}
+        for setting_widget in self._setting_widgets:
+            widget = setting_widget._widget
+            if hasattr(widget, "_choose_existing"):
+                name = to_snake(widget._item_type_name)
+            else:
+                name = to_snake(widget.model.__name__)
+            try:
+                PartialPhotometrySettings(**{name: widget.value})
+            except ValidationError:
+                # Mirrors the per-widget autosave: an in-progress or
+                # incomplete tab is skipped.
+                continue
+            values[name] = widget.value
+        if not values:
+            return
+        # The banner is the display channel for PhotometrySettingsWarning,
+        # so the warning save() re-emits from its bookkeeping load is
+        # silenced rather than printed.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PhotometrySettingsWarning)
+            try:
+                self._wd_settings.save(PartialPhotometrySettings(**values), update=True)
+            except OSError as e:
+                self._note_save_failure(e, "The displayed values could not be saved")
+
+    def _resave_chooser_value(self, setting_widget):
+        """
+        Re-save a `ChooseOrMakeNew`'s displayed value when its setting has
+        disappeared from disk. A chooser shows no save button while an
+        existing item is displayed, so stamping its tab not-saved would
+        leave the user with no way to fix it from the widget; instead the
+        displayed value is saved again, mirroring the save that
+        construction performs. A chooser whose displayed value is
+        incomplete falls back to the not-saved stamp.
+        """
+        widget = setting_widget._widget
+        name = to_snake(widget._item_type_name)
+        try:
+            pps = PartialPhotometrySettings(**{name: widget.value})
+        except ValidationError:
+            # No complete value to save; prompt_save is a no-op for a
+            # chooser, so this is just the not-saved stamp.
+            setting_widget.prompt_save()
+            setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
+            return
+        # The banner is the display channel for PhotometrySettingsWarning,
+        # so the warning save() re-emits from its bookkeeping load is
+        # silenced rather than printed.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PhotometrySettingsWarning)
+            try:
+                self._saver.save(pps, update=True)
+            except OSError as e:
+                self._note_save_failure(e, "The displayed values could not be saved")
+                return
+        self._refresh()
+        setting_widget.badge = SaveStatus.SETTING_IS_SAVED
 
     def _observe_tab_selection(self, change):
         """
         Observer for the tab or accordion selection.
         """
         # Once the user has clicked on the tab, the status badge for the tab
-        # should be the badge for the widget it holds when that badge reports
-        # a positive status and the setting still exists on disk. A badge of
-        # None or NOT_SAVED is instead re-derived by comparing the widget
-        # value to the saved value, so a badge latched at NOT_SAVED can
-        # recover when the setting gets saved by something other than this
-        # widget's own observers -- and a positive badge whose setting has
-        # disappeared from disk drops back to NOT_SAVED.
+        # should stay as-is when the widget reports the setting saved and it
+        # still exists on disk. Any other badge is re-derived by comparing
+        # the widget value to the saved value, so a badge latched at
+        # NOT_SAVED can recover when the setting gets saved by something
+        # other than this widget's own observers, a needs-review badge
+        # settles once the user has looked at the tab -- and a positive
+        # badge whose setting has disappeared from disk drops back to
+        # NOT_SAVED.
 
         new_selected = change["new"]
 
@@ -1229,42 +1619,52 @@ class ReviewSettings(ipw.VBox):
         if new_selected is None:
             return
 
+        # While a load error is active, the on-disk state is broken rather
+        # than missing: the banner is the sole indicator of that, and the
+        # settings below it are greyed out. Badges are never re-derived
+        # from the broken (fallback) snapshot. The CSS inertness is an
+        # affordance only -- programmatic selection bypasses it -- so this
+        # early return is the real guard.
+        if self._load_error_active:
+            return
+
         setting_widget = self._setting_widgets[new_selected]
         setting_badge = setting_widget.badge
 
         # A ChooseOrMakeNew that is making a new item or editing one manages
         # its own badge through _choose_existing_observer; a disk comparison
         # here would report the still-saved on-disk value as SAVED while the
-        # user is mid-edit, so trust its badge unconditionally.
+        # user is mid-edit, so trust its badge unconditionally. The chooser
+        # sets its badge on the next value change anyway.
         chooser = setting_widget._widget
         mid_interaction = (
             isinstance(chooser, ChooseOrMakeNew) and chooser.is_mid_interaction
         )
-        if mid_interaction:
-            # Mid-interaction, even a badge of None is not re-derived from
-            # disk -- the comparison could report the still-saved on-disk
-            # value as SAVED while the user is mid-edit. The chooser sets
-            # its badge on the next value change anyway.
-            if setting_badge is not None:
-                self.badges[new_selected] = setting_badge
-        else:
+        if not mid_interaction:
             snake_name = to_snake(setting_widget._autoui_widget.model.__name__)
             disk_value = getattr(self.current_settings, snake_name)
-            if disk_value is None:
+            if disk_value is None and isinstance(chooser, ChooseOrMakeNew):
+                # A chooser is fixed by re-saving its displayed value, not
+                # by a save button it keeps hidden.
+                self._resave_chooser_value(setting_widget)
+            elif disk_value is None:
                 # No saved value on disk: even a positive badge is stale
                 # here (e.g. the settings file was deleted outside this
                 # widget) -- the mirror image of the latched-NOT_SAVED
                 # recovery below.
+                setting_widget.prompt_save()
                 setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
-            elif setting_badge is not None and (
-                setting_badge != SaveStatus.SETTING_NOT_SAVED
-            ):
-                self.badges[new_selected] = setting_badge
+            elif setting_badge == SaveStatus.SETTING_IS_SAVED:
+                # Saved, and the setting exists on disk: nothing to
+                # re-derive.
+                pass
             else:
-                # A badge of None or NOT_SAVED is re-derived from the
-                # snapshot refreshed above rather than trusted, so a save
-                # made outside this widget's own observers (e.g. by another
-                # widget writing the settings file) is picked up.
+                # Any other badge (None, NOT_SAVED, or needs-review) is
+                # re-derived from the snapshot refreshed above rather than
+                # trusted, so a save made outside this widget's own
+                # observers (e.g. by another widget writing the settings
+                # file) is picked up, and a needs-review badge settles to
+                # SAVED once the user has looked at the tab.
                 try:
                     value_from_widget = (
                         setting_widget._autoui_widget.model.model_validate(
@@ -1273,33 +1673,33 @@ class ReviewSettings(ipw.VBox):
                     )
                 except ValidationError:
                     # The widget holds an incomplete/invalid value; whatever
-                    # is on disk, it does not match what is displayed.
+                    # is on disk, it does not match what is displayed. Also
+                    # prompt for a save, so a red badge never coexists with
+                    # a green save light -- the invalid value keeps the
+                    # save button disabled until it is fixed.
+                    setting_widget.prompt_save()
                     setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
                 else:
                     # A valid widget value that differs from disk deliberately
                     # leaves the badge unchanged, as before this re-derivation
                     # existed.
                     if disk_value == value_from_widget:
+                        # The setting is on disk again, so drop any prompt a
+                        # previous selection left on the save bar.
+                        setting_widget.clear_save_prompt()
                         setting_widget.badge = SaveStatus.SETTING_IS_SAVED
 
         self._container.titles = self._make_titles()
 
-    def _observe_badge_change(self, index):
+    def _observe_badge_change(self, _=None):
         """
-        Observer for the badge of a setting widget.
+        Observer for the badge of any setting widget: the titles are
+        re-derived from the badges, which live on the widgets themselves.
         """
-
-        def observer(change):
-            self.badges[index] = change["new"]
-
-            # This should only be called when a badge changes, so we can just
-            # update the titles.
-            self._container.titles = self._make_titles()
-
-        return observer
+        self._container.titles = self._make_titles()
 
 
-def _add_saving_to_widget(setting_widget):
+def _add_saving_to_widget(setting_widget, wd_settings=None, on_save_error=None):
     """
     Add an observer to a widget that autosaves the settings for that widget to
     the working directory.
@@ -1308,8 +1708,20 @@ def _add_saving_to_widget(setting_widget):
     ----------
     setting_widget : ChooseOrMakeNew
         The widget to add the observer to.
+
+    wd_settings : `~stellarphot.settings.PhotometryWorkingDirSettings`, optional
+        The instance to save through. By default a fresh instance is
+        constructed, which preserves standalone use of this function;
+        `ReviewSettings` passes its shared instance so that the backups
+        these saves make are recorded where the banner can report them.
+
+    on_save_error : callable, optional
+        Called as ``on_save_error(exception, lead_text)`` when the save
+        raises `OSError` (e.g. in a read-only directory). When not
+        provided, the error propagates.
     """
-    wd_settings = PhotometryWorkingDirSettings()
+    if wd_settings is None:
+        wd_settings = PhotometryWorkingDirSettings()
 
     # Define name here so that it is available in the save_wd function. Its
     # value will be set in the if/elif block below.
@@ -1330,7 +1742,12 @@ def _add_saving_to_widget(setting_widget):
         # unaffected.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PhotometrySettingsWarning)
-            wd_settings.save(pps, update=True)
+            try:
+                wd_settings.save(pps, update=True)
+            except OSError as e:
+                if on_save_error is None:
+                    raise
+                on_save_error(e, "The displayed values could not be saved")
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1460,6 +1460,8 @@ class TestReviewSettings:
         # fingerprint is the full error text.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"camera": 12}')
+        with pytest.raises(ValueError) as first_exc:
+            PhotometryWorkingDirSettings().load()
 
         review = ReviewSettings([Camera])
         review._banner_dismiss.click()
@@ -1467,12 +1469,18 @@ class TestReviewSettings:
 
         # A different corruption with the same number of validation errors,
         # so the first line of the error is unchanged but the details are
-        # not. Verify the premise so this test fails loudly if pydantic's
-        # error formatting changes.
+        # not. Verify both halves of that premise so this test fails loudly
+        # if pydantic's error formatting changes: with differing first
+        # lines, the test would pass under a first-line fingerprint too and
+        # stop discriminating.
         wd_settings.settings_file.write_text('{"observatory": 17}')
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError) as second_exc:
             PhotometryWorkingDirSettings().load()
-        assert "validation error" in str(exc_info.value).splitlines()[0]
+        assert (
+            str(first_exc.value).splitlines()[0]
+            == str(second_exc.value).splitlines()[0]
+        )
+        assert str(first_exc.value) != str(second_exc.value)
 
         review._refresh()
         assert review._banner.layout.display == "flex"
@@ -1888,6 +1896,31 @@ class TestReviewSettings:
         review._container.selected_index = 0
         assert review.badges[0] == SaveStatus.SETTING_IS_SAVED
         assert SaveStatus.SETTING_IS_SAVED in review._container.titles[0]
+
+    def test_tab_selection_drops_stale_positive_badge(self):
+        # The mirror image of the latched-NOT_SAVED recovery above: a badge
+        # latched at SETTING_IS_SAVED must drop to SETTING_NOT_SAVED when
+        # the setting disappears from disk (e.g. the settings files are
+        # deleted outside the widget), instead of being trusted
+        # unconditionally while current_settings says the setting does not
+        # exist.
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([PhotometryApertures, Camera])
+
+        # Select the apertures tab so its badge is derived from the value
+        # autosaved during construction.
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+        assert review.badges[0] == SaveStatus.SETTING_IS_SAVED
+
+        # Delete the settings files outside the widget.
+        wd_settings.partial_settings_file.unlink(missing_ok=True)
+        wd_settings.settings_file.unlink(missing_ok=True)
+
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+        assert review.badges[0] == SaveStatus.SETTING_NOT_SAVED
+        assert SaveStatus.SETTING_NOT_SAVED in review._container.titles[0]
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1379,21 +1379,28 @@ class TestReviewSettings:
 
         # The automatic save for PhotometryApertures fires during
         # construction and renames the bad partial settings file to .bak,
-        # which means the *next* load from disk will succeed.
+        # so the refresh at the end of construction already finds the
+        # problem cured -- the message is shown, in its resolved wording.
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "There is a problem with the saved settings" in banner_text
+        assert "A problem with the saved settings" in banner_text
 
         # Selecting the PhotometryApertures tab triggers another refresh.
         # The load succeeds now, but the message should still be shown
-        # because the user never dismissed it -- now marked as resolved
-        # instead of asserting the (no longer true) original claim.
+        # because the user never dismissed it -- now in its past-tense
+        # resolved wording instead of asserting the (no longer true)
+        # original claim or making a future-tense .bak promise about a
+        # rename that already happened.
         review_settings._container.selected_index = 1
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "There is a problem with the saved settings" in banner_text
-        assert "No longer detected as of the latest reload" in banner_text
+        assert "A problem with the saved settings" in banner_text
+        assert "no longer detected as of the latest reload" in banner_text
+        assert "There is a problem" not in banner_text
+        assert "will not be overwritten" not in banner_text
+        assert "was preserved as" in banner_text
+        assert "partial_photometry_settings.json.bak" in banner_text
 
         # Dismissing hides it...
         review_settings._banner_dismiss.click()
@@ -1500,7 +1507,7 @@ class TestReviewSettings:
         review._container.selected_index = 1
 
         assert review._banner.layout.display == "flex"
-        assert "No longer detected as of the latest reload" in review._banner_html.value
+        assert "no longer detected as of the latest reload" in review._banner_html.value
 
     def test_banner_message_updates_instead_of_duplicating(self):
         # The wording composed around a load error can change between
@@ -1553,6 +1560,13 @@ class TestReviewSettings:
 
         review_settings = ReviewSettings([Camera])
 
+        # The Camera save observer fires during construction and sets the
+        # unreadable partial file aside, curing the problem before
+        # construction finishes. Re-corrupt the file and refresh so the
+        # active wording -- the point of this test -- can be observed.
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+        review_settings._refresh()
+
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
         assert "come from the full settings file" in banner_text
@@ -1580,6 +1594,14 @@ class TestReviewSettings:
         )
 
         review_settings = ReviewSettings([Camera])
+
+        # The Camera save observer fires during construction and resolves
+        # the conflict, so recreate it and refresh to observe the active
+        # conflict wording -- the point of this test.
+        wd_settings.partial_settings_file.write_text(
+            PartialPhotometrySettings(camera=conflicting_camera).model_dump_json()
+        )
+        review_settings._refresh()
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
@@ -1688,7 +1710,9 @@ class TestReviewSettings:
         review_settings = ReviewSettings([Camera, PhotometryApertures])
 
         banner_text = review_settings._banner_html.value
-        assert "There is a problem with the saved settings" in banner_text
+        # The autosave cures the problem during construction, so the message
+        # is already in its past-tense resolved wording by this point.
+        assert "problem with the saved settings" in banner_text
         backup = wd_settings.partial_settings_file.with_name(
             wd_settings.partial_settings_file.name + ".bak"
         )
@@ -1719,6 +1743,35 @@ class TestReviewSettings:
             review_settings = ReviewSettings([PhotometryApertures])
 
         assert "Settings were migrated" in review_settings._banner_html.value
+        assert not any(
+            issubclass(w.category, PhotometrySettingsWarning) for w in recorded
+        )
+
+    def test_autosave_reemits_non_settings_warnings(self, mocker):
+        # The autosave suppression exists to keep PhotometrySettingsWarning
+        # from being printed once per autosave (the banner already shows
+        # it), but its recording context swallows every warning raised
+        # during the save. Anything that is not a PhotometrySettingsWarning
+        # (e.g. a serialization or file warning) must be re-emitted so the
+        # suppression does not eat unrelated warnings.
+        def fake_save(_self, _settings, update=False):  # noqa: ARG001
+            warnings.warn("unrelated library warning", UserWarning, stacklevel=2)
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "save", fake_save
+        )
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            # PhotometryApertures can be built from defaults, so it is
+            # autosaved during construction.
+            ReviewSettings([PhotometryApertures])
+
+        messages = [str(w.message) for w in recorded]
+        assert "unrelated library warning" in messages
         assert not any(
             issubclass(w.category, PhotometrySettingsWarning) for w in recorded
         )

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1297,6 +1297,49 @@ class TestReviewSettings:
         assert "<details><summary>Full error</summary><pre>" in banner_text
         assert "Field required" in banner_text.split("<details>")[1]
 
+    def test_banner_reports_both_files_unreadable(self):
+        # When both settings files exist but neither can be read, the
+        # banner names both files and both .bak names in one message.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+        wd_settings.partial_settings_file.write_text('{"pasta": "rigatoni"}')
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+        assert "None of the values below" in banner_text
+        assert (
+            "photometry_settings.json and partial_photometry_settings.json"
+            in banner_text
+        )
+        assert (
+            "photometry_settings.json.bak and partial_photometry_settings.json.bak"
+            in banner_text
+        )
+        assert "will not be overwritten" in banner_text
+
+    def test_banner_single_message_when_error_identity_changes(self):
+        # With both files unreadable, the first refresh raises an error
+        # whose first line comes from the partial file; the construction
+        # autosave (PhotometryApertures saves its defaults) renames the bad
+        # partial file to .bak, so later refreshes raise the full-file
+        # error instead. That is still the same incident, so the banner
+        # must show exactly one problem message, updated in place, not one
+        # per error wording.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+        wd_settings.partial_settings_file.write_text('{"pasta": "rigatoni"}')
+
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        banner_text = review_settings._banner_html.value
+        assert banner_text.count("There is a problem with the saved settings") == 1
+
+        # A tab selection triggers another refresh; still one message.
+        review_settings._container.selected_index = 1
+        banner_text = review_settings._banner_html.value
+        assert banner_text.count("There is a problem with the saved settings") == 1
+
     def test_banner_dismiss_button_stays_dismissed(self):
         # Clicking the dismiss button hides the banner, and the message does
         # not come back when the settings are reloaded (which happens on

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1259,7 +1259,7 @@ class TestReviewSettings:
         # With no saved settings there is nothing to report, so the banner
         # is empty and hidden.
         review_settings = ReviewSettings([Camera])
-        assert review_settings._banner.value == ""
+        assert review_settings._banner_html.value == ""
         assert review_settings._banner.layout.display == "none"
 
     def test_banner_reports_unreadable_settings_file(self):
@@ -1275,9 +1275,37 @@ class TestReviewSettings:
         # exercises the automatic save that happens during widget creation.
         review_settings = ReviewSettings([Camera, PhotometryApertures])
 
-        assert "Unable to read the saved settings" in review_settings._banner.value
+        banner_text = review_settings._banner_html.value
+        assert "Unable to read the saved settings" in banner_text
         assert review_settings._banner.layout.display == "flex"
         assert wd_settings.settings_file.read_text() == bad_content
+
+        # Only the first line of the error is in the visible message; the
+        # rest of the validation error is inside a collapsed details element.
+        visible_text = banner_text.split("<details>")[0]
+        assert "validation error" in visible_text
+        assert "Field required" not in visible_text
+        assert "<details><summary>Full error</summary>" in banner_text
+        assert "Field required" in banner_text.split("<details>")[1]
+
+    def test_banner_dismiss_button_stays_dismissed(self):
+        # Clicking the dismiss button hides the banner, and the same message
+        # does not come back when the settings are reloaded (which happens
+        # on every tab selection).
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        assert review_settings._banner.layout.display == "flex"
+
+        review_settings._banner_dismiss.click()
+        assert review_settings._banner.layout.display == "none"
+        assert review_settings._banner_html.value == ""
+
+        # Selecting a different tab reloads the settings from disk; the
+        # dismissed message should stay dismissed.
+        review_settings._container.selected_index = 1
+        assert review_settings._banner.layout.display == "none"
 
     def test_banner_shows_warnings_from_loading_settings(self, mocker):
         # Warnings generated while loading settings (e.g. a settings-format
@@ -1291,8 +1319,17 @@ class TestReviewSettings:
         )
         review_settings = ReviewSettings([Camera])
 
-        assert "Settings were migrated" in review_settings._banner.value
+        assert "Settings were migrated" in review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
+
+    def test_accordion_collapse_does_not_error(self):
+        # An accordion with every section collapsed has selected_index None,
+        # which used to raise a TypeError in the selection observer.
+        review_settings = ReviewSettings(
+            [Camera, PhotometryApertures], style="accordion"
+        )
+        review_settings._container.selected_index = 0
+        review_settings._container.selected_index = None
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from pathlib import Path
 
@@ -1253,6 +1254,45 @@ class TestReviewSettings:
         review_settings = ReviewSettings([PhotometryApertures, Camera])
         review_settings._container.selected_index = 1
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[1]
+
+    def test_banner_hidden_when_no_settings_files(self):
+        # With no saved settings there is nothing to report, so the banner
+        # is empty and hidden.
+        review_settings = ReviewSettings([Camera])
+        assert review_settings._banner.value == ""
+        assert review_settings._banner.layout.display == "none"
+
+    def test_banner_reports_unreadable_settings_file(self):
+        # A settings file in the working directory that exists but cannot be
+        # read used to be silently ignored. The widget should still come up,
+        # starting from defaults, with a banner explaining what happened, and
+        # the unreadable file should be left in place.
+        wd_settings = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        wd_settings.settings_file.write_text(bad_content)
+
+        # PhotometryApertures can be created from default values, so this also
+        # exercises the automatic save that happens during widget creation.
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+
+        assert "Unable to read the saved settings" in review_settings._banner.value
+        assert review_settings._banner.layout.display == "flex"
+        assert wd_settings.settings_file.read_text() == bad_content
+
+    def test_banner_shows_warnings_from_loading_settings(self, mocker):
+        # Warnings generated while loading settings (e.g. a settings-format
+        # migration) should be displayed in the banner.
+        def fake_load(_self):
+            warnings.warn("Settings were migrated", UserWarning, stacklevel=2)
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert "Settings were migrated" in review_settings._banner.value
+        assert review_settings._banner.layout.display == "flex"
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -10,6 +11,10 @@ from pydantic import ValidationError
 from pydantic.alias_generators import to_snake
 
 from stellarphot.gui.custom_widgets import (
+    _CALM_BORDER,
+    _ERROR_BORDER,
+    _INERT_CLASS,
+    SAVE_PROMPT_MESSAGE,
     ChooseOrMakeNew,
     Confirm,
     ReviewSettings,
@@ -1267,39 +1272,77 @@ class TestReviewSettings:
     def test_banner_reports_unreadable_settings_file(self):
         # A settings file in the working directory that exists but cannot be
         # read used to be silently ignored. The widget should still come up,
-        # starting from defaults, with a banner explaining what happened, and
-        # the unreadable file should be left in place.
+        # starting from defaults, with a modal banner naming the file: the
+        # settings below are greyed out and inert, the banner cannot be
+        # dismissed, and its buttons are the only affordance. The unreadable
+        # file is left in place until the user (or a save) acts.
         wd_settings = PhotometryWorkingDirSettings()
         bad_content = '{"pasta": "carbonara"}'
         wd_settings.settings_file.write_text(bad_content)
 
-        # PhotometryApertures can be created from default values, so this also
-        # exercises the automatic save that happens during widget creation.
-        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        # No autosave fires for a Camera-only list, so the problem stays
+        # active rather than being cured during construction.
+        review_settings = ReviewSettings([Camera])
 
         banner_text = review_settings._banner_html.value
-        assert "There is a problem with the saved settings" in banner_text
+        assert (
+            "photometry_settings.json changed outside this widget "
+            "and could not be read" in banner_text
+        )
         assert review_settings._banner.layout.display == "flex"
         assert wd_settings.settings_file.read_text() == bad_content
 
-        # The message names the unreadable file and points out that a save
-        # will not overwrite it, and that a save that needs to replace it
-        # will first preserve it with a .bak extension.
-        assert "photometry_settings.json.bak" in banner_text
-        assert "will not be overwritten" in banner_text
+        # An active error is modal: amber border, no dismiss button, the
+        # set-aside and Reload buttons shown, the settings inert.
+        assert review_settings._banner.layout.border == _ERROR_BORDER
+        assert review_settings._banner_dismiss.layout.display == "none"
+        assert review_settings._banner_fix.layout.display == ""
+        assert review_settings._banner_reload.layout.display == ""
+        assert _INERT_CLASS in review_settings._container._dom_classes
 
-        # Only the first line of the error is in the visible message; the
-        # rest of the validation error is inside a collapsed details element,
-        # formatted in a pre block that preserves pydantic's line breaks.
+        # The visible message stays short; the whole error, first line
+        # included, is inside a collapsed details element, formatted in a
+        # pre block that preserves pydantic's line breaks.
         visible_text = banner_text.split("<details>")[0]
-        assert "validation error" in visible_text
-        assert "Field required" not in visible_text
+        assert "validation error" not in visible_text
         assert "<details><summary>Full error</summary><pre>" in banner_text
-        assert "Field required" in banner_text.split("<details>")[1]
+        details = banner_text.split("<details>")[1]
+        assert "validation error" in details
+        assert "Field required" in details
+
+    def test_construction_autosave_cures_unreadable_full(self):
+        # A save now sets aside any settings file it knows is unreadable,
+        # so the automatic save of PhotometryApertures during construction
+        # cures a corrupt full settings file: the original content survives
+        # as .bak and the banner reports the problem as already handled.
+        wd_settings = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        wd_settings.settings_file.write_text(bad_content)
+
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+
+        backup = wd_settings.settings_file.with_name(
+            wd_settings.settings_file.name + ".bak"
+        )
+        assert backup.read_text() == bad_content
+        assert not wd_settings.settings_file.exists()
+
+        banner_text = review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+        assert "✓" in banner_text
+        assert "There was a problem with photometry_settings.json" in banner_text
+        # The resolved message names the actual backup, not a guess.
+        assert "the original was saved as photometry_settings.json.bak" in banner_text
+        # The problem is gone: calm green banner, dismissable, settings
+        # enabled, and no fix button.
+        assert review_settings._banner.layout.border == _CALM_BORDER
+        assert review_settings._banner_dismiss.layout.display == ""
+        assert _INERT_CLASS not in review_settings._container._dom_classes
+        assert review_settings._banner_fix.layout.display == "none"
 
     def test_banner_reports_both_files_unreadable(self):
         # When both settings files exist but neither can be read, the
-        # banner names both files and both .bak names in one message.
+        # banner names both files in one message with plural wording.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
         wd_settings.partial_settings_file.write_text('{"pasta": "rigatoni"}')
@@ -1308,48 +1351,44 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
-        assert "None of the values below" in banner_text
+        assert "settings files" in banner_text
         assert (
-            "photometry_settings.json and partial_photometry_settings.json"
-            in banner_text
+            "photometry_settings.json and partial_photometry_settings.json "
+            "changed outside this widget and could not be read" in banner_text
         )
-        assert (
-            "photometry_settings.json.bak and partial_photometry_settings.json.bak"
-            in banner_text
-        )
-        assert "will not be overwritten" in banner_text
+        assert review_settings._banner_fix.layout.display == ""
 
     def test_banner_single_message_when_error_identity_changes(self):
-        # With both files unreadable, the first refresh raises an error
-        # whose first line comes from the partial file; the construction
-        # autosave (PhotometryApertures saves its defaults) renames the bad
-        # partial file to .bak, so later refreshes raise the full-file
-        # error instead. That is still the same incident, so the banner
-        # must show exactly one problem message, updated in place, not one
-        # per error wording.
+        # With both files unreadable, the error's first line comes from the
+        # partial file; once the partial file is gone, the next refresh
+        # raises the full-file error instead. That is still the same
+        # incident, so the banner must show exactly one problem message,
+        # updated in place, not one per error wording.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
         wd_settings.partial_settings_file.write_text('{"pasta": "rigatoni"}')
 
-        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        review_settings = ReviewSettings([Camera])
         banner_text = review_settings._banner_html.value
-        assert banner_text.count("There is a problem with the saved settings") == 1
+        assert banner_text.count("could not be read") == 1
+        assert "and partial_photometry_settings.json" in banner_text
 
-        # A tab selection triggers another refresh; still one message.
-        review_settings._container.selected_index = 1
+        # The partial file disappears; the next refresh reports only the
+        # full file -- still one message, updated in place.
+        wd_settings.partial_settings_file.unlink()
+        review_settings._refresh()
         banner_text = review_settings._banner_html.value
-        assert banner_text.count("There is a problem with the saved settings") == 1
+        assert banner_text.count("could not be read") == 1
+        assert "and partial_photometry_settings.json" not in banner_text
 
     def test_banner_dismiss_button_stays_dismissed(self):
         # Clicking the dismiss button hides the banner, and the message does
         # not come back when the settings are reloaded (which happens on
         # every tab selection). The automatic save of PhotometryApertures
-        # during construction writes a readable partial settings file, which
-        # changes the wording composed around the error on later refreshes;
-        # dismissal must stick anyway because it is keyed on the load
-        # error's fixed identity plus a fingerprint of its full text, and
-        # that text stays stable across these refreshes even though the
-        # wording composed around it changes.
+        # during construction cures the corrupt full settings file, so by
+        # the time the user sees the banner it is a resolved message --
+        # dismissable, removed outright, and not reproduced by later
+        # refreshes of the now-healthy directory.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
 
@@ -1380,25 +1419,26 @@ class TestReviewSettings:
         # The automatic save for PhotometryApertures fires during
         # construction and renames the bad partial settings file to .bak,
         # so the refresh at the end of construction already finds the
-        # problem cured -- the message is shown, marked as no longer
-        # detected.
+        # problem cured -- the message is shown as a short resolved line.
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "There is a problem with the saved settings" in banner_text
+        assert (
+            "There was a problem with partial_photometry_settings.json" in banner_text
+        )
 
         # Selecting the PhotometryApertures tab triggers another refresh.
         # The load succeeds now, but the message should still be shown
-        # because the user never dismissed it -- prefixed with "no longer
-        # detected" so the original report is clearly framed as past, and
-        # its mention of the .bak file still tells the user where the
-        # renamed content went.
+        # because the user never dismissed it -- the resolved one-liner
+        # still tells the user the original content went to a .bak file.
         review_settings._container.selected_index = 1
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "No longer detected as of the latest reload" in banner_text
-        assert "There is a problem with the saved settings" in banner_text
-        assert "partial_photometry_settings.json.bak" in banner_text
+        assert "✓" in banner_text
+        assert (
+            "There was a problem with partial_photometry_settings.json" in banner_text
+        )
+        assert ".bak" in banner_text
 
         # Dismissing hides it...
         review_settings._banner_dismiss.click()
@@ -1409,79 +1449,81 @@ class TestReviewSettings:
         review_settings._container.selected_index = 0
         assert review_settings._banner.layout.display == "none"
 
-    def test_dismissed_messages_pruned_once_no_longer_produced(self):
-        # The set of dismissed messages should not grow without bound: once
-        # a dismissed message is no longer produced by a refresh, it should
-        # be dropped so that an unrelated, differently-worded problem later
-        # is shown rather than being mistaken for something dismissed.
-        wd_settings = PhotometryWorkingDirSettings()
-        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+    def test_dismissed_messages_pruned_once_no_longer_produced(self, mocker):
+        # The set of dismissed keys should not grow without bound: once a
+        # dismissed warning is no longer produced by a refresh, its record
+        # should be dropped, so that if the same problem later recurs it is
+        # shown again rather than being mistaken for something dismissed.
+        produce_warning = {"on": True}
 
-        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        def fake_load(_self):
+            if produce_warning["on"]:
+                warnings.warn(
+                    "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+                )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
         assert review_settings._banner.layout.display == "flex"
 
+        # An active warning is dismissable, and its dismissal is recorded.
         review_settings._banner_dismiss.click()
         assert review_settings._dismissed
 
-        # The bad partial settings file was renamed to .bak during
-        # construction, so this refresh succeeds and no longer produces the
-        # dismissed message; it should be pruned from the dismissed set.
-        review_settings._container.selected_index = 1
-        assert review_settings._dismissed == {}
+        # The warning stops being produced; the record is pruned.
+        produce_warning["on"] = False
+        review_settings._refresh()
+        assert review_settings._dismissed == set()
 
-    def test_dismissed_load_error_reappears_for_new_error(self):
-        # Dismissing a load error must not silently suppress a later, freshly
-        # arisen load error that happens to reuse the same fixed banner key.
+    def test_dismissed_warning_stays_dismissed(self, mocker):
+        # A dismissed warning that is still produced on every refresh is the
+        # same incident (a warning's text is its key), so it stays hidden.
+        def fake_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review = ReviewSettings([Camera])
+
+        # A warnings-only banner is calm green and dismissable.
+        assert review._banner.layout.display == "flex"
+        assert review._banner.layout.border == _CALM_BORDER
+        assert review._banner_dismiss.layout.display == ""
+
+        review._banner_dismiss.click()
+        assert review._banner.layout.display == "none"
+
+        review._refresh()
+        assert review._banner.layout.display == "none"
+
+    def test_new_error_after_resolve_and_dismiss_shows_fresh_banner(self):
+        # Dismissing a resolved load error removes it without recording a
+        # dismissal, so corruption that arises later -- reusing the same
+        # fixed banner key -- is always shown fresh rather than being
+        # silently suppressed by the earlier dismissal.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
 
-        review = ReviewSettings([Camera])
-
+        # The PhotometryApertures autosave during construction cures the
+        # corrupt file, so the banner shows a resolved, dismissable message.
+        review = ReviewSettings([Camera, PhotometryApertures])
+        assert not review._load_error_active
         review._banner_dismiss.click()
         assert review._banner.layout.display == "none"
 
-        # A second, previously fine file now also becomes corrupt. This
-        # changes the error's first line from "Error loading settings: ..."
-        # to "Error loading partial settings: ...", i.e. a genuinely new
-        # incident under the same _LOAD_ERROR_KEY.
-        partial_settings_file = wd_settings.partial_settings_file
-        partial_settings_file.write_text('{"pasta": "rigatoni"}')
+        # The file becomes corrupt again after the dismissal.
+        wd_settings.settings_file.write_text('{"pasta": "rigatoni"}')
         review._refresh()
 
         assert review._banner.layout.display == "flex"
-        assert "There is a problem with the saved settings" in review._banner_html.value
-
-    def test_dismissed_load_error_reappears_when_error_detail_changes(self):
-        # Two different corruptions of the same file can share the same
-        # generic first line ("Error loading settings: N validation errors
-        # for ..."); a dismissal of one must not suppress the other, so the
-        # fingerprint is the full error text.
-        wd_settings = PhotometryWorkingDirSettings()
-        wd_settings.settings_file.write_text('{"camera": 12}')
-        with pytest.raises(ValueError) as first_exc:
-            PhotometryWorkingDirSettings().load()
-
-        review = ReviewSettings([Camera])
-        review._banner_dismiss.click()
-        assert review._banner.layout.display == "none"
-
-        # A different corruption with the same number of validation errors,
-        # so the first line of the error is unchanged but the details are
-        # not. Verify both halves of that premise so this test fails loudly
-        # if pydantic's error formatting changes: with differing first
-        # lines, the test would pass under a first-line fingerprint too and
-        # stop discriminating.
-        wd_settings.settings_file.write_text('{"observatory": 17}')
-        with pytest.raises(ValueError) as second_exc:
-            PhotometryWorkingDirSettings().load()
-        assert (
-            str(first_exc.value).splitlines()[0]
-            == str(second_exc.value).splitlines()[0]
-        )
-        assert str(first_exc.value) != str(second_exc.value)
-
-        review._refresh()
-        assert review._banner.layout.display == "flex"
+        assert review._load_error_active
 
     def test_tab_selection_refreshes_banner_even_with_positive_badge(self):
         # A problem that arises after construction must surface in the
@@ -1500,8 +1542,8 @@ class TestReviewSettings:
 
     def test_banner_marks_resolved_problem(self):
         # When an autosave triggered by a tab selection cures the underlying
-        # problem, the sticky message stays but gets a "resolved" marker
-        # rather than continuing to assert the (no longer true) claim.
+        # problem, the sticky message stays but flips to the short resolved
+        # line rather than continuing to assert the (no longer true) claim.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
 
@@ -1512,36 +1554,40 @@ class TestReviewSettings:
         # Selecting the PhotometryApertures tab triggers another refresh.
         review._container.selected_index = 1
 
+        banner_text = review._banner_html.value
         assert review._banner.layout.display == "flex"
-        assert "No longer detected as of the latest reload" in review._banner_html.value
+        assert "✓" in banner_text
+        assert "There was a problem with partial_photometry_settings.json" in (
+            banner_text
+        )
+        assert "could not be read" not in banner_text
 
     def test_banner_message_updates_instead_of_duplicating(self):
-        # The wording composed around a load error can change between
-        # refreshes for the same underlying problem: here the corrupt full
-        # settings file first has no readable companion ("None of the values
-        # below..."), then the automatic save of PhotometryApertures during
-        # construction writes a readable partial settings file, so later
-        # refreshes report the partial file as the fallback. The banner must
-        # show exactly one message, updated in place to the latest wording,
-        # not one near-duplicate per wording.
+        # The wording of a load error can change between refreshes for the
+        # same problem slot: here the corrupt full settings file is later
+        # joined by a corrupt partial file, so the message names first one
+        # file and then both. The banner must show exactly one message,
+        # updated in place to the latest wording, not one near-duplicate
+        # per wording.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
 
-        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        review_settings = ReviewSettings([Camera])
 
         banner_text = review_settings._banner_html.value
-        assert banner_text.count("There is a problem with the saved settings") == 1
+        assert banner_text.count("could not be read") == 1
+        assert "partial_photometry_settings.json" not in banner_text
 
-        # Selecting a tab triggers another refresh; still just one message.
-        review_settings._container.selected_index = 1
+        # A second file goes bad; the next refresh names both files in the
+        # same single message.
+        wd_settings.partial_settings_file.write_text('{"pasta": "rigatoni"}')
+        review_settings._refresh()
         banner_text = review_settings._banner_html.value
-        assert banner_text.count("There is a problem with the saved settings") == 1
-
-        # The message reflects the latest wording: the autosaved partial
-        # settings file is now the readable fallback, and the original
-        # "no readable settings" sentence has been replaced in place.
-        assert "come from the partial settings file" in banner_text
-        assert "None of the values below" not in banner_text
+        assert banner_text.count("could not be read") == 1
+        assert (
+            "photometry_settings.json and partial_photometry_settings.json"
+            in banner_text
+        )
 
     def test_current_settings_fresh_after_construction(self):
         # Widget construction itself saves settings (PhotometryApertures can
@@ -1575,17 +1621,20 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
-        assert "come from the full settings file" in banner_text
+        assert (
+            "partial_photometry_settings.json changed outside this widget "
+            "and could not be read" in banner_text
+        )
         assert review_settings.current_settings.camera == full_settings.camera
 
     def test_banner_conflict_wording_when_both_files_readable(self):
         # When both the full and partial settings files are individually
         # readable but disagree with each other, the "this file could not
         # be read" wording would be misleading -- both files were read
-        # just fine. The banner should instead say that the values shown
-        # come from the (preferred) full settings file and that saving full
-        # settings resolves the conflict, keeping the conflicting (losing)
-        # partial settings file as a .bak.
+        # just fine. The banner should instead say that the files disagree
+        # and that the values shown come from the (preferred) full settings
+        # file, offering the Keep-the-values-shown and Reload buttons as
+        # the ways forward.
         saved = SavedSettings()
         saved.add_item(Camera(**TEST_CAMERA_VALUES))
 
@@ -1611,11 +1660,149 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
-        assert "will not be overwritten" not in banner_text
-        assert "come from the full settings file" in banner_text
-        assert "resolve the conflict" in banner_text
-        assert "conflicting partial settings file will be preserved" in banner_text
-        assert "partial_photometry_settings.json.bak" in banner_text
+        assert "could not be read" not in banner_text
+        assert (
+            "photometry_settings.json and partial_photometry_settings.json "
+            "changed outside this widget and now disagree" in banner_text
+        )
+        assert "values shown come from photometry_settings.json" in banner_text
+
+        # An active conflict is modal: amber border, no dismiss, only the
+        # Keep-the-values-shown and Reload buttons offered -- the set-aside
+        # button applies to unreadable files, not to a conflict between two
+        # readable ones.
+        assert review_settings._banner.layout.border == _ERROR_BORDER
+        assert review_settings._banner_dismiss.layout.display == "none"
+        assert review_settings._banner_fix.layout.display == "none"
+        assert review_settings._banner_keep.layout.display == ""
+        assert review_settings._banner_reload.layout.display == ""
+        assert _INERT_CLASS in review_settings._container._dom_classes
+
+    def test_banner_keep_values_button_resolves_conflict(self):
+        # Clicking "Keep the values shown" saves the displayed values --
+        # which came from the full settings file -- resolving the conflict
+        # and preserving the losing partial settings file as a .bak backup
+        # the resolved message names exactly.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text(full_settings.model_dump_json())
+
+        conflicting_camera = Camera(**TEST_CAMERA_VALUES)
+        conflicting_camera.gain = 2 * conflicting_camera.gain
+        conflicting_content = PartialPhotometrySettings(
+            camera=conflicting_camera
+        ).model_dump_json()
+        wd_settings.partial_settings_file.write_text(conflicting_content)
+
+        review = ReviewSettings([Camera])
+
+        # The Camera save observer fired during construction and resolved
+        # the conflict (preserving the partial file as .bak); recreate the
+        # conflict so the Keep button is active.
+        wd_settings.partial_settings_file.write_text(conflicting_content)
+        review._refresh()
+        assert review._load_error_active
+        assert review._banner_keep.layout.display == ""
+
+        review._banner_keep.click()
+
+        banner_text = review._banner_html.value
+        assert review._banner.layout.display == "flex"
+        assert review._banner.layout.border == _CALM_BORDER
+        assert "✓" in banner_text
+        assert "the conflict has been resolved" in banner_text
+        # The .bak was taken by the construction-time save, so this save's
+        # backup gets the next numbered name -- and the message says which.
+        assert "partial_photometry_settings.json.bak1" in banner_text
+        backup = wd_settings.partial_settings_file.with_name(
+            wd_settings.partial_settings_file.name + ".bak1"
+        )
+        assert backup.read_text() == conflicting_content
+        assert review._banner_keep.layout.display == "none"
+        assert _INERT_CLASS not in review._container._dom_classes
+
+    def test_banner_reload_button_after_hand_repair(self):
+        # The Reload button is the repair-by-hand path: once the user fixes
+        # or removes the broken file outside the widget, one click resolves
+        # the banner -- with no claim about a .bak that was never made --
+        # and un-greys the settings.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review = ReviewSettings([Camera])
+        assert review._load_error_active
+        assert review._banner_reload.layout.display == ""
+        assert _INERT_CLASS in review._container._dom_classes
+
+        # The user deletes the broken file by hand, then clicks Reload.
+        wd_settings.settings_file.unlink()
+        review._banner_reload.click()
+
+        banner_text = review._banner_html.value
+        assert review._banner.layout.display == "flex"
+        assert review._banner.layout.border == _CALM_BORDER
+        assert "✓" in banner_text
+        assert (
+            "A problem with photometry_settings.json is no longer detected"
+            in banner_text
+        )
+        assert ".bak" not in banner_text
+        assert review._banner_reload.layout.display == "none"
+        assert review._banner_dismiss.layout.display == ""
+        assert _INERT_CLASS not in review._container._dom_classes
+
+    def test_banner_duplicate_partial_oserror(self, mocker):
+        # When the partial settings file is an exact duplicate of the full
+        # settings file, load() tidies it away; if that deletion fails
+        # (e.g. a read-only directory) the banner must say the file is a
+        # duplicate that is safe to delete by hand, and Reload is the only
+        # button offered -- nothing the widget can save fixes a directory
+        # it cannot write to.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text(full_settings.model_dump_json())
+
+        review = ReviewSettings([Camera])
+
+        # Create the duplicate after construction so no construction-time
+        # save is involved, then make deletion fail.
+        wd_settings.partial_settings_file.write_text(full_settings.model_dump_json())
+        deletion_fails = {"on": True}
+        real_unlink = Path.unlink
+
+        def flaky_unlink(self, *args, **kwargs):
+            if deletion_fails["on"]:
+                raise OSError("Read-only file system")
+            return real_unlink(self, *args, **kwargs)
+
+        mocker.patch.object(settings_files.Path, "unlink", flaky_unlink)
+        review._refresh()
+
+        banner_text = review._banner_html.value
+        assert (
+            "partial_photometry_settings.json is an exact duplicate of "
+            "photometry_settings.json" in banner_text
+        )
+        assert "safe to delete" in banner_text
+        assert review._banner.layout.border == _ERROR_BORDER
+        assert review._banner_fix.layout.display == "none"
+        assert review._banner_keep.layout.display == "none"
+        assert review._banner_reload.layout.display == ""
+        assert review._banner_dismiss.layout.display == "none"
+
+        # Once the directory is writable again, Reload resolves it: the
+        # load itself tidies the duplicate away.
+        deletion_fails["on"] = False
+        review._banner_reload.click()
+        assert review._banner.layout.border == _CALM_BORDER
+        assert "No longer detected" in review._banner_html.value
+        assert not wd_settings.partial_settings_file.exists()
 
     def test_construction_autosave_preserves_conflicting_partial(self):
         # The save observers fire during construction with values taken
@@ -1699,6 +1886,9 @@ class TestReviewSettings:
             warnings.warn(
                 "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
             )
+            # The real load() latches this flag before raising an
+            # unreadable-file error; the banner wording relies on it.
+            _self._full_settings_unreadable = True
             raise ValueError("Error loading settings: broken")
 
         mocker.patch.object(
@@ -1748,12 +1938,176 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         # The autosave cures the problem during construction, so the message
-        # is already marked "no longer detected" by this point.
-        assert "problem with the saved settings" in banner_text
+        # is already the short resolved line by this point.
+        assert "There was a problem with partial_photometry_settings.json" in (
+            banner_text
+        )
         backup = wd_settings.partial_settings_file.with_name(
             wd_settings.partial_settings_file.name + ".bak"
         )
         assert backup.read_text() == bad_content
+
+    def test_banner_fix_button_hidden_when_not_applicable(self, mocker):
+        # The set-aside button only makes sense while an unreadable file is
+        # actually present. It stays hidden with no settings files at all...
+        review = ReviewSettings([Camera])
+        assert review._banner_fix.layout.display == "none"
+
+        # ... and for a warnings-only banner.
+        def warn_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", warn_load
+        )
+        review = ReviewSettings([Camera])
+        assert review._banner.layout.display == "flex"
+        assert review._banner_fix.layout.display == "none"
+
+    def test_banner_fix_button_hidden_after_dismissal(self):
+        # An active error cannot be dismissed -- the dismiss button is
+        # hidden -- so dismissal happens after the fix button resolves the
+        # problem, and it takes the whole banner (fix button included) away.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review = ReviewSettings([Camera])
+        assert review._banner_fix.layout.display == ""
+        assert review._banner_dismiss.layout.display == "none"
+
+        review._banner_fix.click()
+        assert review._banner_dismiss.layout.display == ""
+
+        review._banner_dismiss.click()
+        assert review._banner.layout.display == "none"
+        assert review._banner_fix.layout.display == "none"
+
+    def test_banner_fix_button_cures_and_names_bak(self):
+        # Clicking the fix button renames the unreadable file to .bak,
+        # re-saves the values the widget is showing, and flips the banner
+        # to a resolved line naming the actual backup used.
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([Camera, PhotometryApertures])
+
+        # Corrupt the full settings file behind the widget's back, then
+        # refresh (as a tab selection would) so the error is active.
+        bad_content = '{"pasta": "carbonara"}'
+        wd_settings.settings_file.write_text(bad_content)
+        review._refresh()
+        assert "could not be read" in review._banner_html.value
+        assert review._banner_fix.layout.display == ""
+
+        review._banner_fix.click()
+
+        backup = wd_settings.settings_file.with_name(
+            wd_settings.settings_file.name + ".bak"
+        )
+        assert backup.read_text() == bad_content
+        assert not wd_settings.settings_file.exists()
+
+        banner_text = review._banner_html.value
+        assert "✓" in banner_text
+        assert "the original was saved as photometry_settings.json.bak" in banner_text
+        assert review._banner_fix.layout.display == "none"
+
+        # The directory loads cleanly again, with the displayed values.
+        loaded = PhotometryWorkingDirSettings().load()
+        assert loaded.photometry_apertures == PhotometryApertures.model_validate(
+            review._setting_widgets[1]._autoui_widget.value
+        )
+
+    def test_banner_fix_button_oserror_shows_message(self, mocker):
+        # A failure to rename (e.g. a read-only directory) must not raise
+        # out of the click handler; the banner reports it instead and the
+        # file is left untouched.
+        wd_settings = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        wd_settings.settings_file.write_text(bad_content)
+
+        review = ReviewSettings([Camera])
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings,
+            "set_aside_unreadable",
+            side_effect=OSError("Permission denied"),
+        )
+
+        review._banner_fix.click()
+
+        banner_text = review._banner_html.value
+        assert "could not be set aside" in banner_text
+        assert "Permission denied" in banner_text
+        assert "writable" in banner_text
+        assert review._banner.layout.display == "flex"
+        assert wd_settings.settings_file.read_text() == bad_content
+
+    def test_autosave_oserror_routed_to_banner(self, mocker):
+        # An OSError raised by a widget's own autosave (e.g. the directory
+        # became read-only) is routed into the banner instead of raising
+        # out of the save button's click handler.
+        review = ReviewSettings([Camera, PhotometryApertures])
+        assert review._banner.layout.display == "none"
+
+        mocker.patch.object(
+            review._saver, "save", side_effect=OSError("Permission denied")
+        )
+        review._setting_widgets[1]._autoui_widget.savebuttonbar.bn_save.click()
+
+        banner_text = review._banner_html.value
+        assert review._banner.layout.display == "flex"
+        assert "could not be saved" in banner_text
+        assert "Permission denied" in banner_text
+        assert "writable" in banner_text
+
+    def test_badges_not_stamped_during_active_load_error(self):
+        # While a settings file is unreadable the banner is the sole
+        # indicator: tabs keep their badges instead of being stamped
+        # not-saved against the empty fallback settings, and no save prompt
+        # is faked onto the save bar.
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([Camera, PhotometryApertures])
+
+        # Corrupt the partial settings file (which holds the autosaved
+        # apertures) behind the widget's back.
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        review._container.selected_index = 1
+        assert review._banner.layout.display == "flex"
+        assert review.badges[1] == SaveStatus.SETTING_SHOULD_BE_REVIEWED
+        savebuttonbar = review._setting_widgets[1]._autoui_widget.savebuttonbar
+        assert savebuttonbar.message.value != SAVE_PROMPT_MESSAGE
+
+        # Once the setting is simply missing rather than unreadable, the
+        # not-saved stamping resumes.
+        wd_settings.partial_settings_file.unlink()
+        review._container.selected_index = 0
+        review._container.selected_index = 1
+        assert review.badges[1] == SaveStatus.SETTING_NOT_SAVED
+
+    def test_badges_not_stamped_during_active_conflict(self):
+        # The badge guard covers every kind of active load error, not just
+        # unreadable files: while the settings files conflict, tab
+        # selection leaves the badges alone too.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([Camera, PhotometryApertures])
+        badges_before = review.badges
+
+        # Create a full/partial conflict behind the widget's back.
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings.settings_file.write_text(full_settings.model_dump_json())
+        conflicting_camera = Camera(**TEST_CAMERA_VALUES)
+        conflicting_camera.gain = 2 * conflicting_camera.gain
+        wd_settings.partial_settings_file.write_text(
+            PartialPhotometrySettings(camera=conflicting_camera).model_dump_json()
+        )
+
+        review._container.selected_index = 1
+        assert review._load_error_active
+        assert review.badges == badges_before
 
     def test_autosave_does_not_print_settings_warnings(self, mocker):
         # A settings-migration warning raised while loading should reach the
@@ -1917,6 +2271,114 @@ class TestReviewSettings:
         review._container.selected_index = 0
         assert review.badges[0] == SaveStatus.SETTING_NOT_SAVED
         assert SaveStatus.SETTING_NOT_SAVED in review._container.titles[0]
+
+        # The tab must also say how to fix itself: the save bar's status
+        # light reports whether the form has been edited, so without this it
+        # keeps showing "no changes since the last save" beside a tab badged
+        # not-saved, and the enabled save button looks inert.
+        savebuttonbar = review._setting_widgets[0]._autoui_widget.savebuttonbar
+        assert savebuttonbar.unsaved_changes is True
+        assert savebuttonbar.message.value == SAVE_PROMPT_MESSAGE
+
+        # ...and one click of that save button really does fix it.
+        savebuttonbar.bn_save.click()
+        assert review.badges[0] == SaveStatus.SETTING_IS_SAVED
+        assert SaveStatus.SETTING_IS_SAVED in review._container.titles[0]
+        assert wd_settings.partial_settings_file.exists()
+
+    def test_no_filechooser_warning_on_fresh_directory(self, caplog):
+        # SourceLocationSettings.source_list_file defaults to a file name that
+        # does not exist in a new working directory, and ipyautoui's
+        # FileChooser logs a warning whenever it is built with a path that is
+        # not there. That produced a red warning box above every fresh widget
+        # describing an entirely normal situation.
+        with caplog.at_level(logging.WARNING, logger="ipyautoui.custom.filechooser"):
+            ReviewSettings([SourceLocationSettings])
+
+        assert not [
+            record
+            for record in caplog.records
+            if "path given doesnt exist" in record.getMessage()
+        ]
+
+    def test_choose_or_make_new_tab_not_forced_unsaved(self):
+        # A ChooseOrMakeNew is fixed by its dropdown, not by a save button --
+        # one it keeps hidden -- and its unsaved_changes observer derives the
+        # badge from is_mid_interaction, so forcing unsaved_changes here could
+        # report the setting as SAVED. Selecting such a tab with nothing on
+        # disk must badge it not-saved without touching its save bar.
+        review = ReviewSettings([PhotometryApertures, Camera])
+
+        review._container.selected_index = 1
+        assert review.badges[1] == SaveStatus.SETTING_NOT_SAVED
+
+        savebuttonbar = review._setting_widgets[1]._autoui_widget.savebuttonbar
+        assert savebuttonbar.unsaved_changes is False
+        assert savebuttonbar.message.value != SAVE_PROMPT_MESSAGE
+
+    def test_chooser_tab_self_heals_when_setting_disappears(self):
+        # A ChooseOrMakeNew shows no save button while an existing item is
+        # displayed, so when its setting disappears from disk, stamping the
+        # tab not-saved would be a dead end. Selecting the tab re-saves the
+        # displayed value instead, mirroring the save construction performs.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([Camera, PhotometryApertures])
+
+        # The camera chosen during construction was saved to the working
+        # directory; delete the settings files behind the widget's back.
+        wd_settings.partial_settings_file.unlink(missing_ok=True)
+        wd_settings.settings_file.unlink(missing_ok=True)
+
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+
+        assert review.badges[0] == SaveStatus.SETTING_IS_SAVED
+        assert SaveStatus.SETTING_IS_SAVED in review._container.titles[0]
+        loaded = PhotometryWorkingDirSettings().load()
+        assert loaded.camera == Camera(**TEST_CAMERA_VALUES)
+
+    def test_tab_selection_invalid_value_prompts_save(self, mocker):
+        # When the widget holds an invalid value while its setting exists on
+        # disk, selecting the tab stamps it not-saved AND prompts for a
+        # save, so the red badge never coexists with a green save light.
+        review = ReviewSettings([PhotometryApertures, Camera])
+
+        mocker.patch.object(
+            PhotometryApertures,
+            "model_validate",
+            side_effect=ValidationError.from_exception_data("PhotometryApertures", []),
+        )
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+
+        assert review.badges[0] == SaveStatus.SETTING_NOT_SAVED
+        savebuttonbar = review._setting_widgets[0]._autoui_widget.savebuttonbar
+        assert savebuttonbar.unsaved_changes is True
+        assert savebuttonbar.message.value == SAVE_PROMPT_MESSAGE
+
+    def test_badge_write_updates_title(self):
+        # The widgets' badges are the single source of truth -- the badges
+        # property is a read-only view of them -- and writing one re-derives
+        # the container titles, so title and badge cannot diverge.
+        review = ReviewSettings([Camera, PhotometryApertures])
+
+        review._setting_widgets[1].badge = SaveStatus.SETTING_IS_SAVED
+
+        assert review.badges[1] == SaveStatus.SETTING_IS_SAVED
+        assert SaveStatus.SETTING_IS_SAVED in review._container.titles[1]
+
+    def test_widget_children_structure(self):
+        # The inert-styling stylesheet rides along as the first child, ahead
+        # of the banner and the settings container.
+        review = ReviewSettings([Camera])
+
+        style, banner, container = review.children
+        assert isinstance(style, ipw.HTML)
+        assert _INERT_CLASS in style.value
+        assert banner is review._banner
+        assert container is review._container
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1280,12 +1280,17 @@ class TestReviewSettings:
         assert review_settings._banner.layout.display == "flex"
         assert wd_settings.settings_file.read_text() == bad_content
 
+        # The message points out that saving will preserve the unreadable
+        # file with a .bak extension rather than overwrite it.
+        assert "renamed with a .bak extension" in banner_text
+
         # Only the first line of the error is in the visible message; the
-        # rest of the validation error is inside a collapsed details element.
+        # rest of the validation error is inside a collapsed details element,
+        # formatted in a pre block that preserves pydantic's line breaks.
         visible_text = banner_text.split("<details>")[0]
         assert "validation error" in visible_text
         assert "Field required" not in visible_text
-        assert "<details><summary>Full error</summary>" in banner_text
+        assert "<details><summary>Full error</summary><pre>" in banner_text
         assert "Field required" in banner_text.split("<details>")[1]
 
     def test_banner_dismiss_button_stays_dismissed(self):
@@ -1322,6 +1327,77 @@ class TestReviewSettings:
         assert "Settings were migrated" in review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
 
+    def test_banner_escapes_html_from_settings_file(self):
+        # The banner message includes content that came from the settings
+        # file, so markup in a corrupt file must be escaped rather than
+        # rendered as HTML.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text(
+            '{"camera": "<img src=x onerror=alert(1)>"}'
+        )
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert "<img" not in banner_text
+        assert "&lt;img" in banner_text
+
+    def test_banner_shows_warnings_when_load_also_fails(self, mocker):
+        # Warnings emitted while loading settings should reach the banner
+        # even when the load then fails, alongside the error message itself.
+        def fake_load(_self):
+            warnings.warn("Settings were migrated", UserWarning, stacklevel=2)
+            raise ValueError("Error loading settings: broken")
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        # The error is only reported when a settings file actually exists.
+        PhotometryWorkingDirSettings().settings_file.write_text("{}")
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert "Error loading settings: broken" in banner_text
+        assert "Settings were migrated" in banner_text
+        assert review_settings._banner.layout.display == "flex"
+
+    def test_banner_ignores_non_user_warnings(self, mocker):
+        # Warnings other than UserWarning raised on the load path, like a
+        # DeprecationWarning from a library internal, are not actionable by
+        # the user and should stay out of the banner.
+        def fake_load(_self):
+            warnings.warn("this API is deprecated", DeprecationWarning, stacklevel=2)
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert review_settings._banner_html.value == ""
+        assert review_settings._banner.layout.display == "none"
+
+    def test_unreadable_settings_file_preserved_as_bak(self):
+        # An unreadable partial settings file in the working directory should
+        # be reported in the banner, and the automatic save that happens
+        # during widget creation should preserve the original content with a
+        # .bak extension instead of overwriting it.
+        wd_settings = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        wd_settings.partial_settings_file.write_text(bad_content)
+
+        # PhotometryApertures can be created from default values, so the
+        # automatic save fires during widget creation.
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+
+        banner_text = review_settings._banner_html.value
+        assert "Unable to read the saved settings" in banner_text
+        backup = wd_settings.partial_settings_file.with_name(
+            wd_settings.partial_settings_file.name + ".bak"
+        )
+        assert backup.read_text() == bad_content
+
     def test_accordion_collapse_does_not_error(self):
         # An accordion with every section collapsed has selected_index None,
         # which used to raise a TypeError in the selection observer.
@@ -1330,6 +1406,7 @@ class TestReviewSettings:
         )
         review_settings._container.selected_index = 0
         review_settings._container.selected_index = None
+        # Reaching this point without an exception is the test
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1346,8 +1346,10 @@ class TestReviewSettings:
         # every tab selection). The automatic save of PhotometryApertures
         # during construction writes a readable partial settings file, which
         # changes the wording composed around the error on later refreshes;
-        # dismissal must stick anyway because it is keyed on the (stable)
-        # first line of the error, not on the full message text.
+        # dismissal must stick anyway because it is keyed on the load
+        # error's fixed identity plus a fingerprint of its first line, and
+        # that first line stays stable across these refreshes even though
+        # the surrounding wording changes.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
 
@@ -1380,15 +1382,18 @@ class TestReviewSettings:
         # which means the *next* load from disk will succeed.
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
-        message = review_settings._banner_html.value
-        assert message
+        banner_text = review_settings._banner_html.value
+        assert "There is a problem with the saved settings" in banner_text
 
         # Selecting the PhotometryApertures tab triggers another refresh.
         # The load succeeds now, but the message should still be shown
-        # because the user never dismissed it.
+        # because the user never dismissed it -- now marked as resolved
+        # instead of asserting the (no longer true) original claim.
         review_settings._container.selected_index = 1
         assert review_settings._banner.layout.display == "flex"
-        assert review_settings._banner_html.value == message
+        banner_text = review_settings._banner_html.value
+        assert "There is a problem with the saved settings" in banner_text
+        assert "No longer detected as of the latest reload" in banner_text
 
         # Dismissing hides it...
         review_settings._banner_dismiss.click()
@@ -1411,13 +1416,52 @@ class TestReviewSettings:
         assert review_settings._banner.layout.display == "flex"
 
         review_settings._banner_dismiss.click()
-        assert review_settings._dismissed_messages
+        assert review_settings._dismissed
 
         # The bad partial settings file was renamed to .bak during
         # construction, so this refresh succeeds and no longer produces the
         # dismissed message; it should be pruned from the dismissed set.
         review_settings._container.selected_index = 1
-        assert review_settings._dismissed_messages == set()
+        assert review_settings._dismissed == {}
+
+    def test_dismissed_load_error_reappears_for_new_error(self):
+        # Dismissing a load error must not silently suppress a later, freshly
+        # arisen load error that happens to reuse the same fixed banner key.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review = ReviewSettings([Camera])
+
+        review._banner_dismiss.click()
+        assert review._banner.layout.display == "none"
+
+        # A second, previously fine file now also becomes corrupt. This
+        # changes the error's first line from "Error loading settings: ..."
+        # to "Error loading partial settings: ...", i.e. a genuinely new
+        # incident under the same _LOAD_ERROR_KEY.
+        partial_settings_file = wd_settings.partial_settings_file
+        partial_settings_file.write_text('{"pasta": "rigatoni"}')
+        review._refresh()
+
+        assert review._banner.layout.display == "flex"
+        assert "There is a problem with the saved settings" in review._banner_html.value
+
+    def test_banner_marks_resolved_problem(self):
+        # When an autosave triggered by a tab selection cures the underlying
+        # problem, the sticky message stays but gets a "resolved" marker
+        # rather than continuing to assert the (no longer true) claim.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        # The PhotometryApertures autosave during construction renames the
+        # bad partial settings file to .bak, curing the problem.
+        review = ReviewSettings([Camera, PhotometryApertures])
+
+        # Selecting the PhotometryApertures tab triggers another refresh.
+        review._container.selected_index = 1
+
+        assert review._banner.layout.display == "flex"
+        assert "No longer detected as of the latest reload" in review._banner_html.value
 
     def test_banner_message_updates_instead_of_duplicating(self):
         # The wording composed around a load error can change between
@@ -1610,6 +1654,35 @@ class TestReviewSettings:
             wd_settings.partial_settings_file.name + ".bak"
         )
         assert backup.read_text() == bad_content
+
+    def test_autosave_does_not_print_settings_warnings(self, mocker):
+        # A settings-migration warning raised while loading should reach the
+        # banner exactly once. Without the fix, it would also be printed to
+        # the console once per autosaved setting: the widget's own explicit
+        # loads (which feed the banner) route the warning through their own
+        # recording context, but the autosave triggered during construction
+        # calls save(), whose internal bookkeeping load deliberately lets
+        # PhotometrySettingsWarning through.
+        def fake_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            # PhotometryApertures can be built from defaults, so it is
+            # autosaved during construction.
+            review_settings = ReviewSettings([PhotometryApertures])
+
+        assert "Settings were migrated" in review_settings._banner_html.value
+        assert not any(
+            issubclass(w.category, PhotometrySettingsWarning) for w in recorded
+        )
 
     def test_accordion_collapse_does_not_error(self):
         # An accordion with every section collapsed has selected_index None,

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -28,6 +28,7 @@ from stellarphot.settings import (
     PhotometryApertures,
     PhotometryOptionalSettings,
     PhotometrySettings,
+    PhotometrySettingsWarning,
     PhotometryWorkingDirSettings,
     SavedSettings,
     SourceLocationSettings,
@@ -1478,7 +1479,9 @@ class TestReviewSettings:
         # Warnings generated while loading settings (e.g. a settings-format
         # migration) should be displayed in the banner.
         def fake_load(_self):
-            warnings.warn("Settings were migrated", UserWarning, stacklevel=2)
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
             return PartialPhotometrySettings()
 
         mocker.patch.object(
@@ -1508,7 +1511,9 @@ class TestReviewSettings:
         # Warnings emitted while loading settings should reach the banner
         # even when the load then fails, alongside the error message itself.
         def fake_load(_self):
-            warnings.warn("Settings were migrated", UserWarning, stacklevel=2)
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
             raise ValueError("Error loading settings: broken")
 
         mocker.patch.object(
@@ -1524,12 +1529,15 @@ class TestReviewSettings:
         assert "Settings were migrated" in banner_text
         assert review_settings._banner.layout.display == "flex"
 
-    def test_banner_ignores_non_user_warnings(self, mocker):
-        # Warnings other than UserWarning raised on the load path, like a
-        # DeprecationWarning from a library internal, are not actionable by
-        # the user and should stay out of the banner.
+    @pytest.mark.parametrize("category", [DeprecationWarning, UserWarning])
+    def test_banner_ignores_other_warning_categories(self, mocker, category):
+        # Only PhotometrySettingsWarning is user-actionable; anything else
+        # raised on the load path -- a DeprecationWarning from a library
+        # internal, or a plain UserWarning such as a pydantic serializer
+        # warning or astropy's AstropyUserWarning -- should stay out of the
+        # banner.
         def fake_load(_self):
-            warnings.warn("this API is deprecated", DeprecationWarning, stacklevel=2)
+            warnings.warn("some library warning", category, stacklevel=2)
             return PartialPhotometrySettings()
 
         mocker.patch.object(
@@ -1592,6 +1600,42 @@ class TestReviewSettings:
         # the badge list and the tab title.
         assert review_settings.badges[0] == SaveStatus.SETTING_NOT_SAVED
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[0]
+
+    def test_tab_selection_picks_up_external_save(self):
+        # A badge latched at SETTING_NOT_SAVED must recover when the setting
+        # is saved by something other than this widget's own observers, e.g.
+        # another widget or a notebook writing the settings file. Selecting
+        # the tab used to trust a non-None badge unconditionally, so the
+        # not-saved badge stuck forever.
+        wd_settings = PhotometryWorkingDirSettings()
+
+        # PhotometryApertures autosaves its defaults during construction;
+        # deleting the settings file afterwards leaves its tab unsaved.
+        review = ReviewSettings([PhotometryApertures, Camera])
+        wd_settings.partial_settings_file.unlink(missing_ok=True)
+
+        # Switch away and back so the selection observer latches the badge
+        # at not-saved.
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+        assert review.badges[0] == SaveStatus.SETTING_NOT_SAVED
+
+        # Save the value displayed in the widget externally, i.e. through a
+        # fresh PhotometryWorkingDirSettings rather than the widget's own
+        # save machinery.
+        apertures = PhotometryApertures.model_validate(
+            review._setting_widgets[0]._autoui_widget.value
+        )
+        PhotometryWorkingDirSettings().save(
+            PartialPhotometrySettings(photometry_apertures=apertures), update=True
+        )
+
+        # Selecting the tab again re-derives the badge from disk instead of
+        # trusting the latched not-saved badge.
+        review._container.selected_index = 1
+        review._container.selected_index = 0
+        assert review.badges[0] == SaveStatus.SETTING_IS_SAVED
+        assert SaveStatus.SETTING_IS_SAVED in review._container.titles[0]
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1611,6 +1611,37 @@ class TestReviewSettings:
         assert "conflicting partial settings file will be preserved" in banner_text
         assert "partial_photometry_settings.json.bak" in banner_text
 
+    def test_construction_autosave_preserves_conflicting_partial(self):
+        # The save observers fire during construction with values taken
+        # from the full settings file (the fallback when the two settings
+        # files conflict), so the save that resolves the conflict is just
+        # echoing the full file's own camera back. It must still preserve
+        # the losing partial settings file -- whose camera value exists
+        # nowhere else -- as .bak, as the banner promises; it used to be
+        # deleted outright because the echoed camera counted as an
+        # explicit replacement.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text(full_settings.model_dump_json())
+
+        conflicting_camera = Camera(**TEST_CAMERA_VALUES)
+        conflicting_camera.gain = 2 * conflicting_camera.gain
+        partial_content = PartialPhotometrySettings(
+            camera=conflicting_camera
+        ).model_dump_json()
+        wd_settings.partial_settings_file.write_text(partial_content)
+
+        ReviewSettings([Camera])
+
+        assert not wd_settings.partial_settings_file.exists()
+        backup = wd_settings.partial_settings_file.with_name(
+            wd_settings.partial_settings_file.name + ".bak"
+        )
+        assert backup.read_text() == partial_content
+
     def test_banner_handles_invalid_utf8_settings_file(self):
         # Bytes that are not valid UTF-8 raise a UnicodeDecodeError while
         # reading the settings file; that must be handled the same as any
@@ -1748,17 +1779,13 @@ class TestReviewSettings:
         )
 
     def test_autosave_reemits_non_settings_warnings(self, mocker):
-        # The autosave suppression exists to keep PhotometrySettingsWarning
-        # from being printed once per autosave (the banner already shows
-        # it), but its recording context swallows every warning raised
-        # during the save. Anything that is not a PhotometrySettingsWarning
-        # (e.g. a serialization or file warning) must be re-emitted so the
-        # suppression does not eat unrelated warnings.
+        # The autosave suppression's recording context swallows every
+        # warning raised during the save. Anything that is not a
+        # PhotometrySettingsWarning (e.g. a serialization or file warning)
+        # must be re-emitted so the suppression does not eat unrelated
+        # warnings.
         def fake_save(_self, _settings, update=False):  # noqa: ARG001
             warnings.warn("unrelated library warning", UserWarning, stacklevel=2)
-            warnings.warn(
-                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
-            )
 
         mocker.patch.object(
             settings_files.PhotometryWorkingDirSettings, "save", fake_save
@@ -1770,11 +1797,28 @@ class TestReviewSettings:
             # autosaved during construction.
             ReviewSettings([PhotometryApertures])
 
-        messages = [str(w.message) for w in recorded]
-        assert "unrelated library warning" in messages
-        assert not any(
-            issubclass(w.category, PhotometrySettingsWarning) for w in recorded
+        assert "unrelated library warning" in [str(w.message) for w in recorded]
+
+    def test_autosave_reemits_unshown_settings_warnings(self, mocker):
+        # The autosave suppression exists because the banner already shows
+        # the PhotometrySettingsWarnings raised by the widget's own loads.
+        # A PhotometrySettingsWarning the banner has *not* shown -- e.g.
+        # one raised on the save path rather than by load() -- must be
+        # re-emitted rather than silenced.
+        def fake_save(_self, _settings, update=False):  # noqa: ARG001
+            warnings.warn(
+                "Problem while saving", PhotometrySettingsWarning, stacklevel=2
+            )
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "save", fake_save
         )
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            ReviewSettings([PhotometryApertures])
+
+        assert "Problem while saving" in [str(w.message) for w in recorded]
 
     def test_accordion_collapse_does_not_error(self):
         # An accordion with every section collapsed has selected_index None,

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1281,10 +1281,11 @@ class TestReviewSettings:
         assert review_settings._banner.layout.display == "flex"
         assert wd_settings.settings_file.read_text() == bad_content
 
-        # The message points out that saving will preserve the unreadable
-        # file with a .bak extension rather than overwrite it.
+        # The message names the unreadable file and points out that a save
+        # will not overwrite it, and that a save that needs to replace it
+        # will first preserve it with a .bak extension.
         assert "photometry_settings.json.bak" in banner_text
-        assert "rather than overwritten" in banner_text
+        assert "will not be overwritten" in banner_text
 
         # Only the first line of the error is in the visible message; the
         # rest of the validation error is inside a collapsed details element,
@@ -1296,21 +1297,15 @@ class TestReviewSettings:
         assert "Field required" in banner_text.split("<details>")[1]
 
     def test_banner_dismiss_button_stays_dismissed(self):
-        # Clicking the dismiss button hides the banner, and the same message
-        # does not come back when the settings are reloaded (which happens
-        # on every tab selection).
+        # Clicking the dismiss button hides the banner, and the message does
+        # not come back when the settings are reloaded (which happens on
+        # every tab selection). The automatic save of PhotometryApertures
+        # during construction writes a readable partial settings file, which
+        # changes the wording composed around the error on later refreshes;
+        # dismissal must stick anyway because it is keyed on the (stable)
+        # first line of the error, not on the full message text.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
-        # Pre-seed a valid (empty) partial settings file so that the
-        # automatic save triggered by PhotometryApertures during
-        # construction (see below) merely adds a key to an
-        # already-readable partial settings file, rather than making a
-        # previously-unreadable one readable. That keeps the banner
-        # message identical across every refresh in this test, which is
-        # what "stays dismissed" is meant to exercise.
-        wd_settings.partial_settings_file.write_text(
-            PartialPhotometrySettings().model_dump_json()
-        )
 
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
@@ -1380,6 +1375,42 @@ class TestReviewSettings:
         review_settings._container.selected_index = 1
         assert review_settings._dismissed_messages == set()
 
+    def test_banner_message_updates_instead_of_duplicating(self):
+        # The wording composed around a load error can change between
+        # refreshes for the same underlying problem: here the corrupt full
+        # settings file first has no readable companion ("None of the values
+        # below..."), then the automatic save of PhotometryApertures during
+        # construction writes a readable partial settings file, so later
+        # refreshes report the partial file as the fallback. The banner must
+        # show exactly one message, updated in place to the latest wording,
+        # not one near-duplicate per wording.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+
+        banner_text = review_settings._banner_html.value
+        assert banner_text.count("There is a problem with the saved settings") == 1
+
+        # Selecting a tab triggers another refresh; still just one message.
+        review_settings._container.selected_index = 1
+        banner_text = review_settings._banner_html.value
+        assert banner_text.count("There is a problem with the saved settings") == 1
+
+        # The message reflects the latest wording: the autosaved partial
+        # settings file is now the readable fallback, and the original
+        # "no readable settings" sentence has been replaced in place.
+        assert "come from the partial settings file" in banner_text
+        assert "None of the values below" not in banner_text
+
+    def test_current_settings_fresh_after_construction(self):
+        # Widget construction itself saves settings (PhotometryApertures can
+        # be built from defaults and is autosaved), so the snapshot taken at
+        # the top of construction goes stale before the constructor returns.
+        # The refresh at the end of construction must pick up those saves.
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        assert review_settings.current_settings.photometry_apertures is not None
+
     def test_banner_uses_readable_settings_as_fallback(self):
         # If the partial settings file cannot be read but the full settings
         # file is fine, the widget should still be built from the readable
@@ -1397,28 +1428,17 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
-        assert "could still be read" in banner_text
+        assert "come from the full settings file" in banner_text
         assert review_settings.current_settings.camera == full_settings.camera
-
-    def test_banner_names_unreadable_settings_file(self):
-        # The banner should name the specific file that could not be read
-        # so the user knows what a subsequent save would preserve as .bak.
-        wd_settings = PhotometryWorkingDirSettings()
-        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
-
-        review_settings = ReviewSettings([Camera])
-
-        banner_text = review_settings._banner_html.value
-        assert "photometry_settings.json.bak" in banner_text
-        assert "rather than overwritten" in banner_text
 
     def test_banner_conflict_wording_when_both_files_readable(self):
         # When both the full and partial settings files are individually
         # readable but disagree with each other, the "this file could not
         # be read" wording would be misleading -- both files were read
-        # just fine. The banner should instead point out that the
-        # conflicting (losing) partial settings file will be kept as a
-        # .bak when full settings are next saved.
+        # just fine. The banner should instead say that the values shown
+        # come from the (preferred) full settings file and that saving full
+        # settings resolves the conflict, keeping the conflicting (losing)
+        # partial settings file as a .bak.
         saved = SavedSettings()
         saved.add_item(Camera(**TEST_CAMERA_VALUES))
 
@@ -1436,7 +1456,9 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
-        assert "rather than overwritten" not in banner_text
+        assert "will not be overwritten" not in banner_text
+        assert "come from the full settings file" in banner_text
+        assert "resolve the conflict" in banner_text
         assert "conflicting partial settings file will be preserved" in banner_text
         assert "partial_photometry_settings.json.bak" in banner_text
 

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1380,26 +1380,24 @@ class TestReviewSettings:
         # The automatic save for PhotometryApertures fires during
         # construction and renames the bad partial settings file to .bak,
         # so the refresh at the end of construction already finds the
-        # problem cured -- the message is shown, in its resolved wording.
+        # problem cured -- the message is shown, marked as no longer
+        # detected.
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "A problem with the saved settings" in banner_text
+        assert "There is a problem with the saved settings" in banner_text
 
         # Selecting the PhotometryApertures tab triggers another refresh.
         # The load succeeds now, but the message should still be shown
-        # because the user never dismissed it -- now in its past-tense
-        # resolved wording instead of asserting the (no longer true)
-        # original claim or making a future-tense .bak promise about a
-        # rename that already happened.
+        # because the user never dismissed it -- prefixed with "no longer
+        # detected" so the original report is clearly framed as past, and
+        # its mention of the .bak file still tells the user where the
+        # renamed content went.
         review_settings._container.selected_index = 1
         assert review_settings._banner.layout.display == "flex"
         banner_text = review_settings._banner_html.value
-        assert "A problem with the saved settings" in banner_text
-        assert "no longer detected as of the latest reload" in banner_text
-        assert "There is a problem" not in banner_text
-        assert "will not be overwritten" not in banner_text
-        assert "was preserved as" in banner_text
+        assert "No longer detected as of the latest reload" in banner_text
+        assert "There is a problem with the saved settings" in banner_text
         assert "partial_photometry_settings.json.bak" in banner_text
 
         # Dismissing hides it...
@@ -1515,7 +1513,7 @@ class TestReviewSettings:
         review._container.selected_index = 1
 
         assert review._banner.layout.display == "flex"
-        assert "no longer detected as of the latest reload" in review._banner_html.value
+        assert "No longer detected as of the latest reload" in review._banner_html.value
 
     def test_banner_message_updates_instead_of_duplicating(self):
         # The wording composed around a load error can change between
@@ -1750,7 +1748,7 @@ class TestReviewSettings:
 
         banner_text = review_settings._banner_html.value
         # The autosave cures the problem during construction, so the message
-        # is already in its past-tense resolved wording by this point.
+        # is already marked "no longer detected" by this point.
         assert "problem with the saved settings" in banner_text
         backup = wd_settings.partial_settings_file.with_name(
             wd_settings.partial_settings_file.name + ".bak"
@@ -1759,12 +1757,10 @@ class TestReviewSettings:
 
     def test_autosave_does_not_print_settings_warnings(self, mocker):
         # A settings-migration warning raised while loading should reach the
-        # banner exactly once. Without the fix, it would also be printed to
-        # the console once per autosaved setting: the widget's own explicit
-        # loads (which feed the banner) route the warning through their own
-        # recording context, but the autosave triggered during construction
-        # calls save(), whose internal bookkeeping load deliberately lets
-        # PhotometrySettingsWarning through.
+        # banner exactly once. Without the suppression, it would also be
+        # printed to the console once per autosaved setting: the autosave
+        # triggered during construction calls save(), which re-emits any
+        # PhotometrySettingsWarning from its internal bookkeeping load.
         def fake_load(_self):
             warnings.warn(
                 "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
@@ -1787,11 +1783,10 @@ class TestReviewSettings:
         )
 
     def test_autosave_reemits_non_settings_warnings(self, mocker):
-        # The autosave suppression's recording context swallows every
-        # warning raised during the save. Anything that is not a
-        # PhotometrySettingsWarning (e.g. a serialization or file warning)
-        # must be re-emitted so the suppression does not eat unrelated
-        # warnings.
+        # The autosave suppression is a filter scoped to
+        # PhotometrySettingsWarning. Anything else raised during the save
+        # (e.g. a serialization or file warning) must still get out so the
+        # suppression does not eat unrelated warnings.
         def fake_save(_self, _settings, update=False):  # noqa: ARG001
             warnings.warn("unrelated library warning", UserWarning, stacklevel=2)
 
@@ -1807,12 +1802,13 @@ class TestReviewSettings:
 
         assert "unrelated library warning" in [str(w.message) for w in recorded]
 
-    def test_autosave_reemits_unshown_settings_warnings(self, mocker):
-        # The autosave suppression exists because the banner already shows
-        # the PhotometrySettingsWarnings raised by the widget's own loads.
-        # A PhotometrySettingsWarning the banner has *not* shown -- e.g.
-        # one raised on the save path rather than by load() -- must be
-        # re-emitted rather than silenced.
+    def test_autosave_silences_all_settings_warnings(self, mocker):
+        # The banner is the display channel for PhotometrySettingsWarning,
+        # so autosaves silence the whole category -- including one raised on
+        # the save path itself that the banner has not shown. Such a warning
+        # reaches the banner on the next refresh if it also comes from
+        # load(); a warning unique to the save path is dropped, which is the
+        # accepted price of keeping the suppression a simple filter.
         def fake_save(_self, _settings, update=False):  # noqa: ARG001
             warnings.warn(
                 "Problem while saving", PhotometrySettingsWarning, stacklevel=2
@@ -1826,7 +1822,7 @@ class TestReviewSettings:
             warnings.simplefilter("always")
             ReviewSettings([PhotometryApertures])
 
-        assert "Problem while saving" in [str(w.message) for w in recorded]
+        assert "Problem while saving" not in [str(w.message) for w in recorded]
 
     def test_accordion_collapse_does_not_error(self):
         # An accordion with every section collapsed has selected_index None,

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -53,6 +53,16 @@ TEST_PASSBAND_MAP = deepcopy(TEST_PASSBAND_MAP)
 TEST_PHOTOMETRY_SETTINGS = deepcopy(TEST_PHOTOMETRY_SETTINGS)
 
 
+def _settings_panes_inert(review):
+    """
+    True when every settings pane is greyed out, False when none is;
+    fails the test if the panes disagree.
+    """
+    flags = {_INERT_CLASS in pane._dom_classes for pane in review._container.children}
+    assert len(flags) == 1
+    return flags.pop()
+
+
 # See test_settings_file.TestSavedSettings for a detailed description of what the
 # following fixture does. In brief, it patches the settings_files.PlatformDirs class
 # so that the user_data_dir method returns the temporary directory.
@@ -1298,7 +1308,7 @@ class TestReviewSettings:
         assert review_settings._banner_dismiss.layout.display == "none"
         assert review_settings._banner_fix.layout.display == ""
         assert review_settings._banner_reload.layout.display == ""
-        assert _INERT_CLASS in review_settings._container._dom_classes
+        assert _settings_panes_inert(review_settings)
 
         # The visible message stays short; the whole error, first line
         # included, is inside a collapsed details element, formatted in a
@@ -1337,7 +1347,7 @@ class TestReviewSettings:
         # enabled, and no fix button.
         assert review_settings._banner.layout.border == _CALM_BORDER
         assert review_settings._banner_dismiss.layout.display == ""
-        assert _INERT_CLASS not in review_settings._container._dom_classes
+        assert not _settings_panes_inert(review_settings)
         assert review_settings._banner_fix.layout.display == "none"
 
     def test_banner_reports_both_files_unreadable(self):
@@ -1676,7 +1686,7 @@ class TestReviewSettings:
         assert review_settings._banner_fix.layout.display == "none"
         assert review_settings._banner_keep.layout.display == ""
         assert review_settings._banner_reload.layout.display == ""
-        assert _INERT_CLASS in review_settings._container._dom_classes
+        assert _settings_panes_inert(review_settings)
 
     def test_banner_keep_values_button_resolves_conflict(self):
         # Clicking "Keep the values shown" saves the displayed values --
@@ -1722,7 +1732,7 @@ class TestReviewSettings:
         )
         assert backup.read_text() == conflicting_content
         assert review._banner_keep.layout.display == "none"
-        assert _INERT_CLASS not in review._container._dom_classes
+        assert not _settings_panes_inert(review)
 
     def test_banner_reload_button_after_hand_repair(self):
         # The Reload button is the repair-by-hand path: once the user fixes
@@ -1735,7 +1745,7 @@ class TestReviewSettings:
         review = ReviewSettings([Camera])
         assert review._load_error_active
         assert review._banner_reload.layout.display == ""
-        assert _INERT_CLASS in review._container._dom_classes
+        assert _settings_panes_inert(review)
 
         # The user deletes the broken file by hand, then clicks Reload.
         wd_settings.settings_file.unlink()
@@ -1752,7 +1762,7 @@ class TestReviewSettings:
         assert ".bak" not in banner_text
         assert review._banner_reload.layout.display == "none"
         assert review._banner_dismiss.layout.display == ""
-        assert _INERT_CLASS not in review._container._dom_classes
+        assert not _settings_panes_inert(review)
 
     def test_banner_duplicate_partial_oserror(self, mocker):
         # When the partial settings file is an exact duplicate of the full

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -27,6 +27,7 @@ from stellarphot.settings import (
     PassbandMap,
     PhotometryApertures,
     PhotometryOptionalSettings,
+    PhotometrySettings,
     PhotometryWorkingDirSettings,
     SavedSettings,
     SourceLocationSettings,
@@ -1282,7 +1283,8 @@ class TestReviewSettings:
 
         # The message points out that saving will preserve the unreadable
         # file with a .bak extension rather than overwrite it.
-        assert "renamed with a .bak extension" in banner_text
+        assert "photometry_settings.json.bak" in banner_text
+        assert "rather than overwritten" in banner_text
 
         # Only the first line of the error is in the visible message; the
         # rest of the validation error is inside a collapsed details element,
@@ -1299,6 +1301,16 @@ class TestReviewSettings:
         # on every tab selection).
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+        # Pre-seed a valid (empty) partial settings file so that the
+        # automatic save triggered by PhotometryApertures during
+        # construction (see below) merely adds a key to an
+        # already-readable partial settings file, rather than making a
+        # previously-unreadable one readable. That keeps the banner
+        # message identical across every refresh in this test, which is
+        # what "stays dismissed" is meant to exercise.
+        wd_settings.partial_settings_file.write_text(
+            PartialPhotometrySettings().model_dump_json()
+        )
 
         review_settings = ReviewSettings([Camera, PhotometryApertures])
         assert review_settings._banner.layout.display == "flex"
@@ -1311,6 +1323,134 @@ class TestReviewSettings:
         # dismissed message should stay dismissed.
         review_settings._container.selected_index = 1
         assert review_settings._banner.layout.display == "none"
+
+    def test_banner_message_stays_after_underlying_problem_resolves(self):
+        # A banner message must not silently disappear once the user has
+        # had a chance to see it, even if a later refresh no longer
+        # reproduces the underlying problem. This matters because the
+        # automatic save that happens during widget construction (for a
+        # setting like PhotometryApertures that can be built from defaults)
+        # can itself cure the problem -- e.g. by renaming an unreadable
+        # partial settings file to .bak -- before the user has dismissed
+        # anything.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        # The automatic save for PhotometryApertures fires during
+        # construction and renames the bad partial settings file to .bak,
+        # which means the *next* load from disk will succeed.
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        assert review_settings._banner.layout.display == "flex"
+        message = review_settings._banner_html.value
+        assert message
+
+        # Selecting the PhotometryApertures tab triggers another refresh.
+        # The load succeeds now, but the message should still be shown
+        # because the user never dismissed it.
+        review_settings._container.selected_index = 1
+        assert review_settings._banner.layout.display == "flex"
+        assert review_settings._banner_html.value == message
+
+        # Dismissing hides it...
+        review_settings._banner_dismiss.click()
+        assert review_settings._banner.layout.display == "none"
+        assert review_settings._banner_html.value == ""
+
+        # ... and it stays hidden across further refreshes.
+        review_settings._container.selected_index = 0
+        assert review_settings._banner.layout.display == "none"
+
+    def test_dismissed_messages_pruned_once_no_longer_produced(self):
+        # The set of dismissed messages should not grow without bound: once
+        # a dismissed message is no longer produced by a refresh, it should
+        # be dropped so that an unrelated, differently-worded problem later
+        # is shown rather than being mistaken for something dismissed.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+        assert review_settings._banner.layout.display == "flex"
+
+        review_settings._banner_dismiss.click()
+        assert review_settings._dismissed_messages
+
+        # The bad partial settings file was renamed to .bak during
+        # construction, so this refresh succeeds and no longer produces the
+        # dismissed message; it should be pruned from the dismissed set.
+        review_settings._container.selected_index = 1
+        assert review_settings._dismissed_messages == set()
+
+    def test_banner_uses_readable_settings_as_fallback(self):
+        # If the partial settings file cannot be read but the full settings
+        # file is fine, the widget should still be built from the readable
+        # full settings rather than falling all the way back to empty
+        # settings, and the banner should say so.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.save(full_settings)
+        wd_settings.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+        assert "could still be read" in banner_text
+        assert review_settings.current_settings.camera == full_settings.camera
+
+    def test_banner_names_unreadable_settings_file(self):
+        # The banner should name the specific file that could not be read
+        # so the user knows what a subsequent save would preserve as .bak.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert "photometry_settings.json.bak" in banner_text
+        assert "rather than overwritten" in banner_text
+
+    def test_banner_conflict_wording_when_both_files_readable(self):
+        # When both the full and partial settings files are individually
+        # readable but disagree with each other, the "this file could not
+        # be read" wording would be misleading -- both files were read
+        # just fine. The banner should instead point out that the
+        # conflicting (losing) partial settings file will be kept as a
+        # .bak when full settings are next saved.
+        saved = SavedSettings()
+        saved.add_item(Camera(**TEST_CAMERA_VALUES))
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text(full_settings.model_dump_json())
+
+        conflicting_camera = Camera(**TEST_CAMERA_VALUES)
+        conflicting_camera.gain = 2 * conflicting_camera.gain
+        wd_settings.partial_settings_file.write_text(
+            PartialPhotometrySettings(camera=conflicting_camera).model_dump_json()
+        )
+
+        review_settings = ReviewSettings([Camera])
+
+        banner_text = review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+        assert "rather than overwritten" not in banner_text
+        assert "conflicting partial settings file will be preserved" in banner_text
+        assert "partial_photometry_settings.json.bak" in banner_text
+
+    def test_banner_handles_invalid_utf8_settings_file(self):
+        # Bytes that are not valid UTF-8 raise a UnicodeDecodeError while
+        # reading the settings file; that must be handled the same as any
+        # other unreadable settings file rather than propagating out of
+        # widget construction.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_bytes(b"\xff\xfe not utf8")
+
+        review_settings = ReviewSettings([Camera])
+
+        assert review_settings._banner.layout.display == "flex"
 
     def test_banner_shows_warnings_from_loading_settings(self, mocker):
         # Warnings generated while loading settings (e.g. a settings-format

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1276,7 +1276,7 @@ class TestReviewSettings:
         review_settings = ReviewSettings([Camera, PhotometryApertures])
 
         banner_text = review_settings._banner_html.value
-        assert "Unable to read the saved settings" in banner_text
+        assert "There is a problem with the saved settings" in banner_text
         assert review_settings._banner.layout.display == "flex"
         assert wd_settings.settings_file.read_text() == bad_content
 
@@ -1392,7 +1392,7 @@ class TestReviewSettings:
         review_settings = ReviewSettings([Camera, PhotometryApertures])
 
         banner_text = review_settings._banner_html.value
-        assert "Unable to read the saved settings" in banner_text
+        assert "There is a problem with the saved settings" in banner_text
         backup = wd_settings.partial_settings_file.with_name(
             wd_settings.partial_settings_file.name + ".bak"
         )
@@ -1407,6 +1407,29 @@ class TestReviewSettings:
         review_settings._container.selected_index = 0
         review_settings._container.selected_index = None
         # Reaching this point without an exception is the test
+
+    def test_tab_selection_marks_unsaved_setting(self):
+        # Selecting a tab whose setting is not saved on disk should set that
+        # tab's badge to SETTING_NOT_SAVED. This used to silently do nothing
+        # because the selection observer rebound a local variable instead of
+        # setting the widget's badge.
+        wd_settings = PhotometryWorkingDirSettings()
+
+        # PhotometryApertures can be created from default values, so it is
+        # saved automatically when the widget is created; deleting the
+        # settings file afterwards leaves its tab in the not-saved state.
+        review_settings = ReviewSettings([PhotometryApertures, Camera])
+        wd_settings.partial_settings_file.unlink(missing_ok=True)
+
+        # Switch away from the apertures tab and back so the selection
+        # observer fires for it.
+        review_settings._container.selected_index = 1
+        review_settings._container.selected_index = 0
+
+        # Setting the widget badge triggers the observer that copies it into
+        # the badge list and the tab title.
+        assert review_settings.badges[0] == SaveStatus.SETTING_NOT_SAVED
+        assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[0]
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1347,9 +1347,9 @@ class TestReviewSettings:
         # during construction writes a readable partial settings file, which
         # changes the wording composed around the error on later refreshes;
         # dismissal must stick anyway because it is keyed on the load
-        # error's fixed identity plus a fingerprint of its first line, and
-        # that first line stays stable across these refreshes even though
-        # the surrounding wording changes.
+        # error's fixed identity plus a fingerprint of its full text, and
+        # that text stays stable across these refreshes even though the
+        # wording composed around it changes.
         wd_settings = PhotometryWorkingDirSettings()
         wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
 
@@ -1445,6 +1445,45 @@ class TestReviewSettings:
 
         assert review._banner.layout.display == "flex"
         assert "There is a problem with the saved settings" in review._banner_html.value
+
+    def test_dismissed_load_error_reappears_when_error_detail_changes(self):
+        # Two different corruptions of the same file can share the same
+        # generic first line ("Error loading settings: N validation errors
+        # for ..."); a dismissal of one must not suppress the other, so the
+        # fingerprint is the full error text.
+        wd_settings = PhotometryWorkingDirSettings()
+        wd_settings.settings_file.write_text('{"camera": 12}')
+
+        review = ReviewSettings([Camera])
+        review._banner_dismiss.click()
+        assert review._banner.layout.display == "none"
+
+        # A different corruption with the same number of validation errors,
+        # so the first line of the error is unchanged but the details are
+        # not. Verify the premise so this test fails loudly if pydantic's
+        # error formatting changes.
+        wd_settings.settings_file.write_text('{"observatory": 17}')
+        with pytest.raises(ValueError) as exc_info:
+            PhotometryWorkingDirSettings().load()
+        assert "validation error" in str(exc_info.value).splitlines()[0]
+
+        review._refresh()
+        assert review._banner.layout.display == "flex"
+
+    def test_tab_selection_refreshes_banner_even_with_positive_badge(self):
+        # A problem that arises after construction must surface in the
+        # banner on the next tab selection even when the selected tab's
+        # badge is positive, i.e. when no badge re-derivation from disk
+        # would otherwise happen.
+        wd_settings = PhotometryWorkingDirSettings()
+        review = ReviewSettings([Camera, PhotometryApertures])
+        assert review._banner.layout.display == "none"
+
+        review._setting_widgets[1].badge = SaveStatus.SETTING_IS_SAVED
+        wd_settings.settings_file.write_text('{"pasta": "carbonara"}')
+
+        review._container.selected_index = 1
+        assert review._banner.layout.display == "flex"
 
     def test_banner_marks_resolved_problem(self):
         # When an autosave triggered by a tab selection cures the underlying

--- a/stellarphot/gui/views.py
+++ b/stellarphot/gui/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from ipyautoui import AutoUi
 from ipywidgets import Layout
 
@@ -7,6 +9,22 @@ from stellarphot.settings.models import (
 )
 
 __all__ = ["ui_generator"]
+
+
+def _drop_missing_path_warning(record):
+    return "path given doesnt exist" not in record.getMessage()
+
+
+# ipyautoui's FileChooser logs a warning whenever it is built with a path that
+# does not exist. Settings like SourceLocationSettings default to a file name
+# that is not there yet in a new working directory, so this fires on every
+# fresh widget to report an entirely normal situation -- and the message names
+# no path, so there is nothing actionable to lose by dropping it. A filter on
+# the one message, rather than raising the logger's level, keeps anything else
+# that module logs. This is a process-wide mutation of a third-party logger at
+# import time, accepted because the alternative is threading suppression
+# scaffolding through widget construction to silence a single string.
+logging.getLogger("ipyautoui.custom.filechooser").addFilter(_drop_missing_path_warning)
 
 
 def ui_generator(model, max_field_width=None, file_chooser_max_width=None):

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from pathlib import Path
 from typing import ClassVar
 
@@ -407,7 +408,13 @@ class PhotometryWorkingDirSettings:
         full_settings = False
 
         try:
-            _ = self.load()
+            # This load is internal bookkeeping; any warnings it generates
+            # (e.g. a settings-format migration message) were already shown
+            # when the settings were first loaded, so don't repeat them on
+            # every save.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                _ = self.load()
         except ValueError:
             # If we catch a ValueError, then we are in a situation where we have no
             # settings files. We can proceed to save the settings.

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -689,6 +689,9 @@ class PhotometryWorkingDirSettings:
             If no settings file exists, if a settings file exists but cannot
             be read, or if the partial and full settings files are both
             readable but conflict with each other.
+        OSError
+            If deleting a partial settings file that exactly duplicates the
+            full settings file fails (e.g. in a read-only directory).
         """
         # Assume we have nothing to begin....
         self._partial_settings = None

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -475,7 +475,12 @@ class PhotometryWorkingDirSettings:
         case where the partial settings conflict with the full settings.
         Partial values that differ from the written settings only because
         the ``settings`` argument explicitly replaced them do not trigger
-        the backup: the caller supplied the new value deliberately.
+        the backup: the caller supplied the new value deliberately. That
+        exclusion does not apply when the on-disk partial settings
+        conflicted with the on-disk full settings -- the "caller" may just
+        be echoing the full settings back, as the
+        `~stellarphot.gui.ReviewSettings` autosaves do -- so the losing
+        partial file is then always preserved.
         Existing backups are never overwritten; if a ``.bak`` file already
         exists, numbered suffixes (``.bak1``, ``.bak2``, ...) are used
         instead.
@@ -493,13 +498,14 @@ class PhotometryWorkingDirSettings:
                 warnings.simplefilter("ignore")
                 warnings.simplefilter("default", PhotometrySettingsWarning)
                 _ = self.load()
-        except ValueError:
+        except (ValueError, OSError):
             # load() raises ValueError when there are no settings files at
             # all, when a file exists but cannot be read, and when readable
-            # partial and full settings conflict. The save proceeds in every
-            # one of those cases; the unreadable-file cases rely on the
-            # snapshot below so the problem file is set aside as .bak
-            # rather than destroyed.
+            # partial and full settings conflict; it raises OSError when
+            # tidying a duplicate partial settings file fails (e.g. in a
+            # read-only directory). The save proceeds in every one of those
+            # cases; the unreadable-file cases rely on the flags below so
+            # the problem file is set aside as .bak rather than destroyed.
             pass
 
         # Whether each existing settings file failed to parse during the
@@ -509,6 +515,20 @@ class PhotometryWorkingDirSettings:
         # about to be replaced is renamed aside instead of destroyed.
         unreadable_full = self.full_settings_unreadable
         unreadable_partial = self.partial_settings_unreadable
+
+        # After a successful load at most one of the in-memory settings is
+        # non-None (a duplicate partial file is tidied away). Both being
+        # non-None means the load above raised with the partial file
+        # unresolved: the files conflicted, or tidying failed. Either way
+        # the partial file's differing values were never confirmed as
+        # replaced by anyone -- a save "replacing" a value may just be
+        # echoing the full settings file back, as the ReviewSettings
+        # construction autosaves do -- so the explicit-replacement
+        # exclusion at disposal time does not apply and the partial file
+        # is backed up whenever any of its values would be lost.
+        partial_unresolved = (
+            self._settings is not None and self._partial_settings is not None
+        )
 
         match settings:
             case PartialPhotometrySettings():
@@ -599,13 +619,15 @@ class PhotometryWorkingDirSettings:
                     f"not {type(settings)}"
                 )
 
-        # If the file we are about to write exists but could not be read, rename
-        # it aside so its contents are preserved rather than overwritten. This
-        # must happen before the write below, which would clobber the file.
-        if file == self._settings_file and unreadable_full:
-            self._move_aside(self._settings_file)
-        elif file == self._partial_settings_file and unreadable_partial:
-            self._move_aside(self._partial_settings_file)
+        # If the file we are about to write exists but could not be read, its
+        # contents must be set aside rather than overwritten. The rename
+        # happens between writing the temporary file and the replace below,
+        # so a failure while writing the new content leaves the unreadable
+        # file in place under its original name instead of leaving no
+        # settings file at all.
+        set_aside_target = (file == self._settings_file and unreadable_full) or (
+            file == self._partial_settings_file and unreadable_partial
+        )
 
         # Write the settings to a file. The settings themselves are models, so we
         # are guaranteed to write the correct model type (partial or full settings)
@@ -616,6 +638,8 @@ class PhotometryWorkingDirSettings:
         tmp_file = file.with_name(file.name + ".tmp")
         try:
             tmp_file.write_text(json_data, encoding=ENCODING)
+            if set_aside_target:
+                self._move_aside(file)
             tmp_file.replace(file)
         finally:
             # After a successful replace the temporary file no longer exists,
@@ -639,7 +663,9 @@ class PhotometryWorkingDirSettings:
             # -- so this comparison is against the pre-save partial settings.
             written = settings.model_dump()
             partial_values_lost = self._partial_settings is not None and any(
-                v is not None and written.get(k) != v and k not in explicitly_replaced
+                v is not None
+                and written.get(k) != v
+                and (partial_unresolved or k not in explicitly_replaced)
                 for k, v in self._partial_settings.model_dump().items()
             )
             if unreadable_partial or partial_values_lost:

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -306,6 +306,7 @@ class PhotometryWorkingDirSettings:
         )
         self._partial_settings = None
         self._settings = None
+        self._load_attempted = False
 
     @property
     def settings(self):
@@ -325,21 +326,27 @@ class PhotometryWorkingDirSettings:
     def full_settings_unreadable(self):
         """
         True when the full settings file exists on disk but could not be read
-        by the most recent `load`. Only meaningful after `load` has been
-        called on this instance -- before any load, the in-memory settings
-        are None, so an existing readable file would also report True.
+        by the most recent `load`. Always False before `load` has been called
+        on this instance.
         """
-        return self._settings_file.exists() and self._settings is None
+        return (
+            self._load_attempted
+            and self._settings_file.exists()
+            and self._settings is None
+        )
 
     @property
     def partial_settings_unreadable(self):
         """
         True when the partial settings file exists on disk but could not be
-        read by the most recent `load`. Only meaningful after `load` has been
-        called on this instance -- before any load, the in-memory settings
-        are None, so an existing readable file would also report True.
+        read by the most recent `load`. Always False before `load` has been
+        called on this instance.
         """
-        return self._partial_settings_file.exists() and self._partial_settings is None
+        return (
+            self._load_attempted
+            and self._partial_settings_file.exists()
+            and self._partial_settings is None
+        )
 
     # Properties for settings file and partial settings file
     @property
@@ -515,6 +522,14 @@ class PhotometryWorkingDirSettings:
                     if not update:
                         # If so, we can't save partial settings if the update flag
                         # is False.
+                        if unreadable_full:
+                            raise ValueError(
+                                "Cannot save partial settings: a full settings file "
+                                f"exists at {self._settings_file} but could not be "
+                                "read. Fix or remove that file, or save with "
+                                "update=True, which saves the partial settings and "
+                                "leaves the unreadable file in place."
+                            )
                         raise ValueError(
                             "Cannot save partial settings when full "
                             "settings already exist."
@@ -630,6 +645,8 @@ class PhotometryWorkingDirSettings:
         PhotometrySettings | PartialPhotometrySettings | None
             The settings loaded from disk, or None if there are no settings files.
         """
+        self._load_attempted = True
+
         # Assume we have nothing to begin....
         self._partial_settings = None
         self._settings = None

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -555,7 +555,8 @@ class PhotometryWorkingDirSettings:
                                 f"exists at {self._settings_file} but could not be "
                                 "read. Fix or remove that file, or save with "
                                 "update=True, which saves the partial settings and "
-                                "leaves the unreadable file in place."
+                                "preserves the unreadable file -- in place, or as a "
+                                ".bak backup if the save produces complete settings."
                             )
                         raise ValueError(
                             "Cannot save partial settings when full "

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -423,9 +423,12 @@ class PhotometryWorkingDirSettings:
         while backup.exists():
             counter += 1
             backup = path.with_name(f"{path.name}.bak{counter}")
-        # replace() rather than rename() so that the (unlikely) race of the
-        # chosen backup name being created between the exists() check and
-        # the rename still succeeds on every platform.
+        # replace() gives deterministic cross-platform behavior. In the
+        # (unlikely) race where the chosen backup name is created between
+        # the exists() check above and this call, the just-created file is
+        # silently overwritten -- a narrow window this single-user,
+        # widget-driven code accepts. rename() would not close it either:
+        # os.rename also silently replaces an existing file on POSIX.
         path.replace(backup)
         return backup
 
@@ -473,16 +476,23 @@ class PhotometryWorkingDirSettings:
         full_settings = False
 
         try:
-            # This load is internal bookkeeping; any warnings it generates
-            # (e.g. a settings-format migration message) were already shown
-            # when the settings were first loaded, so don't repeat them on
-            # every save.
+            # This load is internal bookkeeping. Library warnings it
+            # generates were already surfaced when the settings were first
+            # loaded, so don't repeat them on every save -- but let
+            # PhotometrySettingsWarning through, so a caller whose first
+            # interaction with the settings is a save() still sees
+            # user-actionable problems such as a settings-format migration.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                warnings.simplefilter("default", PhotometrySettingsWarning)
                 _ = self.load()
         except ValueError:
-            # If we catch a ValueError, then we are in a situation where we have no
-            # settings files. We can proceed to save the settings.
+            # load() raises ValueError when there are no settings files at
+            # all, when a file exists but cannot be read, and when readable
+            # partial and full settings conflict. The save proceeds in every
+            # one of those cases; the unreadable-file cases rely on the
+            # snapshot below so the problem file is set aside as .bak
+            # rather than destroyed.
             pass
 
         # A file that is unreadable failed to parse during the load above.
@@ -572,11 +582,18 @@ class PhotometryWorkingDirSettings:
 
         # Write the settings to a file. The settings themselves are models, so we
         # are guaranteed to write the correct model type (partial or full settings)
-        # to the file. Serialize before opening the file so that a failure to
-        # serialize cannot truncate an existing settings file.
+        # to the file. Write to a temporary file in the same directory and then
+        # atomically replace the target, so that a failure at any point during
+        # serialization or writing leaves any existing settings file untouched.
         json_data = settings.model_dump_json(indent=4)
-        with file.open("w", encoding=ENCODING) as f:
-            f.write(json_data)
+        tmp_file = file.with_name(file.name + ".tmp")
+        try:
+            tmp_file.write_text(json_data, encoding=ENCODING)
+            tmp_file.replace(file)
+        finally:
+            # After a successful replace the temporary file no longer exists,
+            # so this only cleans up after a failed write.
+            tmp_file.unlink(missing_ok=True)
 
         if full_settings:
             # Now that the full settings that supersede the partial settings
@@ -686,9 +703,9 @@ class PhotometryWorkingDirSettings:
 
         if full_from_partial != self._settings:
             raise ValueError(
-                "Partial settings and full settings do not match. Please "
-                "resolve the discrepancy by deleting one of the settings "
-                "files.\n"
+                "Partial settings and full settings do not match.\n"
+                "Saving full settings will resolve the conflict; the partial "
+                "settings file will be preserved with a .bak suffix.\n"
                 f"Folder with settings: {self._working_dir}\n"
                 f"Partial settings: {self._partial_settings_file}\n"
                 f"Full settings: {self._settings_file}"

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -404,6 +404,10 @@ class PhotometryWorkingDirSettings:
         Finally, if we are passed a partial setting and there is a full setting on disk,
         then the partial settings are merged with the full settings, and the full
         settings are saved.
+
+        An existing settings file that cannot be read is never overwritten in
+        place; it is renamed with a ``.bak`` suffix before the new settings are
+        written.
         """
         full_settings = False
 
@@ -419,6 +423,18 @@ class PhotometryWorkingDirSettings:
             # If we catch a ValueError, then we are in a situation where we have no
             # settings files. We can proceed to save the settings.
             pass
+
+        # A file that exists on disk but whose in-memory settings are None
+        # failed to parse during the load above. Note the two flags now,
+        # before the code below reassigns the in-memory settings, so that
+        # the unreadable file can be renamed aside instead of destroyed.
+        # If the load failed on the partial file then the full file was
+        # never parsed, so this may occasionally set aside a .bak for a
+        # readable full file -- that errs on the side of preserving data.
+        unreadable_full = self._settings_file.exists() and self._settings is None
+        unreadable_partial = (
+            self._partial_settings_file.exists() and self._partial_settings is None
+        )
 
         match settings:
             case PartialPhotometrySettings():
@@ -449,7 +465,8 @@ class PhotometryWorkingDirSettings:
                     # If the settings file exists but could not be read then
                     # self._settings is None and there is nothing to merge the
                     # partial settings into. The partial settings are saved on
-                    # their own and the unreadable file is left in place.
+                    # their own and the unreadable file is renamed with a .bak
+                    # suffix before anything overwrites it.
 
                 # Are we updating or replacing partial settings?
                 if update and self._partial_settings is not None:
@@ -487,8 +504,31 @@ class PhotometryWorkingDirSettings:
                 )
 
         if full_settings:
-            self._partial_settings_file.unlink(missing_ok=True)
+            if unreadable_partial:
+                # Preserve the unreadable partial file instead of deleting it.
+                # Use replace rather than rename so that an existing .bak file
+                # is overwritten on all platforms.
+                self._partial_settings_file.replace(
+                    self._partial_settings_file.with_name(
+                        self._partial_settings_file.name + ".bak"
+                    )
+                )
+            else:
+                self._partial_settings_file.unlink(missing_ok=True)
             self._partial_settings = None
+
+        # If the file we are about to write exists but could not be read, rename
+        # it aside so its contents are preserved rather than overwritten.
+        if file == self._settings_file and unreadable_full:
+            self._settings_file.replace(
+                self._settings_file.with_name(self._settings_file.name + ".bak")
+            )
+        elif file == self._partial_settings_file and unreadable_partial:
+            self._partial_settings_file.replace(
+                self._partial_settings_file.with_name(
+                    self._partial_settings_file.name + ".bak"
+                )
+            )
 
         # Write the settings to a file. The settings themselves are models, so we
         # are guaranteed to write the correct model type (partial or full settings)

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -14,13 +14,27 @@ from .models import (
     PhotometrySettings,
 )
 
-__all__ = ["SavedSettings", "SETTINGS_FILE_VERSION", "PhotometryWorkingDirSettings"]
+__all__ = [
+    "SavedSettings",
+    "SETTINGS_FILE_VERSION",
+    "PhotometrySettingsWarning",
+    "PhotometryWorkingDirSettings",
+]
 
 # We will have to version settings formats, I think. Hopefully this changes rarely
 # or never.
 SETTINGS_FILE_VERSION = "2"  # value chosen to match major version of stellarphot
 
 ENCODING = "utf-8"
+
+
+class PhotometrySettingsWarning(UserWarning):
+    """
+    Warning category for user-actionable problems with saved photometry
+    settings files (e.g. a settings-format migration). Warnings of this
+    category are shown to the user in the `~stellarphot.gui.ReviewSettings`
+    banner; plain `UserWarning`\\s from libraries on the load path are not.
+    """
 
 
 class SavedFileOperations:
@@ -307,6 +321,26 @@ class PhotometryWorkingDirSettings:
         """
         return self._partial_settings
 
+    @property
+    def full_settings_unreadable(self):
+        """
+        True when the full settings file exists on disk but could not be read
+        by the most recent `load`. Only meaningful after `load` has been
+        called on this instance -- before any load, the in-memory settings
+        are None, so an existing readable file would also report True.
+        """
+        return self._settings_file.exists() and self._settings is None
+
+    @property
+    def partial_settings_unreadable(self):
+        """
+        True when the partial settings file exists on disk but could not be
+        read by the most recent `load`. Only meaningful after `load` has been
+        called on this instance -- before any load, the in-memory settings
+        are None, so an existing readable file would also report True.
+        """
+        return self._partial_settings_file.exists() and self._partial_settings is None
+
     # Properties for settings file and partial settings file
     @property
     def settings_file(self):
@@ -375,6 +409,26 @@ class PhotometryWorkingDirSettings:
 
         return disk_settings
 
+    def _move_aside(self, path):
+        """
+        Rename ``path`` to a backup name that does not already exist and
+        return the backup path.
+
+        The first available of ``path.bak``, ``path.bak1``, ``path.bak2``,
+        ... is used, so an earlier backup -- which may hold the only copy of
+        settings from a previous corruption -- is never overwritten.
+        """
+        backup = path.with_name(path.name + ".bak")
+        counter = 0
+        while backup.exists():
+            counter += 1
+            backup = path.with_name(f"{path.name}.bak{counter}")
+        # replace() rather than rename() so that the (unlikely) race of the
+        # chosen backup name being created between the exists() check and
+        # the rename still succeeds on every platform.
+        path.replace(backup)
+        return backup
+
     def save(self, settings, update=False):
         """
         Save the partial or full settings to the working directory. Note well that
@@ -412,6 +466,9 @@ class PhotometryWorkingDirSettings:
         renamed with a ``.bak`` suffix, rather than deleted, when a save
         writes full settings -- this includes, but is not limited to, the
         case where the partial settings conflict with the full settings.
+        Existing backups are never overwritten; if a ``.bak`` file already
+        exists, numbered suffixes (``.bak1``, ``.bak2``, ...) are used
+        instead.
         """
         full_settings = False
 
@@ -428,16 +485,15 @@ class PhotometryWorkingDirSettings:
             # settings files. We can proceed to save the settings.
             pass
 
-        # A file that exists on disk but whose in-memory settings are None
-        # failed to parse during the load above. Note the two flags now,
-        # before the code below reassigns the in-memory settings, so that
-        # the unreadable file can be renamed aside instead of destroyed.
-        # load() parses both files before raising, so these flags are accurate
-        # even when only one of the two files is unreadable.
-        unreadable_full = self._settings_file.exists() and self._settings is None
-        unreadable_partial = (
-            self._partial_settings_file.exists() and self._partial_settings is None
-        )
+        # A file that is unreadable failed to parse during the load above.
+        # Snapshot the two properties now, before the code below reassigns
+        # the in-memory settings (which would change what the properties
+        # report), so that the unreadable file can be renamed aside instead
+        # of destroyed. load() parses both files before raising, so these
+        # flags are accurate even when only one of the two files is
+        # unreadable.
+        unreadable_full = self.full_settings_unreadable
+        unreadable_partial = self.partial_settings_unreadable
 
         match settings:
             case PartialPhotometrySettings():
@@ -506,12 +562,34 @@ class PhotometryWorkingDirSettings:
                     f"not {type(settings)}"
                 )
 
+        # If the file we are about to write exists but could not be read, rename
+        # it aside so its contents are preserved rather than overwritten. This
+        # must happen before the write below, which would clobber the file.
+        if file == self._settings_file and unreadable_full:
+            self._move_aside(self._settings_file)
+        elif file == self._partial_settings_file and unreadable_partial:
+            self._move_aside(self._partial_settings_file)
+
+        # Write the settings to a file. The settings themselves are models, so we
+        # are guaranteed to write the correct model type (partial or full settings)
+        # to the file. Serialize before opening the file so that a failure to
+        # serialize cannot truncate an existing settings file.
+        json_data = settings.model_dump_json(indent=4)
+        with file.open("w", encoding=ENCODING) as f:
+            f.write(json_data)
+
         if full_settings:
+            # Now that the full settings that supersede the partial settings
+            # are safely on disk, the partial settings file can be disposed
+            # of. Doing this only after a successful write means a failed
+            # write cannot destroy the partial settings, which may be the
+            # only copy of some values.
+            #
             # Preserve the on-disk partial settings as .bak, instead of
             # deleting them, whenever some of their information would
             # otherwise be lost: either the file could not be read at all, or
             # it is readable but has a non-None value that differs from what
-            # is about to be written as the full settings. self._partial_settings
+            # was just written as the full settings. self._partial_settings
             # still reflects whatever was loaded from disk at the top of this
             # method -- none of the full-settings code paths above reassign it
             # -- so this comparison is against the pre-save partial settings.
@@ -521,35 +599,10 @@ class PhotometryWorkingDirSettings:
                 for k, v in self._partial_settings.model_dump().items()
             )
             if unreadable_partial or partial_values_lost:
-                # Use replace rather than rename so that an existing .bak
-                # file is overwritten on all platforms.
-                self._partial_settings_file.replace(
-                    self._partial_settings_file.with_name(
-                        self._partial_settings_file.name + ".bak"
-                    )
-                )
+                self._move_aside(self._partial_settings_file)
             else:
                 self._partial_settings_file.unlink(missing_ok=True)
             self._partial_settings = None
-
-        # If the file we are about to write exists but could not be read, rename
-        # it aside so its contents are preserved rather than overwritten.
-        if file == self._settings_file and unreadable_full:
-            self._settings_file.replace(
-                self._settings_file.with_name(self._settings_file.name + ".bak")
-            )
-        elif file == self._partial_settings_file and unreadable_partial:
-            self._partial_settings_file.replace(
-                self._partial_settings_file.with_name(
-                    self._partial_settings_file.name + ".bak"
-                )
-            )
-
-        # Write the settings to a file. The settings themselves are models, so we
-        # are guaranteed to write the correct model type (partial or full settings)
-        # to the file.
-        with file.open("w", encoding=ENCODING) as f:
-            f.write(settings.model_dump_json(indent=4))
 
     def load(self):
         """

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -407,9 +407,11 @@ class PhotometryWorkingDirSettings:
 
         An existing settings file that cannot be read is never overwritten in
         place; it is renamed with a ``.bak`` suffix before the new settings are
-        written. A readable partial settings file that conflicts with the full
-        settings is likewise renamed with a ``.bak`` suffix, rather than
-        deleted, when a save writes full settings.
+        written. A readable partial settings file whose non-None values are
+        not all carried into the full settings being written is likewise
+        renamed with a ``.bak`` suffix, rather than deleted, when a save
+        writes full settings -- this includes, but is not limited to, the
+        case where the partial settings conflict with the full settings.
         """
         full_settings = False
 
@@ -435,14 +437,6 @@ class PhotometryWorkingDirSettings:
         unreadable_full = self._settings_file.exists() and self._settings is None
         unreadable_partial = (
             self._partial_settings_file.exists() and self._partial_settings is None
-        )
-        # Both in-memory settings are populated only when the load above
-        # raised because the two files are readable but inconsistent. The
-        # partial file loses that conflict once full settings are written, so
-        # it must be set aside rather than deleted -- its differing values
-        # cannot be reconstructed from the saved settings.
-        conflicting_partial = (
-            self._settings is not None and self._partial_settings is not None
         )
 
         match settings:
@@ -513,11 +507,22 @@ class PhotometryWorkingDirSettings:
                 )
 
         if full_settings:
-            if unreadable_partial or conflicting_partial:
-                # Preserve a partial file that could not be read, or whose
-                # contents lost a conflict with the full settings, instead of
-                # deleting it. Use replace rather than rename so that an
-                # existing .bak file is overwritten on all platforms.
+            # Preserve the on-disk partial settings as .bak, instead of
+            # deleting them, whenever some of their information would
+            # otherwise be lost: either the file could not be read at all, or
+            # it is readable but has a non-None value that differs from what
+            # is about to be written as the full settings. self._partial_settings
+            # still reflects whatever was loaded from disk at the top of this
+            # method -- none of the full-settings code paths above reassign it
+            # -- so this comparison is against the pre-save partial settings.
+            written = settings.model_dump()
+            partial_values_lost = self._partial_settings is not None and any(
+                v is not None and written.get(k) != v
+                for k, v in self._partial_settings.model_dump().items()
+            )
+            if unreadable_partial or partial_values_lost:
+                # Use replace rather than rename so that an existing .bak
+                # file is overwritten on all platforms.
                 self._partial_settings_file.replace(
                     self._partial_settings_file.with_name(
                         self._partial_settings_file.name + ".bak"
@@ -563,35 +568,39 @@ class PhotometryWorkingDirSettings:
             raise ValueError(f"Settings file {self._settings_file} does not exist")
 
         errors = []
+        last_exc = None
 
-        # Load PartialPhotometrySettings first, if it exists.
+        # Load PartialPhotometrySettings first, if it exists. A read failure
+        # (ValidationError, or an OSError/UnicodeDecodeError while opening or
+        # decoding the file) leaves self._partial_settings as None, exactly
+        # like the missing/unparseable-content case below.
         if self._partial_settings_file.exists():
-            with self._partial_settings_file.open(encoding=ENCODING) as f:
-                content = f.read()
-
             try:
+                with self._partial_settings_file.open(encoding=ENCODING) as f:
+                    content = f.read()
                 self._partial_settings = PartialPhotometrySettings.model_validate_json(
                     content
                 )
-            except ValidationError as e:
+            except (ValidationError, OSError, UnicodeDecodeError) as e:
                 errors.append(f"Error loading partial settings: {e}")
+                last_exc = e
 
         # Now load full settings if they exist
         if self._settings_file.exists():
-            with self._settings_file.open(encoding=ENCODING) as f:
-                content = f.read()
-
             try:
+                with self._settings_file.open(encoding=ENCODING) as f:
+                    content = f.read()
                 self._settings = PhotometrySettings.model_validate_json(content)
-            except ValidationError as e:
+            except (ValidationError, OSError, UnicodeDecodeError) as e:
                 errors.append(f"Error loading settings: {e}")
+                last_exc = e
 
         # Both files are parsed before any error is raised so that the
         # in-memory settings reflect every file that could be read; save()
         # relies on that to merge into readable settings and to rename only
         # genuinely unreadable files to .bak.
         if errors:
-            raise ValueError("\n".join(errors))
+            raise ValueError("\n".join(errors)) from last_exc
 
         # Handle case where we have valid partial and valid full settings
         self._resolve_full_partial_conflict()
@@ -624,11 +633,11 @@ class PhotometryWorkingDirSettings:
 
         if full_from_partial != self._settings:
             raise ValueError(
-                "Partial settings and full settings do not match. "
-                "Please resolve the discrepancy by deleting one of the "
-                "settings files."
-                f"Folder with settings: {self._working_dir}"
-                f"Partial settings: {self._partial_settings_file} "
+                "Partial settings and full settings do not match. Please "
+                "resolve the discrepancy by deleting one of the settings "
+                "files.\n"
+                f"Folder with settings: {self._working_dir}\n"
+                f"Partial settings: {self._partial_settings_file}\n"
                 f"Full settings: {self._settings_file}"
             )
 

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -427,7 +427,7 @@ class PhotometryWorkingDirSettings:
                             "Cannot save partial settings when full "
                             "settings already exist."
                         )
-                    else:
+                    elif self._settings is not None:
                         # Load the full settings and update them with the
                         # partial settings
                         disk_settings = self._settings.model_dump()
@@ -439,6 +439,10 @@ class PhotometryWorkingDirSettings:
                         disk_settings = PhotometrySettings.model_validate(disk_settings)
 
                         settings = disk_settings
+                    # If the settings file exists but could not be read then
+                    # self._settings is None and there is nothing to merge the
+                    # partial settings into. The partial settings are saved on
+                    # their own and the unreadable file is left in place.
 
                 # Are we updating or replacing partial settings?
                 if update and self._partial_settings is not None:

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -306,7 +306,8 @@ class PhotometryWorkingDirSettings:
         )
         self._partial_settings = None
         self._settings = None
-        self._load_attempted = False
+        self._full_settings_unreadable = False
+        self._partial_settings_unreadable = False
 
     @property
     def settings(self):
@@ -325,28 +326,24 @@ class PhotometryWorkingDirSettings:
     @property
     def full_settings_unreadable(self):
         """
-        True when the full settings file exists on disk but could not be read
-        by the most recent `load`. Always False before `load` has been called
-        on this instance.
+        True when the full settings file existed but could not be read by the
+        most recent `load` on this instance. Always False before `load` has
+        been called. The flag reflects that load, not the live state of the
+        disk: it is not cleared by the file being fixed or removed, and not
+        set by a bad file appearing, until the next `load`.
         """
-        return (
-            self._load_attempted
-            and self._settings_file.exists()
-            and self._settings is None
-        )
+        return self._full_settings_unreadable
 
     @property
     def partial_settings_unreadable(self):
         """
-        True when the partial settings file exists on disk but could not be
-        read by the most recent `load`. Always False before `load` has been
-        called on this instance.
+        True when the partial settings file existed but could not be read by
+        the most recent `load` on this instance. Always False before `load`
+        has been called. The flag reflects that load, not the live state of
+        the disk: it is not cleared by the file being fixed or removed, and
+        not set by a bad file appearing, until the next `load`.
         """
-        return (
-            self._load_attempted
-            and self._partial_settings_file.exists()
-            and self._partial_settings is None
-        )
+        return self._partial_settings_unreadable
 
     # Properties for settings file and partial settings file
     @property
@@ -505,13 +502,11 @@ class PhotometryWorkingDirSettings:
             # rather than destroyed.
             pass
 
-        # A file that is unreadable failed to parse during the load above.
-        # Snapshot the two properties now, before the code below reassigns
-        # the in-memory settings (which would change what the properties
-        # report), so that the unreadable file can be renamed aside instead
-        # of destroyed. load() parses both files before raising, so these
-        # flags are accurate even when only one of the two files is
-        # unreadable.
+        # Whether each existing settings file failed to parse during the
+        # bookkeeping load above. load() latches these flags and parses both
+        # files before raising, so they are accurate even when only one of
+        # the two files is unreadable. They decide below whether a file
+        # about to be replaced is renamed aside instead of destroyed.
         unreadable_full = self.full_settings_unreadable
         unreadable_partial = self.partial_settings_unreadable
 
@@ -669,11 +664,11 @@ class PhotometryWorkingDirSettings:
             be read, or if the partial and full settings files are both
             readable but conflict with each other.
         """
-        self._load_attempted = True
-
         # Assume we have nothing to begin....
         self._partial_settings = None
         self._settings = None
+        self._full_settings_unreadable = False
+        self._partial_settings_unreadable = False
 
         if not (self._settings_file.exists() or self._partial_settings_file.exists()):
             raise ValueError(f"Settings file {self._settings_file} does not exist")
@@ -693,6 +688,7 @@ class PhotometryWorkingDirSettings:
                     content
                 )
             except (ValidationError, OSError, UnicodeDecodeError) as e:
+                self._partial_settings_unreadable = True
                 errors.append(f"Error loading partial settings: {e}")
                 last_exc = e
 
@@ -703,6 +699,7 @@ class PhotometryWorkingDirSettings:
                     content = f.read()
                 self._settings = PhotometrySettings.model_validate_json(content)
             except (ValidationError, OSError, UnicodeDecodeError) as e:
+                self._full_settings_unreadable = True
                 errors.append(f"Error loading settings: {e}")
                 last_exc = e
 

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -308,6 +308,7 @@ class PhotometryWorkingDirSettings:
         self._settings = None
         self._full_settings_unreadable = False
         self._partial_settings_unreadable = False
+        self._backups_made = {}
 
     @property
     def settings(self):
@@ -344,6 +345,17 @@ class PhotometryWorkingDirSettings:
         not set by a bad file appearing, until the next `load`.
         """
         return self._partial_settings_unreadable
+
+    @property
+    def backups_made(self):
+        """
+        Mapping of each original `pathlib.Path` this instance has renamed
+        to a backup -- whether by `save` or by `set_aside_unreadable` -- to
+        the `pathlib.Path` of its backup. When the same file has been set
+        aside more than once, the most recent backup wins. A copy is
+        returned, so mutating it does not affect the instance's records.
+        """
+        return dict(self._backups_made)
 
     # Properties for settings file and partial settings file
     @property
@@ -434,7 +446,46 @@ class PhotometryWorkingDirSettings:
         # widget-driven code accepts. rename() would not close it either:
         # os.rename also silently replaces an existing file on POSIX.
         path.replace(backup)
+        # Record the rename so callers (e.g. the ReviewSettings banner) can
+        # report the actual backup name instead of guessing at it.
+        self._backups_made[path] = backup
         return backup
+
+    def set_aside_unreadable(self):
+        """
+        Rename any settings file the most recent `load` on this instance
+        found unreadable to a ``.bak`` name (or the next free numbered
+        backup) and return a dict mapping each original path to its backup
+        path.
+
+        A file that has been removed or repaired-and-reloaded since that
+        load is skipped. The corresponding unreadable flag is cleared for
+        each file set aside, so the flags keep describing the directory
+        contents.
+
+        Returns
+        -------
+        dict
+            Mapping of each original `pathlib.Path` that was renamed to the
+            `pathlib.Path` of its backup. Empty when there was nothing to
+            set aside.
+
+        Raises
+        ------
+        OSError
+            If a rename fails (e.g. the directory is not writable). Any
+            file already renamed stays renamed.
+        """
+        moved = {}
+        if self._full_settings_unreadable and self._settings_file.exists():
+            moved[self._settings_file] = self._move_aside(self._settings_file)
+            self._full_settings_unreadable = False
+        if self._partial_settings_unreadable and self._partial_settings_file.exists():
+            moved[self._partial_settings_file] = self._move_aside(
+                self._partial_settings_file
+            )
+            self._partial_settings_unreadable = False
+        return moved
 
     def save(self, settings, update=False):
         """
@@ -468,13 +519,16 @@ class PhotometryWorkingDirSettings:
 
         An existing settings file that cannot be read is never overwritten in
         place; it is renamed with a ``.bak`` suffix before the new settings are
-        written. A readable partial settings file whose non-None values are
-        not all carried into the full settings being written is likewise
-        renamed with a ``.bak`` suffix, rather than deleted, when a save
-        writes full settings -- it may hold the only copy of those values.
-        Existing backups are never overwritten; if a ``.bak`` file already
-        exists, numbered suffixes (``.bak1``, ``.bak2``, ...) are used
-        instead.
+        written. A save also sets aside, with the same ``.bak`` naming, any
+        settings file its pre-save load found unreadable even when the save
+        does not rewrite that particular file -- a save never leaves behind a
+        file it knows is unreadable. A readable partial settings file whose
+        non-None values are not all carried into the full settings being
+        written is likewise renamed with a ``.bak`` suffix, rather than
+        deleted, when a save writes full settings -- it may hold the only
+        copy of those values. Existing backups are never overwritten; if a
+        ``.bak`` file already exists, numbered suffixes (``.bak1``,
+        ``.bak2``, ...) are used instead.
         """
         full_settings = False
 
@@ -532,8 +586,8 @@ class PhotometryWorkingDirSettings:
                                 f"exists at {self._settings_file} but could not be "
                                 "read. Fix or remove that file, or save with "
                                 "update=True, which saves the partial settings and "
-                                "preserves the unreadable file -- in place, or as a "
-                                ".bak backup if the save produces complete settings."
+                                "sets the unreadable full settings file aside as a "
+                                ".bak backup."
                             )
                         raise ValueError(
                             "Cannot save partial settings when full "
@@ -618,6 +672,14 @@ class PhotometryWorkingDirSettings:
             # After a successful replace the temporary file no longer exists,
             # so this only cleans up after a failed write.
             tmp_file.unlink(missing_ok=True)
+
+        if not full_settings and unreadable_full and self._settings_file.exists():
+            # This save wrote only the partial file, but the bookkeeping load
+            # found the full settings file unreadable. Leaving that file
+            # behind would keep every future load failing, so it is set
+            # aside now that the new partial settings are safely on disk.
+            self._move_aside(self._settings_file)
+            self._settings = None
 
         if full_settings:
             # Now that the full settings that supersede the partial settings

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -407,7 +407,9 @@ class PhotometryWorkingDirSettings:
 
         An existing settings file that cannot be read is never overwritten in
         place; it is renamed with a ``.bak`` suffix before the new settings are
-        written.
+        written. A readable partial settings file that conflicts with the full
+        settings is likewise renamed with a ``.bak`` suffix, rather than
+        deleted, when a save writes full settings.
         """
         full_settings = False
 
@@ -433,6 +435,14 @@ class PhotometryWorkingDirSettings:
         unreadable_full = self._settings_file.exists() and self._settings is None
         unreadable_partial = (
             self._partial_settings_file.exists() and self._partial_settings is None
+        )
+        # Both in-memory settings are populated only when the load above
+        # raised because the two files are readable but inconsistent. The
+        # partial file loses that conflict once full settings are written, so
+        # it must be set aside rather than deleted -- its differing values
+        # cannot be reconstructed from the saved settings.
+        conflicting_partial = (
+            self._settings is not None and self._partial_settings is not None
         )
 
         match settings:
@@ -503,10 +513,11 @@ class PhotometryWorkingDirSettings:
                 )
 
         if full_settings:
-            if unreadable_partial:
-                # Preserve the unreadable partial file instead of deleting it.
-                # Use replace rather than rename so that an existing .bak file
-                # is overwritten on all platforms.
+            if unreadable_partial or conflicting_partial:
+                # Preserve a partial file that could not be read, or whose
+                # contents lost a conflict with the full settings, instead of
+                # deleting it. Use replace rather than rename so that an
+                # existing .bak file is overwritten on all platforms.
                 self._partial_settings_file.replace(
                     self._partial_settings_file.with_name(
                         self._partial_settings_file.name + ".bak"

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -471,16 +471,7 @@ class PhotometryWorkingDirSettings:
         written. A readable partial settings file whose non-None values are
         not all carried into the full settings being written is likewise
         renamed with a ``.bak`` suffix, rather than deleted, when a save
-        writes full settings -- this includes, but is not limited to, the
-        case where the partial settings conflict with the full settings.
-        Partial values that differ from the written settings only because
-        the ``settings`` argument explicitly replaced them do not trigger
-        the backup: the caller supplied the new value deliberately. That
-        exclusion does not apply when the on-disk partial settings
-        conflicted with the on-disk full settings -- the "caller" may just
-        be echoing the full settings back, as the
-        `~stellarphot.gui.ReviewSettings` autosaves do -- so the losing
-        partial file is then always preserved.
+        writes full settings -- it may hold the only copy of those values.
         Existing backups are never overwritten; if a ``.bak`` file already
         exists, numbered suffixes (``.bak1``, ``.bak2``, ...) are used
         instead.
@@ -490,14 +481,16 @@ class PhotometryWorkingDirSettings:
         try:
             # This load is internal bookkeeping. Library warnings it
             # generates were already surfaced when the settings were first
-            # loaded, so don't repeat them on every save -- but let
-            # PhotometrySettingsWarning through, so a caller whose first
-            # interaction with the settings is a save() still sees
-            # user-actionable problems such as a settings-format migration.
-            with warnings.catch_warnings():
+            # loaded, so don't repeat them on every save. Any
+            # PhotometrySettingsWarning -- a user-actionable problem such as
+            # a settings-format migration -- is recorded here and re-emitted
+            # below, outside this filter context, so that it reaches a
+            # caller whose first interaction with the settings is a save(),
+            # subject to that caller's own warning filters.
+            with warnings.catch_warnings(record=True) as recorded:
                 warnings.simplefilter("ignore")
-                warnings.simplefilter("default", PhotometrySettingsWarning)
-                _ = self.load()
+                warnings.simplefilter("always", PhotometrySettingsWarning)
+                self.load()
         except (ValueError, OSError):
             # load() raises ValueError when there are no settings files at
             # all, when a file exists but cannot be read, and when readable
@@ -507,6 +500,13 @@ class PhotometryWorkingDirSettings:
             # cases; the unreadable-file cases rely on the flags below so
             # the problem file is set aside as .bak rather than destroyed.
             pass
+        for warning in recorded:
+            warnings.warn_explicit(
+                warning.message,
+                warning.category,
+                warning.filename,
+                warning.lineno,
+            )
 
         # Whether each existing settings file failed to parse during the
         # bookkeeping load above. load() latches these flags and parses both
@@ -516,33 +516,10 @@ class PhotometryWorkingDirSettings:
         unreadable_full = self.full_settings_unreadable
         unreadable_partial = self.partial_settings_unreadable
 
-        # After a successful load at most one of the in-memory settings is
-        # non-None (a duplicate partial file is tidied away). Both being
-        # non-None means the load above raised with the partial file
-        # unresolved: the files conflicted, or tidying failed. Either way
-        # the partial file's differing values were never confirmed as
-        # replaced by anyone -- a save "replacing" a value may just be
-        # echoing the full settings file back, as the ReviewSettings
-        # construction autosaves do -- so the explicit-replacement
-        # exclusion at disposal time does not apply and the partial file
-        # is backed up whenever any of its values would be lost.
-        partial_unresolved = (
-            self._settings is not None and self._partial_settings is not None
-        )
-
         match settings:
             case PartialPhotometrySettings():
                 # This case MUST come first, because PartialPhotometrySettings is a
                 # subclass of PhotometrySettings.
-
-                # Values the caller explicitly provided. Used at disposal
-                # time below: a partial value on disk that differs from the
-                # written settings only because the caller replaced it is
-                # deleted rather than backed up -- replacing it was the
-                # point of the save.
-                explicitly_replaced = {
-                    k for k, v in settings.model_dump().items() if v is not None
-                }
 
                 # Are there already full settings?
                 if self._settings_file.exists():
@@ -605,11 +582,6 @@ class PhotometryWorkingDirSettings:
                     self._partial_settings = settings
                     file = self._partial_settings_file
             case PhotometrySettings():
-                # A full-settings save replaces everything wholesale; it
-                # carries no signal about which partial values the caller
-                # looked at, so none are treated as deliberate replacements
-                # and any differing partial value still gets a backup.
-                explicitly_replaced = set()
                 self._settings = settings
                 file = self._settings_file
                 full_settings = True
@@ -664,9 +636,7 @@ class PhotometryWorkingDirSettings:
             # -- so this comparison is against the pre-save partial settings.
             written = settings.model_dump()
             partial_values_lost = self._partial_settings is not None and any(
-                v is not None
-                and written.get(k) != v
-                and (partial_unresolved or k not in explicitly_replaced)
+                v is not None and written.get(k) != v
                 for k, v in self._partial_settings.model_dump().items()
             )
             if unreadable_partial or partial_values_lost:

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -476,6 +476,9 @@ class PhotometryWorkingDirSettings:
         renamed with a ``.bak`` suffix, rather than deleted, when a save
         writes full settings -- this includes, but is not limited to, the
         case where the partial settings conflict with the full settings.
+        Partial values that differ from the written settings only because
+        the ``settings`` argument explicitly replaced them do not trigger
+        the backup: the caller supplied the new value deliberately.
         Existing backups are never overwritten; if a ``.bak`` file already
         exists, numbered suffixes (``.bak1``, ``.bak2``, ...) are used
         instead.
@@ -516,6 +519,15 @@ class PhotometryWorkingDirSettings:
             case PartialPhotometrySettings():
                 # This case MUST come first, because PartialPhotometrySettings is a
                 # subclass of PhotometrySettings.
+
+                # Values the caller explicitly provided. Used at disposal
+                # time below: a partial value on disk that differs from the
+                # written settings only because the caller replaced it is
+                # deleted rather than backed up -- replacing it was the
+                # point of the save.
+                explicitly_replaced = {
+                    k for k, v in settings.model_dump().items() if v is not None
+                }
 
                 # Are there already full settings?
                 if self._settings_file.exists():
@@ -577,6 +589,11 @@ class PhotometryWorkingDirSettings:
                     self._partial_settings = settings
                     file = self._partial_settings_file
             case PhotometrySettings():
+                # A full-settings save replaces everything wholesale; it
+                # carries no signal about which partial values the caller
+                # looked at, so none are treated as deliberate replacements
+                # and any differing partial value still gets a backup.
+                explicitly_replaced = set()
                 self._settings = settings
                 file = self._settings_file
                 full_settings = True
@@ -627,7 +644,7 @@ class PhotometryWorkingDirSettings:
             # -- so this comparison is against the pre-save partial settings.
             written = settings.model_dump()
             partial_values_lost = self._partial_settings is not None and any(
-                v is not None and written.get(k) != v
+                v is not None and written.get(k) != v and k not in explicitly_replaced
                 for k, v in self._partial_settings.model_dump().items()
             )
             if unreadable_partial or partial_values_lost:
@@ -642,8 +659,15 @@ class PhotometryWorkingDirSettings:
 
         Returns
         -------
-        PhotometrySettings | PartialPhotometrySettings | None
-            The settings loaded from disk, or None if there are no settings files.
+        PhotometrySettings | PartialPhotometrySettings
+            The settings loaded from disk.
+
+        Raises
+        ------
+        ValueError
+            If no settings file exists, if a settings file exists but cannot
+            be read, or if the partial and full settings files are both
+            readable but conflict with each other.
         """
         self._load_attempted = True
 

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -428,9 +428,8 @@ class PhotometryWorkingDirSettings:
         # failed to parse during the load above. Note the two flags now,
         # before the code below reassigns the in-memory settings, so that
         # the unreadable file can be renamed aside instead of destroyed.
-        # If the load failed on the partial file then the full file was
-        # never parsed, so this may occasionally set aside a .bak for a
-        # readable full file -- that errs on the side of preserving data.
+        # load() parses both files before raising, so these flags are accurate
+        # even when only one of the two files is unreadable.
         unreadable_full = self._settings_file.exists() and self._settings is None
         unreadable_partial = (
             self._partial_settings_file.exists() and self._partial_settings is None
@@ -552,6 +551,8 @@ class PhotometryWorkingDirSettings:
         if not (self._settings_file.exists() or self._partial_settings_file.exists()):
             raise ValueError(f"Settings file {self._settings_file} does not exist")
 
+        errors = []
+
         # Load PartialPhotometrySettings first, if it exists.
         if self._partial_settings_file.exists():
             with self._partial_settings_file.open(encoding=ENCODING) as f:
@@ -562,7 +563,7 @@ class PhotometryWorkingDirSettings:
                     content
                 )
             except ValidationError as e:
-                raise ValueError(f"Error loading partial settings: {e}") from e
+                errors.append(f"Error loading partial settings: {e}")
 
         # Now load full settings if they exist
         if self._settings_file.exists():
@@ -572,7 +573,14 @@ class PhotometryWorkingDirSettings:
             try:
                 self._settings = PhotometrySettings.model_validate_json(content)
             except ValidationError as e:
-                raise ValueError(f"Error loading settings: {e}") from e
+                errors.append(f"Error loading settings: {e}")
+
+        # Both files are parsed before any error is raised so that the
+        # in-memory settings reflect every file that could be read; save()
+        # relies on that to merge into readable settings and to rename only
+        # genuinely unreadable files to .bak.
+        if errors:
+            raise ValueError("\n".join(errors))
 
         # Handle case where we have valid partial and valid full settings
         self._resolve_full_partial_conflict()

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -756,17 +756,16 @@ class TestPhotometryWorkingDirSettings:
             settings_file.settings_file.name + ".tmp"
         ).exists()
 
-    def test_save_completing_partial_no_backup_for_replaced_value(self):
+    def test_save_completing_partial_backs_up_replaced_value(self):
         # A partial update that both replaces a previously saved partial
-        # value and completes the full settings deletes the on-disk partial
-        # file without a backup when its only divergence is the value the
-        # caller explicitly replaced -- replacing it was the point of the
-        # save, so nothing is lost.
+        # value and completes the full settings preserves the on-disk
+        # partial file as .bak: one of its non-None values was not carried
+        # into the full settings that were written, and the backup rule
+        # does not try to guess whether the caller replaced it on purpose.
         settings_file = PhotometryWorkingDirSettings()
         old_camera = Camera.model_validate_json(CAMERA)
-        settings_file.partial_settings_file.write_text(
-            PartialPhotometrySettings(camera=old_camera).model_dump_json()
-        )
+        partial_content = PartialPhotometrySettings(camera=old_camera).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
 
         new_settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         assert new_settings.camera != old_camera
@@ -777,7 +776,7 @@ class TestPhotometryWorkingDirSettings:
         backup_file = settings_file.partial_settings_file.with_name(
             settings_file.partial_settings_file.name + ".bak"
         )
-        assert not backup_file.exists()
+        assert backup_file.read_text() == partial_content
 
     def test_save_conflicting_partial_backed_up_despite_explicit_replacement(self):
         # When the on-disk partial settings conflict with the on-disk full
@@ -893,6 +892,30 @@ class TestPhotometryWorkingDirSettings:
         settings_file = PhotometryWorkingDirSettings()
         camera = Camera.model_validate_json(CAMERA)
         with pytest.warns(PhotometrySettingsWarning, match="migrated"):
+            settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+    def test_save_settings_warnings_respect_caller_filters(self, mocker):
+        # save() re-emits PhotometrySettingsWarning outside its internal
+        # filter context, so a caller that has already surfaced the warning
+        # elsewhere (like the ReviewSettings banner) can suppress it with an
+        # ordinary warning filter.
+        real_load = PhotometryWorkingDirSettings.load
+
+        def warning_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return real_load(_self)
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", warning_load
+        )
+
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            warnings.simplefilter("ignore", PhotometrySettingsWarning)
             settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
 
     def test_load_conflicting_partial_and_full_settings(self):

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -483,6 +484,27 @@ class TestPhotometryWorkingDirSettings:
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
         assert settings_file.settings_file.read_text() == bad_content
+
+    def test_save_does_not_repeat_load_warnings(self, mocker):
+        # save() calls load() internally for bookkeeping. Warnings from that
+        # load (e.g. a settings-format migration message) were already shown
+        # when the settings were first loaded, so save() should not repeat
+        # them.
+        real_load = PhotometryWorkingDirSettings.load
+
+        def warning_load(_self):
+            warnings.warn("Settings were migrated", UserWarning, stacklevel=2)
+            return real_load(_self)
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", warning_load
+        )
+
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
 
     def test_load_conflicting_partial_and_full_settings(self):
         # Make a valid partial settings file and a valid full settings file

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -756,6 +756,29 @@ class TestPhotometryWorkingDirSettings:
             settings_file.settings_file.name + ".tmp"
         ).exists()
 
+    def test_save_completing_partial_no_backup_for_replaced_value(self):
+        # A partial update that both replaces a previously saved partial
+        # value and completes the full settings deletes the on-disk partial
+        # file without a backup when its only divergence is the value the
+        # caller explicitly replaced -- replacing it was the point of the
+        # save, so nothing is lost.
+        settings_file = PhotometryWorkingDirSettings()
+        old_camera = Camera.model_validate_json(CAMERA)
+        settings_file.partial_settings_file.write_text(
+            PartialPhotometrySettings(camera=old_camera).model_dump_json()
+        )
+
+        new_settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        assert new_settings.camera != old_camera
+        settings_file.save(new_settings, update=True)
+
+        assert settings_file.settings.camera == new_settings.camera
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert not backup_file.exists()
+
     def test_save_suppresses_non_settings_warnings_from_load(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
         # load (e.g. library warnings) were already shown when the settings

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -1097,6 +1097,28 @@ class TestPhotometryWorkingDirSettings:
         assert fresh_instance.full_settings_unreadable
         assert not fresh_instance.partial_settings_unreadable
 
+    def test_unreadable_properties_latch_at_load(self):
+        # The properties report the outcome of the most recent load(), not
+        # the live state of the disk: removing the corrupt file after a
+        # failed load does not clear the flag...
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.settings_file.write_text('{"pasta": "carbonara"}')
+
+        with pytest.raises(ValueError, match="Error loading settings"):
+            settings_file.load()
+        settings_file.settings_file.unlink()
+        assert settings_file.full_settings_unreadable
+
+        # ... and a corrupt file appearing after a successful load is not
+        # reported as unreadable until a load has actually tried to read it.
+        fresh = PhotometryWorkingDirSettings()
+        fresh.partial_settings_file.write_text(
+            PartialPhotometrySettings().model_dump_json()
+        )
+        fresh.load()
+        fresh.settings_file.write_text('{"pasta": "carbonara"}')
+        assert not fresh.full_settings_unreadable
+
     def test_save_partial_no_update_with_unreadable_full_settings_message(self):
         # When trying to save partial settings with update=False and the full
         # settings file exists but is unreadable, the error message should be

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -816,3 +816,106 @@ class TestPhotometryWorkingDirSettings:
         assert from_file2 == PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
         # Make sure we have no partial settings
         assert settings_file.partial_settings is None
+
+    def test_save_full_direct_with_differing_partial_settings_makes_backup(self):
+        # A direct save of full settings (not a partial update) should still
+        # preserve a readable, on-disk partial settings file as .bak when one
+        # of its non-None values is not carried into the full settings being
+        # written -- that value would otherwise be silently lost, since a
+        # direct full save never merges in the on-disk partial settings.
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        partial_content = PartialPhotometrySettings(camera=camera).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == partial_content
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+
+    def test_save_full_direct_with_matching_partial_settings_no_backup(self):
+        # If the only non-None value in the on-disk partial settings matches
+        # the corresponding value in the full settings being written, nothing
+        # would be lost by discarding the partial file, so no .bak should be
+        # created.
+        settings_file = PhotometryWorkingDirSettings()
+        matching_camera = Camera(**TEST_PHOTOMETRY_SETTINGS["camera"])
+        partial_content = PartialPhotometrySettings(
+            camera=matching_camera
+        ).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert not backup_file.exists()
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+
+    def test_load_settings_file_invalid_utf8(self):
+        # A settings file that is not valid UTF-8 should be treated the same
+        # as a ValidationError: load() reports it as a readable-but-bad file,
+        # and a subsequent save preserves the original bytes as a .bak rather
+        # than silently overwriting them.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_bytes = b"\xff\xfe not utf8"
+        settings_file.settings_file.write_bytes(bad_bytes)
+
+        with pytest.raises(ValueError, match="Error loading settings"):
+            settings_file.load()
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_bytes() == bad_bytes
+
+    def test_load_error_chains_exception(self):
+        # The ValueError raised by a failed load should chain the underlying
+        # exception via `from`, so the original cause is not lost.
+        settings_file = PhotometryWorkingDirSettings()
+        with settings_file.settings_file.open("w") as f:
+            f.write("{bad: settings}")
+
+        with pytest.raises(ValueError) as exc_info:
+            settings_file.load()
+
+        assert exc_info.value.__cause__ is not None
+
+    def test_load_conflict_error_message_puts_paths_on_later_lines(self):
+        # The GUI shows only the first line of an error prominently and folds
+        # the rest into collapsed details, so the file paths must not appear
+        # on the first line of the conflict message.
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        with settings_file.partial_settings_file.open("w") as f:
+            f.write(partial_settings.model_dump_json())
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        with settings_file.settings_file.open("w") as f:
+            f.write(full_settings.model_dump_json())
+
+        with pytest.raises(ValueError) as exc_info:
+            settings_file.load()
+
+        message = str(exc_info.value)
+        first_line = message.splitlines()[0]
+        assert "photometry_settings.json" not in first_line
+        assert "\nFull settings:" in message
+        assert str(settings_file.settings_file) in message
+        assert str(settings_file.partial_settings_file) in message

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -13,6 +13,7 @@ from stellarphot.settings import (
     PartialPhotometrySettings,
     PassbandMap,
     PhotometrySettings,
+    PhotometrySettingsWarning,
     PhotometryWorkingDirSettings,
     SavedSettings,
     settings_files,  # This import is needed for mocking -- see TestSavedSettings
@@ -736,11 +737,31 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.partial_settings_file.read_text() == partial_content
 
-    def test_save_does_not_repeat_load_warnings(self, mocker):
+    def test_failed_write_leaves_existing_settings_intact(self, mocker):
+        # A failure partway through writing the new settings must not
+        # truncate or destroy the existing readable settings file; the
+        # write goes to a temporary file that atomically replaces the
+        # target only on success.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+        original = settings_file.settings_file.read_text()
+
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            PhotometryWorkingDirSettings().save(full_settings)
+
+        assert settings_file.settings_file.read_text() == original
+        assert not settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".tmp"
+        ).exists()
+
+    def test_save_suppresses_non_settings_warnings_from_load(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
-        # load (e.g. a settings-format migration message) were already shown
-        # when the settings were first loaded, so save() should not repeat
-        # them.
+        # load (e.g. library warnings) were already shown when the settings
+        # were first loaded, so save() should not repeat them -- but see
+        # test_save_lets_settings_warnings_through for the one category that
+        # must still get through.
         real_load = PhotometryWorkingDirSettings.load
 
         def warning_load(_self):
@@ -755,6 +776,28 @@ class TestPhotometryWorkingDirSettings:
         camera = Camera.model_validate_json(CAMERA)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
+            settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+    def test_save_lets_settings_warnings_through(self, mocker):
+        # save()'s internal load suppresses library warnings, but a
+        # PhotometrySettingsWarning (e.g. a settings-format migration
+        # message) must reach a caller whose first interaction with the
+        # settings is a save().
+        real_load = PhotometryWorkingDirSettings.load
+
+        def warning_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return real_load(_self)
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", warning_load
+        )
+
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        with pytest.warns(PhotometrySettingsWarning, match="migrated"):
             settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
 
     def test_load_conflicting_partial_and_full_settings(self):

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -1028,3 +1028,72 @@ class TestPhotometryWorkingDirSettings:
         assert "\nFull settings:" in message
         assert str(settings_file.settings_file) in message
         assert str(settings_file.partial_settings_file) in message
+
+    def test_unreadable_properties_false_before_load(self):
+        # Before any load() call, the *_unreadable properties should be False
+        # even if a valid settings file exists on disk.
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a valid full settings file
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json(indent=4))
+
+        # Create a fresh instance
+        fresh_instance = PhotometryWorkingDirSettings()
+
+        # Before load(), both properties should be False
+        assert not fresh_instance.full_settings_unreadable
+        assert not fresh_instance.partial_settings_unreadable
+
+        # After load(), they should still be False because the file is readable
+        fresh_instance.load()
+        assert not fresh_instance.full_settings_unreadable
+        assert not fresh_instance.partial_settings_unreadable
+
+    def test_unreadable_properties_corrupt_file_before_and_after_load(self):
+        # Before any load() call, the *_unreadable properties should be False
+        # even if a corrupt settings file exists. After load() fails on a
+        # corrupt file, the properties should report True.
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a corrupt full settings file
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        # Create a fresh instance
+        fresh_instance = PhotometryWorkingDirSettings()
+
+        # Before load(), full_settings_unreadable should be False
+        assert not fresh_instance.full_settings_unreadable
+
+        # Attempt to load - this should raise
+        with pytest.raises(ValueError, match="Error loading settings"):
+            fresh_instance.load()
+
+        # After load() fails, full_settings_unreadable should be True
+        assert fresh_instance.full_settings_unreadable
+        assert not fresh_instance.partial_settings_unreadable
+
+    def test_save_partial_no_update_with_unreadable_full_settings_message(self):
+        # When trying to save partial settings with update=False and the full
+        # settings file exists but is unreadable, the error message should be
+        # specific about the unreadable file, not the generic message about
+        # full settings already existing.
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a corrupt full settings file
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        # Create a fresh instance and try to save partial with update=False
+        fresh_instance = PhotometryWorkingDirSettings()
+        partial_settings = PartialPhotometrySettings(
+            camera=Camera.model_validate_json(CAMERA)
+        )
+
+        # Should raise ValueError with "could not be read" in the message
+        with pytest.raises(ValueError, match="could not be read"):
+            fresh_instance.save(partial_settings, update=False)
+
+        # Verify the unreadable file's content is untouched
+        assert fresh_instance.settings_file.read_text() == bad_content

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -473,7 +473,8 @@ class TestPhotometryWorkingDirSettings:
     def test_save_partial_update_with_unreadable_full_settings(self):
         # An existing full settings file that cannot be read should not make
         # a partial save crash. The partial settings are saved on their own
-        # and the unreadable file is left in place.
+        # and the unreadable file is set aside as .bak -- a save never
+        # leaves behind a file it knows is unreadable.
         settings_file = PhotometryWorkingDirSettings()
         bad_content = '{"pasta": "carbonara"}'
         settings_file.settings_file.write_text(bad_content)
@@ -484,7 +485,11 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
-        assert settings_file.settings_file.read_text() == bad_content
+        assert not settings_file.settings_file.exists()
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
 
     def test_save_partial_with_unreadable_partial_settings_makes_backup(self):
         # An existing partial settings file that cannot be read should not be
@@ -590,9 +595,9 @@ class TestPhotometryWorkingDirSettings:
     def test_save_partial_update_with_corrupt_full_and_valid_partial(self):
         # Test that when both a corrupt full settings file and a valid partial
         # settings file exist, a partial save with update=True will:
-        # 1. Leave the corrupt full file in place (un-renamed)
+        # 1. Set the corrupt full file aside as .bak, content preserved
         # 2. Merge into the valid partial and save the result
-        # 3. Not create a .bak of the corrupt full file
+        # 3. Leave the directory loadable again
         settings_file = PhotometryWorkingDirSettings()
 
         # Write a valid partial settings file with a camera
@@ -614,22 +619,18 @@ class TestPhotometryWorkingDirSettings:
         new_partial = PartialPhotometrySettings(observatory=observatory)
         settings_file.save(new_partial, update=True)
 
-        # Assert: corrupt full file is left in place un-renamed
-        assert settings_file.settings_file.exists()
-        assert settings_file.settings_file.read_text() == corrupt_full_content
+        # Assert: corrupt full file was set aside as .bak, content preserved
+        assert not settings_file.settings_file.exists()
         backup_file = settings_file.settings_file.with_name(
             settings_file.settings_file.name + ".bak"
         )
-        assert not backup_file.exists()
+        assert backup_file.read_text() == corrupt_full_content
 
-        # Assert: partial file on disk contains merged settings
-        # (old camera + new observatory). Verify by parsing the file directly
-        # since the corrupt full file prevents load() from succeeding.
-        partial_from_disk = PartialPhotometrySettings.model_validate_json(
-            settings_file.partial_settings_file.read_text()
-        )
-        assert partial_from_disk.camera == camera
-        assert partial_from_disk.observatory == observatory
+        # Assert: with the corrupt file out of the way, load() succeeds and
+        # returns the merged settings (old camera + new observatory).
+        loaded = PhotometryWorkingDirSettings().load()
+        assert loaded.camera == camera
+        assert loaded.observatory == observatory
 
     @pytest.mark.parametrize("save_what", ["partial_update", "full"])
     def test_save_with_conflicting_partial_settings_makes_backup(self, save_what):
@@ -821,6 +822,25 @@ class TestPhotometryWorkingDirSettings:
         mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
         with pytest.raises(OSError, match="disk full"):
             settings_file.save(full_settings)
+
+        assert settings_file.settings_file.read_text() == bad_content
+        assert not settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        ).exists()
+
+    def test_failed_partial_write_leaves_unreadable_full_in_place(self, mocker):
+        # A partial save normally sets aside an unreadable full settings
+        # file, but only after the new partial settings are safely on disk.
+        # If the write fails, the unreadable full file must stay in place
+        # under its original name.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        camera = Camera.model_validate_json(CAMERA)
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
 
         assert settings_file.settings_file.read_text() == bad_content
         assert not settings_file.settings_file.with_name(
@@ -1237,3 +1257,160 @@ class TestPhotometryWorkingDirSettings:
 
         # Verify the unreadable file's content is untouched
         assert fresh_instance.settings_file.read_text() == bad_content
+
+    def test_set_aside_unreadable_moves_files_and_clears_flags(self):
+        # Both files corrupt: set_aside_unreadable() renames both to .bak,
+        # preserving contents, reports what went where, and clears the
+        # flags so they keep describing the directory contents.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_full = '{"pasta": "carbonara"}'
+        bad_partial = '{"pasta": "rigatoni"}'
+        settings_file.settings_file.write_text(bad_full)
+        settings_file.partial_settings_file.write_text(bad_partial)
+
+        with pytest.raises(ValueError, match="Error loading"):
+            settings_file.load()
+
+        moved = settings_file.set_aside_unreadable()
+
+        expected = {
+            settings_file.settings_file: settings_file.settings_file.with_name(
+                settings_file.settings_file.name + ".bak"
+            ),
+            settings_file.partial_settings_file: (
+                settings_file.partial_settings_file.with_name(
+                    settings_file.partial_settings_file.name + ".bak"
+                )
+            ),
+        }
+        assert moved == expected
+        assert moved[settings_file.settings_file].read_text() == bad_full
+        assert moved[settings_file.partial_settings_file].read_text() == bad_partial
+        assert not settings_file.settings_file.exists()
+        assert not settings_file.partial_settings_file.exists()
+        assert not settings_file.full_settings_unreadable
+        assert not settings_file.partial_settings_unreadable
+
+        # With the bad files out of the way there is nothing left to load.
+        with pytest.raises(ValueError, match="does not exist"):
+            PhotometryWorkingDirSettings().load()
+
+    def test_set_aside_unreadable_uses_numbered_backup(self):
+        # An existing .bak is never overwritten; the next free numbered
+        # backup name is used instead.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+        older_backup = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        older_backup.write_text("an older backup")
+
+        with pytest.raises(ValueError, match="Error loading"):
+            settings_file.load()
+
+        moved = settings_file.set_aside_unreadable()
+
+        backup = moved[settings_file.settings_file]
+        assert backup.name == settings_file.settings_file.name + ".bak1"
+        assert backup.read_text() == bad_content
+        assert older_backup.read_text() == "an older backup"
+
+    def test_set_aside_unreadable_noop_when_nothing_unreadable(self):
+        # Nothing to do before any load has run...
+        settings_file = PhotometryWorkingDirSettings()
+        assert settings_file.set_aside_unreadable() == {}
+
+        # ... and nothing to do after a load that succeeds.
+        settings_file.partial_settings_file.write_text(
+            PartialPhotometrySettings().model_dump_json()
+        )
+        settings_file.load()
+        assert settings_file.set_aside_unreadable() == {}
+        assert settings_file.partial_settings_file.exists()
+
+    def test_set_aside_unreadable_skips_missing_file(self):
+        # The flag latches at load, but a file removed since then must be
+        # skipped rather than raising.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.settings_file.write_text('{"pasta": "carbonara"}')
+
+        with pytest.raises(ValueError, match="Error loading"):
+            settings_file.load()
+        settings_file.settings_file.unlink()
+
+        assert settings_file.set_aside_unreadable() == {}
+
+    def test_backups_made_empty_on_fresh_instance(self):
+        assert PhotometryWorkingDirSettings().backups_made == {}
+
+    def test_backups_made_records_save_set_aside(self):
+        # A save that sets aside an unreadable file records the backup it
+        # made, keyed by the original path.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.partial_settings_file.write_text('{"pasta": "carbonara"}')
+
+        camera = Camera.model_validate_json(CAMERA)
+        settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+        expected_backup = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert settings_file.backups_made == {
+            settings_file.partial_settings_file: expected_backup
+        }
+
+    def test_backups_made_records_conflicting_partial_backup(self):
+        # A full save that preserves a conflicting (readable) partial
+        # settings file records that backup too.
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        settings_file.partial_settings_file.write_text(
+            PartialPhotometrySettings(camera=camera).model_dump_json()
+        )
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        expected_backup = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert settings_file.backups_made == {
+            settings_file.partial_settings_file: expected_backup
+        }
+
+    def test_backups_made_records_set_aside_unreadable(self):
+        # set_aside_unreadable flows through the same bookkeeping, so its
+        # renames are recorded identically.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.settings_file.write_text('{"pasta": "carbonara"}')
+        settings_file.partial_settings_file.write_text('{"pasta": "rigatoni"}')
+
+        with pytest.raises(ValueError, match="Error loading"):
+            settings_file.load()
+        moved = settings_file.set_aside_unreadable()
+
+        assert settings_file.backups_made == moved
+
+    def test_backups_made_accumulates_and_newest_wins(self):
+        # Records accumulate across incidents on the same instance, the
+        # numbered backup names are recorded exactly, and a repeat incident
+        # for the same file records the newest backup.
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+
+        settings_file.partial_settings_file.write_text('{"pasta": "carbonara"}')
+        settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+        # Corrupt the freshly saved partial settings file again; the .bak
+        # name is taken now, so this incident's backup is .bak1.
+        settings_file.partial_settings_file.write_text('{"pasta": "rigatoni"}')
+        settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+        newest_backup = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak1"
+        )
+        assert settings_file.backups_made == {
+            settings_file.partial_settings_file: newest_backup
+        }
+        assert newest_backup.read_text() == '{"pasta": "rigatoni"}'

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -365,7 +365,7 @@ class TestPhotometryWorkingDirSettings:
         # Need to accept the second argument, but don't use it.
         self.original_wdir = Path.cwd()
         os.chdir(self.temp_dir.name)
-        for file in Path.cwd().glob("*.json"):
+        for file in Path.cwd().glob("*.json*"):
             file.unlink()
 
     def teardown_method(self, _):
@@ -484,6 +484,63 @@ class TestPhotometryWorkingDirSettings:
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
         assert settings_file.settings_file.read_text() == bad_content
+
+    def test_save_partial_with_unreadable_partial_settings_makes_backup(self):
+        # An existing partial settings file that cannot be read should not be
+        # overwritten by a partial save. The new partial settings are written
+        # and the unreadable original is preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.partial_settings_file.write_text(bad_content)
+
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.save(partial_settings, update=True)
+
+        assert settings_file.partial_settings_file.exists()
+        assert settings_file.partial_settings == partial_settings
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_full_with_unreadable_full_settings_makes_backup(self):
+        # An existing full settings file that cannot be read should not be
+        # overwritten when partial settings that are actually complete are
+        # saved to the full settings file. The new full settings are written
+        # and the unreadable original is preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "amatriciana"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(settings, update=True)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == settings
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_full_with_unreadable_partial_settings_makes_backup(self):
+        # Saving full settings normally deletes any partial settings file. If
+        # the partial settings file cannot be read it should instead be
+        # preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "puttanesca"}'
+        settings_file.partial_settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
 
     def test_save_does_not_repeat_load_warnings(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -468,6 +468,22 @@ class TestPhotometryWorkingDirSettings:
         else:
             assert settings_file.settings.camera.name == full_settings.camera.name
 
+    def test_save_partial_update_with_unreadable_full_settings(self):
+        # An existing full settings file that cannot be read should not make
+        # a partial save crash. The partial settings are saved on their own
+        # and the unreadable file is left in place.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.save(partial_settings, update=True)
+
+        assert settings_file.partial_settings_file.exists()
+        assert settings_file.partial_settings == partial_settings
+        assert settings_file.settings_file.read_text() == bad_content
+
     def test_load_conflicting_partial_and_full_settings(self):
         # Make a valid partial settings file and a valid full settings file
         # that conflict with each other.

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -670,6 +670,72 @@ class TestPhotometryWorkingDirSettings:
         # the conflict
         assert PhotometryWorkingDirSettings().load() == full_settings
 
+    def test_unreadable_properties_reflect_last_load(self):
+        # After a load(), the *_unreadable properties report exactly which
+        # existing files could not be read: here the full settings file is
+        # corrupt and there is no partial settings file at all.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.settings_file.write_text('{"pasta": "carbonara"}')
+
+        with pytest.raises(ValueError, match="Error loading settings"):
+            settings_file.load()
+
+        assert settings_file.full_settings_unreadable
+        assert not settings_file.partial_settings_unreadable
+
+    def test_save_does_not_overwrite_existing_backup(self):
+        # A .bak file may hold the only copy of settings from an earlier
+        # corruption, so a save that needs to set aside another unreadable
+        # file must use a numbered backup name (.bak1, .bak2, ...) rather
+        # than overwriting the existing .bak.
+        settings_file = PhotometryWorkingDirSettings()
+        old_backup_content = '{"pasta": "amatriciana"}'
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        backup_file.write_text(old_backup_content)
+
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        # The earlier backup is untouched and the unreadable file went to
+        # the next available numbered name.
+        assert backup_file.read_text() == old_backup_content
+        numbered_backup = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak1"
+        )
+        assert numbered_backup.read_text() == bad_content
+        assert settings_file.settings == full_settings
+
+    def test_failed_write_preserves_partial_settings_file(self, mocker):
+        # Saving full settings disposes of the partial settings file, whose
+        # non-None values may exist nowhere else if the write of the full
+        # settings then fails. The disposal must therefore happen only after
+        # the full settings are safely on disk.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        # The partial camera matches the full settings being saved, which is
+        # the case where save() would simply delete (not back up) the
+        # partial settings file.
+        partial_content = PartialPhotometrySettings(
+            camera=full_settings.camera
+        ).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        # Serialization happens before the settings file is opened for
+        # writing, so this failure stands in for any failure to get the new
+        # settings onto disk.
+        mocker.patch.object(
+            PhotometrySettings, "model_dump_json", side_effect=RuntimeError("disk full")
+        )
+        with pytest.raises(RuntimeError, match="disk full"):
+            settings_file.save(full_settings)
+
+        assert settings_file.partial_settings_file.read_text() == partial_content
+
     def test_save_does_not_repeat_load_warnings(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
         # load (e.g. a settings-format migration message) were already shown

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -542,6 +542,94 @@ class TestPhotometryWorkingDirSettings:
         )
         assert backup_file.read_text() == bad_content
 
+    def test_save_partial_update_with_corrupt_partial_and_valid_full(self):
+        # Test that when both a valid full settings file and a corrupt partial
+        # settings file exist, a partial save with update=True will:
+        # 1. Rename the corrupt partial file to .bak
+        # 2. Merge the new partial into the valid full settings
+        # 3. Save the result as a full settings file (since the partial is
+        #    compatible with full)
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a valid full settings file
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json(indent=4))
+
+        # Write a corrupt partial settings file
+        corrupt_partial_content = '{"pasta": "carbonara"}'
+        settings_file.partial_settings_file.write_text(corrupt_partial_content)
+
+        # Create a fresh instance to trigger load()
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Save a new partial settings with a different camera
+        camera = Camera.model_validate_json(CAMERA)
+        new_partial = PartialPhotometrySettings(camera=camera)
+        settings_file.save(new_partial, update=True)
+
+        # Assert: corrupt partial file is renamed to .bak
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.exists()
+        assert backup_file.read_text() == corrupt_partial_content
+
+        # Assert: subsequent load succeeds and returns merged settings
+        fresh_instance = PhotometryWorkingDirSettings()
+        loaded = fresh_instance.load()
+        # The loaded settings should have the new camera and all other fields
+        # from the original full settings
+        assert loaded.camera == camera
+        assert (
+            loaded.observatory
+            == PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS).observatory
+        )
+
+    def test_save_partial_update_with_corrupt_full_and_valid_partial(self):
+        # Test that when both a corrupt full settings file and a valid partial
+        # settings file exist, a partial save with update=True will:
+        # 1. Leave the corrupt full file in place (un-renamed)
+        # 2. Merge into the valid partial and save the result
+        # 3. Not create a .bak of the corrupt full file
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a valid partial settings file with a camera
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.partial_settings_file.write_text(
+            partial_settings.model_dump_json(indent=4)
+        )
+
+        # Write a corrupt full settings file
+        corrupt_full_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(corrupt_full_content)
+
+        # Create a fresh instance
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Save a new partial settings with an observatory
+        observatory = Observatory(**TEST_PHOTOMETRY_SETTINGS["observatory"])
+        new_partial = PartialPhotometrySettings(observatory=observatory)
+        settings_file.save(new_partial, update=True)
+
+        # Assert: corrupt full file is left in place un-renamed
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings_file.read_text() == corrupt_full_content
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert not backup_file.exists()
+
+        # Assert: partial file on disk contains merged settings
+        # (old camera + new observatory). Verify by parsing the file directly
+        # since the corrupt full file prevents load() from succeeding.
+        partial_from_disk = PartialPhotometrySettings.model_validate_json(
+            settings_file.partial_settings_file.read_text()
+        )
+        assert partial_from_disk.camera == camera
+        assert partial_from_disk.observatory == observatory
+
     def test_save_does_not_repeat_load_warnings(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
         # load (e.g. a settings-format migration message) were already shown

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -630,6 +630,46 @@ class TestPhotometryWorkingDirSettings:
         assert partial_from_disk.camera == camera
         assert partial_from_disk.observatory == observatory
 
+    @pytest.mark.parametrize("save_what", ["partial_update", "full"])
+    def test_save_with_conflicting_partial_settings_makes_backup(self, save_what):
+        # A readable partial settings file that conflicts with the full
+        # settings loses the conflict when a save writes full settings; it
+        # should be preserved with a .bak extension rather than deleted,
+        # because its differing values cannot be reconstructed from the
+        # saved settings.
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write conflicting valid files directly to the directory to avoid
+        # any conflict resolution in the save method.
+        camera = Camera.model_validate_json(CAMERA)
+        partial_content = PartialPhotometrySettings(camera=camera).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json())
+
+        # Create a fresh instance and save full settings, either directly or
+        # by way of a partial update that merges into the full settings.
+        settings_file = PhotometryWorkingDirSettings()
+        if save_what == "partial_update":
+            to_save = PartialPhotometrySettings(
+                observatory=Observatory(**TEST_PHOTOMETRY_SETTINGS["observatory"])
+            )
+        else:
+            to_save = full_settings
+        settings_file.save(to_save, update=True)
+
+        # Assert: the conflicting partial file is set aside, not deleted
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == partial_content
+
+        # Assert: the directory loads cleanly, with the full settings winning
+        # the conflict
+        assert PhotometryWorkingDirSettings().load() == full_settings
+
     def test_save_does_not_repeat_load_warnings(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
         # load (e.g. a settings-format migration message) were already shown

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -779,6 +779,78 @@ class TestPhotometryWorkingDirSettings:
         )
         assert not backup_file.exists()
 
+    def test_save_conflicting_partial_backed_up_despite_explicit_replacement(self):
+        # When the on-disk partial settings conflict with the on-disk full
+        # settings, the losing partial file must be preserved as .bak even
+        # when the value saved for the conflicting field was supplied
+        # explicitly -- the "caller" may just be echoing the full settings
+        # file's own value back, as the ReviewSettings construction
+        # autosaves do, in which case nobody ever chose to discard the
+        # conflicting value. It used to be deleted outright.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json())
+
+        conflicting_camera = Camera(**TEST_PHOTOMETRY_SETTINGS["camera"])
+        conflicting_camera.gain = 2 * conflicting_camera.gain
+        partial_content = PartialPhotometrySettings(
+            camera=conflicting_camera
+        ).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        # Echo the full settings' own camera back, as an autosave would.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.save(
+            PartialPhotometrySettings(camera=full_settings.camera), update=True
+        )
+
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == partial_content
+
+    def test_failed_write_leaves_unreadable_file_in_place(self, mocker):
+        # If writing the new settings fails, an unreadable file at the
+        # target name must remain in place under its original name -- not
+        # be renamed to .bak with nothing left in its place.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            settings_file.save(full_settings)
+
+        assert settings_file.settings_file.read_text() == bad_content
+        assert not settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        ).exists()
+
+    def test_save_survives_oserror_from_bookkeeping_load(self, mocker):
+        # load() raises OSError, not ValueError, when tidying a duplicate
+        # partial settings file fails (e.g. in a read-only directory).
+        # save() must treat that like any other failed bookkeeping load
+        # instead of crashing -- ReviewSettings calls save() during widget
+        # construction.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json())
+        settings_file.partial_settings_file.write_text(
+            PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS).model_dump_json()
+        )
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings,
+            "_resolve_full_partial_conflict",
+            side_effect=OSError("Read-only file system"),
+        )
+
+        camera = Camera.model_validate_json(CAMERA)
+        settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+        assert settings_file.settings.camera == camera
+
     def test_save_suppresses_non_settings_warnings_from_load(self, mocker):
         # save() calls load() internally for bookkeeping. Warnings from that
         # load (e.g. library warnings) were already shown when the settings


### PR DESCRIPTION
Previously, any failure to read the saved settings files in the working directory was silently swallowed by `ReviewSettings` (`except ValueError` around `PhotometryWorkingDirSettings().load()`), so the widget came up with defaults and no indication that an existing settings file had been ignored.

This PR adds a banner above the settings tabs that reports:

- an existing settings file that cannot be read (the widget still starts from defaults and tells the user why; the unreadable file is preserved by renaming it with a `.bak` suffix before any save would overwrite it), and
- any warnings generated while loading settings.

The warnings path is groundwork for #656: when the settings-format migration lands, its migration warning will be displayed in this banner automatically, addressing the concern that migration messages would otherwise never be seen by GUI users. Only the new `PhotometrySettingsWarning` category (a `UserWarning` subclass) is routed to the banner, so plain `UserWarning`s and deprecation noise from dependency internals stay out of it. Note for #656: the migration warning must be emitted as `PhotometrySettingsWarning` to appear in the banner.

Also fixes a latent crash this exposed: `PhotometryWorkingDirSettings.save(partial, update=True)` with an existing-but-unreadable full settings file raised `AttributeError` (`self._settings` is `None` after the failed load) — exactly what `ReviewSettings`' automatic default-saving does during construction, which would have killed the widget before the banner could be shown.

Changes from the review of this PR:

- `save()` never destroys a settings file it could not read: whether the unreadable file is the partial or the full one, it is renamed to `<name>.json.bak` before the write or delete that would have clobbered it, and existing backups are never overwritten (numbered `.bak1`, `.bak2`, ... are used instead). Writes go to a temporary file that atomically replaces the target, and the partial settings file is disposed of only after the full settings are safely on disk.
- Banner text derived from file contents (pydantic error text, warning messages) is HTML-escaped at message-construction time; the full error is shown in a `<pre>` block inside a collapsed `<details>` element.
- Warnings emitted by a `load()` that then raises are still shown alongside the error, instead of being dropped.
- `current_settings` is now a side-effect-free snapshot; reloading from disk and updating the banner happens only through an explicit `_refresh()`.
- Dismissing the load-error message does not suppress a later, *different* load error: dismissals are fingerprinted on the error's full text (first lines of pydantic errors are too generic to tell two corruptions of the same file apart), so a new incident that reuses the single load-error slot is shown again.
- A sticky banner message whose problem the latest reload no longer reproduces is marked "No longer detected as of the latest reload" instead of continuing to read as a current problem (so a hand-fixed settings file doesn't leave the banner asserting something false, while the user still learns e.g. that a file was set aside as `.bak`).
- The banner's `.bak` promise mentions that a numbered backup is used when the plain `.bak` name is already taken.
- `ReviewSettings`' autosaves suppress the `PhotometrySettingsWarning` pass-through from `save()`'s bookkeeping load (the banner already shows the warning), so a future migration warning is not also printed once per autosaved setting.
- `full_settings_unreadable`/`partial_settings_unreadable` are `False` before `load()` has been called on the instance, instead of reporting an existing readable file as unreadable; `save(partial, update=False)` raises an accurate error when the existing full settings file could not be read, rather than claiming full settings "already exist".

Simplifications from a final review pass (behavior preserved except where noted):

- The banner keeps one entry per message (fingerprint, HTML, resolved flag) instead of three parallel dicts, and a resolved message is shown with a generic "No longer detected as of the latest reload:" prefix over its original wording — the same treatment warnings already got — instead of a hand-composed past-tense variant of the load-error message.
- `save()` backs up the partial settings file whenever any of its non-None values is not carried into the full settings being written, dropping the exclusion for values the caller explicitly replaced. The only flow that exclusion could distinguish — a direct API save that both completes the settings and overwrites an existing partial value — now yields a `.bak` instead of a deletion; the `ReviewSettings` autosave flow never hits it, because settings only become full by filling a field that was `None` on disk.
- `save()` re-emits `PhotometrySettingsWarning` from its bookkeeping load outside its internal filter context, so a caller's own warning filters apply; the autosave suppression is now a plain `simplefilter("ignore", PhotometrySettingsWarning)` around the save instead of a callback threaded into the save observer plus manual re-emission. Trade: a settings warning unique to the save path is silenced during autosaves rather than printed (one from `load()` still reaches the banner on the next refresh).

No settings files at all shows no banner — a fresh directory is normal.

Tests: banner hidden with no settings files; banner shown for an unreadable file (including the automatic-save path) with the original content preserved at `.bak`; banner shows load-time warnings, including from loads that then fail; markup in a corrupt file is escaped, not rendered; non-`PhotometrySettingsWarning`s stay out of the banner; a dismissed load error reappears when the underlying error changes; a cured problem is marked "no longer detected"; autosaves do not print settings warnings to the console; the `*_unreadable` properties before/after load; direct tests of the `save()` rename-aside for both files and of the atomic-write failure paths; a partial settings file whose values would be lost by a full save is preserved as `.bak`; `save()`'s re-emitted settings warnings can be silenced by an ordinary caller-side warning filter.

This PR was written by Claude at @mwcraig's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013a9fCwVA8ZhRiu9JJNZwzD

