### PR TITLE
Fix three crashes/dead code in settings save and ReviewSettings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,14 @@ Bug Fixes
   to original-image pixel coordinates with an off-by-0.5 formula), and it no
   longer mutates the caller's ``CCDData.mask`` in place when flagging pixels
   above ``max_adu``. [#651]
++ ``PhotometryWorkingDirSettings.save(partial_settings, update=True)`` no
+  longer raises ``AttributeError`` when an existing full settings file
+  cannot be read; the partial settings are saved on their own since there
+  is nothing to merge them into. In ``ReviewSettings``, collapsing every
+  section of an accordion no longer raises ``TypeError``, and selecting a
+  tab whose setting is not saved on disk now actually marks the tab as not
+  saved (the selection observer previously rebound a local variable
+  instead of setting the badge). [#661]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -907,6 +907,11 @@ class ReviewSettings(ipw.VBox):
         # Get the index
         new_selected = change["new"]
 
+        # An accordion reports a selection of None when every section is
+        # collapsed; there is nothing to update in that case.
+        if new_selected is None:
+            return
+
         setting_badge = self._setting_widgets[new_selected].badge
         if setting_badge is not None:
             self.badges[new_selected] = setting_badge
@@ -919,7 +924,7 @@ class ReviewSettings(ipw.VBox):
             disk_value = getattr(self.current_settings, snake_name)
             if disk_value is None:
                 # The setting is not saved
-                setting_widget = SaveStatus.SETTING_NOT_SAVED
+                setting_widget.badge = SaveStatus.SETTING_NOT_SAVED
             else:
                 # Set the badge to saved if it has been saved.
                 value_from_widget = setting_widget._autoui_widget.model.model_validate(

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1254,6 +1254,39 @@ class TestReviewSettings:
         review_settings._container.selected_index = 1
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[1]
 
+    def test_accordion_collapse_does_not_error(self):
+        # An accordion with every section collapsed has selected_index None,
+        # which used to raise a TypeError in the selection observer.
+        review_settings = ReviewSettings(
+            [Camera, PhotometryApertures], style="accordion"
+        )
+        review_settings._container.selected_index = 0
+        review_settings._container.selected_index = None
+        # Reaching this point without an exception is the test
+
+    def test_tab_selection_marks_unsaved_setting(self):
+        # Selecting a tab whose setting is not saved on disk should set that
+        # tab's badge to SETTING_NOT_SAVED. This used to silently do nothing
+        # because the selection observer rebound a local variable instead of
+        # setting the widget's badge.
+        wd_settings = PhotometryWorkingDirSettings()
+
+        # PhotometryApertures can be created from default values, so it is
+        # saved automatically when the widget is created; deleting the
+        # settings file afterwards leaves its tab in the not-saved state.
+        review_settings = ReviewSettings([PhotometryApertures, Camera])
+        wd_settings.partial_settings_file.unlink(missing_ok=True)
+
+        # Switch away from the apertures tab and back so the selection
+        # observer fires for it.
+        review_settings._container.selected_index = 1
+        review_settings._container.selected_index = 0
+
+        # Setting the widget badge triggers the observer that copies it into
+        # the badge list and the tab title.
+        assert review_settings.badges[0] == SaveStatus.SETTING_NOT_SAVED
+        assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[0]
+
 
 def test_add_saving_with_unrecognized_widget():
     # Check that an error is raised if a widget is added to the saving list

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -427,7 +427,7 @@ class PhotometryWorkingDirSettings:
                             "Cannot save partial settings when full "
                             "settings already exist."
                         )
-                    else:
+                    elif self._settings is not None:
                         # Load the full settings and update them with the
                         # partial settings
                         disk_settings = self._settings.model_dump()
@@ -439,6 +439,10 @@ class PhotometryWorkingDirSettings:
                         disk_settings = PhotometrySettings.model_validate(disk_settings)
 
                         settings = disk_settings
+                    # If the settings file exists but could not be read then
+                    # self._settings is None and there is nothing to merge the
+                    # partial settings into. The partial settings are saved on
+                    # their own.
 
                 # Are we updating or replacing partial settings?
                 if update and self._partial_settings is not None:

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -468,6 +468,24 @@ class TestPhotometryWorkingDirSettings:
         else:
             assert settings_file.settings.camera.name == full_settings.camera.name
 
+    def test_save_partial_update_with_unreadable_full_settings(self):
+        # An existing full settings file that cannot be read used to make
+        # save(partial, update=True) crash with an AttributeError, because
+        # the failed load left self._settings as None. There is nothing to
+        # merge the partial settings into in that case, so they are saved
+        # on their own and the unreadable file is left in place.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.save(partial_settings, update=True)
+
+        assert settings_file.partial_settings_file.exists()
+        assert settings_file.partial_settings == partial_settings
+        assert settings_file.settings_file.read_text() == bad_content
+
     def test_load_conflicting_partial_and_full_settings(self):
         # Make a valid partial settings file and a valid full settings file
         # that conflict with each other.


### PR DESCRIPTION
Extracted from #657 as part of decomposing that PR into small, reviewable pieces. These are the pure bug fixes — each exists on `main` today and is independent of the settings banner work.

1. **`PhotometryWorkingDirSettings.save(partial, update=True)` crashed with `AttributeError` when an existing full settings file could not be read.** The failed `load()` is swallowed, leaving `self._settings` as `None`, and the merge step then called `None.model_dump()`. Since `ReviewSettings.__init__` autosaves through exactly this path, the widget could not be constructed at all in a working directory with a corrupt settings file. Now the partial settings are saved on their own — there is nothing to merge them into.
2. **Collapsing every section of a `ReviewSettings` accordion raised `TypeError`.** An accordion reports `selected_index = None` when all sections are collapsed, and the selection observer indexed a list with it.
3. **Selecting a tab whose setting is not saved on disk never marked the tab.** The observer rebound a local variable (`setting_widget = SaveStatus.SETTING_NOT_SAVED`) instead of setting the widget's badge.

Each fix has a regression test that fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184JRanBeqVLwzTW11UbTvg