### PR TITLE
Make settings writes safe: atomic replace and .bak preservation of unreadable files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,18 @@ Bug Fixes
   tab whose setting is not saved on disk now actually marks the tab as not
   saved (the selection observer previously rebound a local variable
   instead of setting the badge). [#661]
++ ``PhotometryWorkingDirSettings`` no longer destroys settings on failed
+  or conflicting writes. Settings are written to a temporary file that
+  atomically replaces the target, so an interrupted write cannot
+  truncate an existing settings file; the partial settings file is
+  disposed of only after new full settings are safely on disk; and a
+  settings file that exists but cannot be read is renamed to a ``.bak``
+  backup (numbered ``.bak1``, ``.bak2``, ... if needed) instead of being
+  silently overwritten or deleted. ``load()`` now parses both settings
+  files before raising so a save can merge into whichever file was
+  readable, and a file that is unreadable because of an encoding or
+  operating-system error is reported the same way as corrupt JSON
+  instead of raising an unexpected exception type. [#662]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,17 +77,13 @@ Bug Fixes
   tab whose setting is not saved on disk now actually marks the tab as not
   saved (the selection observer previously rebound a local variable
   instead of setting the badge). [#661]
-+ ``PhotometryWorkingDirSettings`` no longer destroys settings on failed
-  writes. Settings are written to a temporary file that atomically
-  replaces the target, the partial settings file is removed only after
-  full settings are safely on disk, and an unreadable settings file is
-  set aside as a numbered ``.bak`` backup instead of being overwritten.
-  Encoding and OS errors while reading settings now raise
-  ``SettingsFileReadError``, a ``ValueError`` subclass. A partial save
-  no longer resurrects values from a conflicting partial settings file;
-  the conflicting file is set aside as a ``.bak`` backup. Saved cameras,
-  observatories, and passband maps are now also written with an atomic
-  replace. [#662]
++ Saving settings can no longer destroy existing ones: all settings files
+  (including saved cameras, observatories, and passband maps) are written
+  via an atomic temporary-file replace, unreadable or conflicting files
+  are set aside as numbered ``.bak`` backups instead of being overwritten,
+  and a partial save no longer resurrects stale values from a conflicting
+  partial settings file. Encoding and OS errors while reading settings now
+  raise ``SettingsFileReadError``, a ``ValueError`` subclass. [#662]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,7 +83,11 @@ Bug Fixes
   full settings are safely on disk, and an unreadable settings file is
   set aside as a numbered ``.bak`` backup instead of being overwritten.
   Encoding and OS errors while reading settings now raise
-  ``SettingsFileReadError``, a ``ValueError`` subclass. [#662]
+  ``SettingsFileReadError``, a ``ValueError`` subclass. A partial save
+  no longer resurrects values from a conflicting partial settings file;
+  the conflicting file is set aside as a ``.bak`` backup. Saved cameras,
+  observatories, and passband maps are now also written with an atomic
+  replace. [#662]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,17 +78,12 @@ Bug Fixes
   saved (the selection observer previously rebound a local variable
   instead of setting the badge). [#661]
 + ``PhotometryWorkingDirSettings`` no longer destroys settings on failed
-  or conflicting writes. Settings are written to a temporary file that
-  atomically replaces the target, so an interrupted write cannot
-  truncate an existing settings file; the partial settings file is
-  disposed of only after new full settings are safely on disk; and a
-  settings file that exists but cannot be read is renamed to a ``.bak``
-  backup (numbered ``.bak1``, ``.bak2``, ... if needed) instead of being
-  silently overwritten or deleted. ``load()`` now parses both settings
-  files before raising so a save can merge into whichever file was
-  readable, and a file that is unreadable because of an encoding or
-  operating-system error is reported the same way as corrupt JSON
-  instead of raising an unexpected exception type. [#662]
+  writes. Settings are written to a temporary file that atomically
+  replaces the target, the partial settings file is removed only after
+  full settings are safely on disk, and an unreadable settings file is
+  set aside as a numbered ``.bak`` backup instead of being overwritten.
+  Encoding and OS errors while reading settings now raise
+  ``SettingsFileReadError``, a ``ValueError`` subclass. [#662]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -291,6 +291,8 @@ class PhotometryWorkingDirSettings:
         )
         self._partial_settings = None
         self._settings = None
+        self._full_settings_unreadable = False
+        self._partial_settings_unreadable = False
 
     @property
     def settings(self):
@@ -403,15 +405,38 @@ class PhotometryWorkingDirSettings:
         Finally, if we are passed a partial setting and there is a full setting on disk,
         then the partial settings are merged with the full settings, and the full
         settings are saved.
+
+        An existing settings file that cannot be read is never overwritten in
+        place; it is renamed with a ``.bak`` suffix before the new settings
+        are written, and a save also sets aside, with the same ``.bak``
+        naming, any settings file its pre-save load found unreadable even
+        when the save does not rewrite that particular file. Existing backups
+        are never overwritten; if a ``.bak`` file already exists, numbered
+        suffixes (``.bak1``, ``.bak2``, ...) are used instead. The settings
+        are written to a temporary file that atomically replaces the target,
+        and the partial settings file is disposed of only after new full
+        settings are safely on disk, so a failed write cannot truncate or
+        destroy existing settings.
         """
         full_settings = False
 
         try:
             _ = self.load()
         except ValueError:
-            # If we catch a ValueError, then we are in a situation where we have no
-            # settings files. We can proceed to save the settings.
+            # load() raises ValueError when there are no settings files at
+            # all and when a file exists but cannot be read. The save
+            # proceeds in both cases; the unreadable-file case relies on the
+            # flags below so the problem file is set aside as .bak rather
+            # than destroyed.
             pass
+
+        # Whether each existing settings file failed to parse during the
+        # bookkeeping load above. load() latches these flags and parses both
+        # files before raising, so they are accurate even when only one of
+        # the two files is unreadable. They decide below whether a file
+        # about to be replaced is renamed aside instead of destroyed.
+        unreadable_full = self._full_settings_unreadable
+        unreadable_partial = self._partial_settings_unreadable
 
         match settings:
             case PartialPhotometrySettings():
@@ -442,7 +467,8 @@ class PhotometryWorkingDirSettings:
                     # If the settings file exists but could not be read then
                     # self._settings is None and there is nothing to merge the
                     # partial settings into. The partial settings are saved on
-                    # their own.
+                    # their own and the unreadable file is renamed with a .bak
+                    # suffix once the new settings are safely on disk.
 
                 # Are we updating or replacing partial settings?
                 if update and self._partial_settings is not None:
@@ -479,15 +505,76 @@ class PhotometryWorkingDirSettings:
                     f"not {type(settings)}"
                 )
 
-        if full_settings:
-            self._partial_settings_file.unlink(missing_ok=True)
-            self._partial_settings = None
+        # If the file we are about to write exists but could not be read, its
+        # contents must be set aside rather than overwritten. The rename
+        # happens between writing the temporary file and the replace below,
+        # so a failure while writing the new content leaves the unreadable
+        # file in place under its original name instead of leaving no
+        # settings file at all.
+        set_aside_target = (file == self._settings_file and unreadable_full) or (
+            file == self._partial_settings_file and unreadable_partial
+        )
 
         # Write the settings to a file. The settings themselves are models, so we
         # are guaranteed to write the correct model type (partial or full settings)
-        # to the file.
-        with file.open("w", encoding=ENCODING) as f:
-            f.write(settings.model_dump_json(indent=4))
+        # to the file. Write to a temporary file in the same directory and then
+        # atomically replace the target, so that a failure at any point during
+        # serialization or writing leaves any existing settings file untouched.
+        json_data = settings.model_dump_json(indent=4)
+        tmp_file = file.with_name(file.name + ".tmp")
+        try:
+            tmp_file.write_text(json_data, encoding=ENCODING)
+            if set_aside_target:
+                self._move_aside(file)
+            tmp_file.replace(file)
+        finally:
+            # After a successful replace the temporary file no longer exists,
+            # so this only cleans up after a failed write.
+            tmp_file.unlink(missing_ok=True)
+
+        if not full_settings and unreadable_full and self._settings_file.exists():
+            # This save wrote only the partial file, but the bookkeeping load
+            # found the full settings file unreadable. Leaving that file
+            # behind would keep every future load failing, so it is set
+            # aside now that the new partial settings are safely on disk.
+            self._move_aside(self._settings_file)
+            self._settings = None
+
+        if full_settings:
+            # Now that the full settings that supersede the partial settings
+            # are safely on disk, the partial settings file can be disposed
+            # of. Doing this only after a successful write means a failed
+            # write cannot destroy the partial settings. An unreadable
+            # partial settings file is preserved as .bak instead of deleted
+            # -- it may hold the only copy of some values.
+            if self._partial_settings_file.exists():
+                if unreadable_partial:
+                    self._move_aside(self._partial_settings_file)
+                else:
+                    self._partial_settings_file.unlink()
+            self._partial_settings = None
+
+    def _move_aside(self, path):
+        """
+        Rename ``path`` to a backup name that does not already exist and
+        return the backup path.
+
+        The first available of ``path.bak``, ``path.bak1``, ``path.bak2``,
+        ... is used, so an earlier backup -- which may hold the only copy of
+        settings from a previous corruption -- is never overwritten.
+        """
+        backup = path.with_name(path.name + ".bak")
+        counter = 0
+        while backup.exists():
+            counter += 1
+            backup = path.with_name(f"{path.name}.bak{counter}")
+        # replace() gives deterministic cross-platform behavior. In the
+        # (unlikely) race where the chosen backup name is created between
+        # the exists() check above and this call, the just-created file is
+        # silently overwritten -- a narrow window this single-user,
+        # widget-driven code accepts.
+        path.replace(backup)
+        return backup
 
     def load(self):
         """
@@ -495,37 +582,61 @@ class PhotometryWorkingDirSettings:
 
         Returns
         -------
-        PhotometrySettings | PartialPhotometrySettings | None
-            The settings loaded from disk, or None if there are no settings files.
+        PhotometrySettings | PartialPhotometrySettings
+            The settings loaded from disk.
+
+        Raises
+        ------
+        ValueError
+            If no settings file exists, if a settings file exists but cannot
+            be read, or if the partial and full settings files are both
+            readable but conflict with each other.
         """
         # Assume we have nothing to begin....
         self._partial_settings = None
         self._settings = None
+        self._full_settings_unreadable = False
+        self._partial_settings_unreadable = False
 
         if not (self._settings_file.exists() or self._partial_settings_file.exists()):
             raise ValueError(f"Settings file {self._settings_file} does not exist")
 
-        # Load PartialPhotometrySettings first, if it exists.
-        if self._partial_settings_file.exists():
-            with self._partial_settings_file.open(encoding=ENCODING) as f:
-                content = f.read()
+        errors = []
+        last_exc = None
 
+        # Load PartialPhotometrySettings first, if it exists. A read failure
+        # (ValidationError, or an OSError/UnicodeDecodeError while opening or
+        # decoding the file) leaves self._partial_settings as None, exactly
+        # like the missing-file case.
+        if self._partial_settings_file.exists():
             try:
+                with self._partial_settings_file.open(encoding=ENCODING) as f:
+                    content = f.read()
                 self._partial_settings = PartialPhotometrySettings.model_validate_json(
                     content
                 )
-            except ValidationError as e:
-                raise ValueError(f"Error loading partial settings: {e}") from e
+            except (ValidationError, OSError, UnicodeDecodeError) as e:
+                self._partial_settings_unreadable = True
+                errors.append(f"Error loading partial settings: {e}")
+                last_exc = e
 
         # Now load full settings if they exist
         if self._settings_file.exists():
-            with self._settings_file.open(encoding=ENCODING) as f:
-                content = f.read()
-
             try:
+                with self._settings_file.open(encoding=ENCODING) as f:
+                    content = f.read()
                 self._settings = PhotometrySettings.model_validate_json(content)
-            except ValidationError as e:
-                raise ValueError(f"Error loading settings: {e}") from e
+            except (ValidationError, OSError, UnicodeDecodeError) as e:
+                self._full_settings_unreadable = True
+                errors.append(f"Error loading settings: {e}")
+                last_exc = e
+
+        # Both files are parsed before any error is raised so that the
+        # in-memory settings reflect every file that could be read; save()
+        # relies on that to merge into readable settings and to rename only
+        # genuinely unreadable files to .bak.
+        if errors:
+            raise ValueError("\n".join(errors)) from last_exc
 
         # Handle case where we have valid partial and valid full settings
         self._resolve_full_partial_conflict()

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -41,6 +41,125 @@ class SettingsFileReadError(ValueError):
     """
 
 
+def _backup_path(path):
+    """
+    Choose a backup name for a file that does not already exist.
+
+    Parameters
+    ----------
+    path : `pathlib.Path`
+        The file a backup name is needed for.
+
+    Returns
+    -------
+    `pathlib.Path`
+        The first available of ``<name>.bak``, ``<name>.bak1``,
+        ``<name>.bak2``, ... so an earlier backup -- which may hold
+        the only copy of settings from a previous corruption -- is
+        never overwritten.
+    """
+    backup = path.with_name(path.name + ".bak")
+    counter = 0
+    while backup.exists():
+        counter += 1
+        backup = path.with_name(f"{path.name}.bak{counter}")
+    return backup
+
+
+def _move_aside(path):
+    """
+    Rename a file to a backup name that does not already exist.
+
+    Parameters
+    ----------
+    path : `pathlib.Path`
+        The file to rename.
+
+    Returns
+    -------
+    `pathlib.Path`
+        The path the file was renamed to.
+    """
+    backup = _backup_path(path)
+    # replace() gives deterministic cross-platform behavior. In the
+    # (unlikely) race where the chosen backup name is created between
+    # the exists() check in _backup_path and this call, the
+    # just-created file is silently overwritten -- a narrow window
+    # this single-user, widget-driven code accepts.
+    path.replace(backup)
+    return backup
+
+
+def _copy_aside(path):
+    """
+    Copy a file to a backup name that does not already exist, leaving
+    the original in place.
+
+    Used instead of `_move_aside` when the original must survive at its
+    own name until a subsequent step succeeds -- a failure after the
+    copy leaves the file where it was.
+
+    Parameters
+    ----------
+    path : `pathlib.Path`
+        The file to copy.
+
+    Returns
+    -------
+    `pathlib.Path`
+        The path of the backup copy.
+    """
+    backup = _backup_path(path)
+    # Copy bytes, not text -- the file being set aside may not be
+    # decodable. Exclusive creation ("x") preserves the guarantee that
+    # an existing backup is never overwritten even if the chosen name
+    # appears between _backup_path and this write.
+    with backup.open("xb") as f:
+        f.write(path.read_bytes())
+    return backup
+
+
+def _atomic_write_json(file, json_data, set_aside_target=False):
+    """
+    Write JSON content to a file so that a failure at any point leaves
+    any existing file at the target untouched.
+
+    The content goes to a temporary file in the same directory that
+    atomically replaces the target on success. mkstemp creates the
+    temporary file exclusively with a unique name, so overlapping writes
+    cannot collide on it.
+
+    Parameters
+    ----------
+    file : `pathlib.Path`
+        The destination file.
+
+    json_data : str
+        The JSON content to write.
+
+    set_aside_target : bool, optional
+        If True, preserve the existing (presumably unreadable) file at
+        the target as a ``.bak`` copy before it is replaced. The backup
+        is a copy made between writing the temporary file and the
+        replace, so a failure at either point leaves the target in place
+        under its original name.
+    """
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=file.parent, prefix=file.name + ".", suffix=".tmp"
+    )
+    os.close(tmp_fd)
+    tmp_file = Path(tmp_name)
+    try:
+        tmp_file.write_text(json_data, encoding=ENCODING)
+        if set_aside_target:
+            _copy_aside(file)
+        tmp_file.replace(file)
+    finally:
+        # After a successful replace the temporary file no longer exists,
+        # so this only cleans up after a failed write.
+        tmp_file.unlink(missing_ok=True)
+
+
 class SavedFileOperations:
     # Provide a place to store the path to the settings file. Annotate as a ClassVar
     # so that pydantic doesn't think it is a field. Also mark it as private to
@@ -50,8 +169,7 @@ class SavedFileOperations:
     def save(self):
         file_path = self._settings_path / self._file_name
         json_data = self.model_dump_json(indent=4)
-        with file_path.open("w", encoding=ENCODING) as f:
-            f.write(json_data)
+        _atomic_write_json(file_path, json_data)
 
     def get(self, name):
         """
@@ -458,6 +576,17 @@ class PhotometryWorkingDirSettings:
         unreadable_full = self._full_settings_unreadable
         unreadable_partial = self._partial_settings_unreadable
 
+        # When both files were readable, load() either removed a partial
+        # file that matched the full settings or raised because the two
+        # conflict. Both still being loaded therefore means the partial
+        # settings conflict with the full settings: their values must not
+        # leak into what is saved, and the partial file -- which may hold
+        # the only copy of the conflicting values -- is preserved as a
+        # backup below instead of deleted.
+        conflicting_partial = (
+            self._settings is not None and self._partial_settings is not None
+        )
+
         match settings:
             case PartialPhotometrySettings():
                 # This case MUST come first, because PartialPhotometrySettings is a
@@ -490,8 +619,16 @@ class PhotometryWorkingDirSettings:
                     # their own and the unreadable file is renamed with a .bak
                     # suffix once the new settings are safely on disk.
 
-                # Are we updating or replacing partial settings?
-                if update and self._partial_settings is not None:
+                # Are we updating or replacing partial settings? A
+                # conflicting partial is skipped: the settings here have
+                # already been merged into the full settings above, and
+                # merging them into the stale partial would resurrect any
+                # of its values the full settings legitimately set to None.
+                if (
+                    update
+                    and not conflicting_partial
+                    and (self._partial_settings is not None)
+                ):
                     # Get the partial settings that were loaded from disk
                     existing_partial_settings = self._partial_settings.model_dump()
 
@@ -536,124 +673,31 @@ class PhotometryWorkingDirSettings:
 
         # Write the settings to a file. The settings themselves are models, so we
         # are guaranteed to write the correct model type (partial or full settings)
-        # to the file. Write to a temporary file in the same directory and then
-        # atomically replace the target, so that a failure at any point during
-        # serialization or writing leaves any existing settings file untouched.
-        # mkstemp creates the file exclusively with a unique name, so
-        # overlapping saves cannot collide on the temporary file.
+        # to the file.
         json_data = settings.model_dump_json(indent=4)
-        tmp_fd, tmp_name = tempfile.mkstemp(
-            dir=file.parent, prefix=file.name + ".", suffix=".tmp"
-        )
-        os.close(tmp_fd)
-        tmp_file = Path(tmp_name)
-        try:
-            tmp_file.write_text(json_data, encoding=ENCODING)
-            if set_aside_target:
-                self._copy_aside(file)
-            tmp_file.replace(file)
-        finally:
-            # After a successful replace the temporary file no longer exists,
-            # so this only cleans up after a failed write.
-            tmp_file.unlink(missing_ok=True)
+        _atomic_write_json(file, json_data, set_aside_target=set_aside_target)
 
         if not full_settings and unreadable_full and self._settings_file.exists():
             # This save wrote only the partial file, but the bookkeeping load
             # found the full settings file unreadable. Leaving that file
             # behind would keep every future load failing, so it is set
             # aside now that the new partial settings are safely on disk.
-            self._move_aside(self._settings_file)
+            _move_aside(self._settings_file)
             self._settings = None
 
         if full_settings:
             # Now that the full settings that supersede the partial settings
             # are safely on disk, the partial settings file can be disposed
             # of. Doing this only after a successful write means a failed
-            # write cannot destroy the partial settings. An unreadable
-            # partial settings file is preserved as .bak instead of deleted
-            # -- it may hold the only copy of some values.
+            # write cannot destroy the partial settings. An unreadable or
+            # conflicting partial settings file is preserved as .bak instead
+            # of deleted -- it may hold the only copy of some values.
             if self._partial_settings_file.exists():
-                if unreadable_partial:
-                    self._move_aside(self._partial_settings_file)
+                if unreadable_partial or conflicting_partial:
+                    _move_aside(self._partial_settings_file)
                 else:
                     self._partial_settings_file.unlink()
             self._partial_settings = None
-
-    @staticmethod
-    def _backup_path(path):
-        """
-        Choose a backup name for a file that does not already exist.
-
-        Parameters
-        ----------
-        path : `pathlib.Path`
-            The file a backup name is needed for.
-
-        Returns
-        -------
-        `pathlib.Path`
-            The first available of ``<name>.bak``, ``<name>.bak1``,
-            ``<name>.bak2``, ... so an earlier backup -- which may hold
-            the only copy of settings from a previous corruption -- is
-            never overwritten.
-        """
-        backup = path.with_name(path.name + ".bak")
-        counter = 0
-        while backup.exists():
-            counter += 1
-            backup = path.with_name(f"{path.name}.bak{counter}")
-        return backup
-
-    def _move_aside(self, path):
-        """
-        Rename a file to a backup name that does not already exist.
-
-        Parameters
-        ----------
-        path : `pathlib.Path`
-            The file to rename.
-
-        Returns
-        -------
-        `pathlib.Path`
-            The path the file was renamed to.
-        """
-        backup = self._backup_path(path)
-        # replace() gives deterministic cross-platform behavior. In the
-        # (unlikely) race where the chosen backup name is created between
-        # the exists() check in _backup_path and this call, the
-        # just-created file is silently overwritten -- a narrow window
-        # this single-user, widget-driven code accepts.
-        path.replace(backup)
-        return backup
-
-    def _copy_aside(self, path):
-        """
-        Copy a file to a backup name that does not already exist, leaving
-        the original in place.
-
-        Used instead of `_move_aside` when the original must survive at its
-        own name until a subsequent step succeeds -- a failure after the
-        copy leaves the file where it was.
-
-        Parameters
-        ----------
-        path : `pathlib.Path`
-            The file to copy.
-
-        Returns
-        -------
-        `pathlib.Path`
-            The path of the backup copy.
-        """
-        backup = self._backup_path(path)
-        # Copy bytes, not text -- the file being set aside may not be
-        # decodable. Exclusive creation ("x") preserves the guarantee that
-        # an existing backup is never overwritten even if the chosen name
-        # appears between _backup_path and this write.
-        with backup.open("xb") as f:
-            f.write(path.read_bytes())
-        return backup
 
     def load(self):
         """

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -111,11 +111,24 @@ def _copy_aside(path):
     """
     backup = _backup_path(path)
     # Copy bytes, not text -- the file being set aside may not be
-    # decodable. Exclusive creation ("x") preserves the guarantee that
-    # an existing backup is never overwritten even if the chosen name
-    # appears between _backup_path and this write.
-    with backup.open("xb") as f:
-        f.write(path.read_bytes())
+    # decodable. Reading before the backup is created means a source
+    # that cannot be read leaves nothing behind. Exclusive creation
+    # ("x") preserves the guarantee that an existing backup is never
+    # overwritten even if the chosen name appears between _backup_path
+    # and this write.
+    data = path.read_bytes()
+    try:
+        with backup.open("xb") as f:
+            f.write(data)
+    except FileExistsError:
+        # The exclusive open created nothing -- the file at the backup
+        # name belongs to another writer, so it must not be removed.
+        raise
+    except OSError:
+        # A failed write leaves an empty or truncated backup that later
+        # set-asides would skip past; remove it before propagating.
+        backup.unlink(missing_ok=True)
+        raise
     return backup
 
 

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -1,4 +1,6 @@
+import os
 import re
+import tempfile
 from pathlib import Path
 from typing import ClassVar
 
@@ -13,13 +15,30 @@ from .models import (
     PhotometrySettings,
 )
 
-__all__ = ["SavedSettings", "SETTINGS_FILE_VERSION", "PhotometryWorkingDirSettings"]
+__all__ = [
+    "SavedSettings",
+    "SETTINGS_FILE_VERSION",
+    "PhotometryWorkingDirSettings",
+    "SettingsFileReadError",
+]
 
 # We will have to version settings formats, I think. Hopefully this changes rarely
 # or never.
 SETTINGS_FILE_VERSION = "2"  # value chosen to match major version of stellarphot
 
 ENCODING = "utf-8"
+
+
+class SettingsFileReadError(ValueError):
+    """
+    Raised when a settings file exists but cannot be read because of an
+    operating-system or encoding error, as opposed to a readable file that
+    contains invalid settings.
+
+    Subclasses `ValueError` so callers that catch `ValueError` are
+    unaffected, while letting a caller distinguish "your settings exist but
+    could not be read" from "no or invalid settings".
+    """
 
 
 class SavedFileOperations:
@@ -407,8 +426,8 @@ class PhotometryWorkingDirSettings:
         settings are saved.
 
         An existing settings file that cannot be read is never overwritten in
-        place; it is renamed with a ``.bak`` suffix before the new settings
-        are written, and a save also sets aside, with the same ``.bak``
+        place; it is preserved under a ``.bak`` name before the new settings
+        replace it, and a save also sets aside, with the same ``.bak``
         naming, any settings file its pre-save load found unreadable even
         when the save does not rewrite that particular file. Existing backups
         are never overwritten; if a ``.bak`` file already exists, numbered
@@ -431,10 +450,11 @@ class PhotometryWorkingDirSettings:
             pass
 
         # Whether each existing settings file failed to parse during the
-        # bookkeeping load above. load() latches these flags and parses both
-        # files before raising, so they are accurate even when only one of
-        # the two files is unreadable. They decide below whether a file
-        # about to be replaced is renamed aside instead of destroyed.
+        # bookkeeping load above. load() records these flags on the instance
+        # before raising, and it parses both files before raising, so the
+        # flags are accurate even when only one of the two files is
+        # unreadable. They decide below whether a file about to be replaced
+        # is set aside as a backup instead of destroyed.
         unreadable_full = self._full_settings_unreadable
         unreadable_partial = self._partial_settings_unreadable
 
@@ -506,11 +526,10 @@ class PhotometryWorkingDirSettings:
                 )
 
         # If the file we are about to write exists but could not be read, its
-        # contents must be set aside rather than overwritten. The rename
-        # happens between writing the temporary file and the replace below,
-        # so a failure while writing the new content leaves the unreadable
-        # file in place under its original name instead of leaving no
-        # settings file at all.
+        # contents must be set aside rather than overwritten. The backup is a
+        # copy made between writing the temporary file and the replace below,
+        # so a failure at either point leaves the unreadable file in place
+        # under its original name instead of leaving no settings file at all.
         set_aside_target = (file == self._settings_file and unreadable_full) or (
             file == self._partial_settings_file and unreadable_partial
         )
@@ -520,12 +539,18 @@ class PhotometryWorkingDirSettings:
         # to the file. Write to a temporary file in the same directory and then
         # atomically replace the target, so that a failure at any point during
         # serialization or writing leaves any existing settings file untouched.
+        # mkstemp creates the file exclusively with a unique name, so
+        # overlapping saves cannot collide on the temporary file.
         json_data = settings.model_dump_json(indent=4)
-        tmp_file = file.with_name(file.name + ".tmp")
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            dir=file.parent, prefix=file.name + ".", suffix=".tmp"
+        )
+        os.close(tmp_fd)
+        tmp_file = Path(tmp_name)
         try:
             tmp_file.write_text(json_data, encoding=ENCODING)
             if set_aside_target:
-                self._move_aside(file)
+                self._copy_aside(file)
             tmp_file.replace(file)
         finally:
             # After a successful replace the temporary file no longer exists,
@@ -554,26 +579,80 @@ class PhotometryWorkingDirSettings:
                     self._partial_settings_file.unlink()
             self._partial_settings = None
 
-    def _move_aside(self, path):
+    @staticmethod
+    def _backup_path(path):
         """
-        Rename ``path`` to a backup name that does not already exist and
-        return the backup path.
+        Choose a backup name for a file that does not already exist.
 
-        The first available of ``path.bak``, ``path.bak1``, ``path.bak2``,
-        ... is used, so an earlier backup -- which may hold the only copy of
-        settings from a previous corruption -- is never overwritten.
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            The file a backup name is needed for.
+
+        Returns
+        -------
+        `pathlib.Path`
+            The first available of ``<name>.bak``, ``<name>.bak1``,
+            ``<name>.bak2``, ... so an earlier backup -- which may hold
+            the only copy of settings from a previous corruption -- is
+            never overwritten.
         """
         backup = path.with_name(path.name + ".bak")
         counter = 0
         while backup.exists():
             counter += 1
             backup = path.with_name(f"{path.name}.bak{counter}")
+        return backup
+
+    def _move_aside(self, path):
+        """
+        Rename a file to a backup name that does not already exist.
+
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            The file to rename.
+
+        Returns
+        -------
+        `pathlib.Path`
+            The path the file was renamed to.
+        """
+        backup = self._backup_path(path)
         # replace() gives deterministic cross-platform behavior. In the
         # (unlikely) race where the chosen backup name is created between
-        # the exists() check above and this call, the just-created file is
-        # silently overwritten -- a narrow window this single-user,
-        # widget-driven code accepts.
+        # the exists() check in _backup_path and this call, the
+        # just-created file is silently overwritten -- a narrow window
+        # this single-user, widget-driven code accepts.
         path.replace(backup)
+        return backup
+
+    def _copy_aside(self, path):
+        """
+        Copy a file to a backup name that does not already exist, leaving
+        the original in place.
+
+        Used instead of `_move_aside` when the original must survive at its
+        own name until a subsequent step succeeds -- a failure after the
+        copy leaves the file where it was.
+
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            The file to copy.
+
+        Returns
+        -------
+        `pathlib.Path`
+            The path of the backup copy.
+        """
+        backup = self._backup_path(path)
+        # Copy bytes, not text -- the file being set aside may not be
+        # decodable. Exclusive creation ("x") preserves the guarantee that
+        # an existing backup is never overwritten even if the chosen name
+        # appears between _backup_path and this write.
+        with backup.open("xb") as f:
+            f.write(path.read_bytes())
         return backup
 
     def load(self):
@@ -588,9 +667,13 @@ class PhotometryWorkingDirSettings:
         Raises
         ------
         ValueError
-            If no settings file exists, if a settings file exists but cannot
-            be read, or if the partial and full settings files are both
-            readable but conflict with each other.
+            If no settings file exists, if a settings file can be read but
+            contains invalid settings, or if the partial and full settings
+            files are both readable but conflict with each other.
+        SettingsFileReadError
+            If a settings file exists but cannot be read because of an
+            operating-system or encoding error. This is a subclass of
+            `ValueError`.
         """
         # Assume we have nothing to begin....
         self._partial_settings = None
@@ -601,46 +684,72 @@ class PhotometryWorkingDirSettings:
         if not (self._settings_file.exists() or self._partial_settings_file.exists()):
             raise ValueError(f"Settings file {self._settings_file} does not exist")
 
-        errors = []
-        last_exc = None
-
-        # Load PartialPhotometrySettings first, if it exists. A read failure
-        # (ValidationError, or an OSError/UnicodeDecodeError while opening or
-        # decoding the file) leaves self._partial_settings as None, exactly
-        # like the missing-file case.
-        if self._partial_settings_file.exists():
-            try:
-                with self._partial_settings_file.open(encoding=ENCODING) as f:
-                    content = f.read()
-                self._partial_settings = PartialPhotometrySettings.model_validate_json(
-                    content
-                )
-            except (ValidationError, OSError, UnicodeDecodeError) as e:
-                self._partial_settings_unreadable = True
-                errors.append(f"Error loading partial settings: {e}")
-                last_exc = e
+        # Load PartialPhotometrySettings first, if it exists. A failure
+        # leaves self._partial_settings as None, exactly like the
+        # missing-file case.
+        self._partial_settings, partial_exc = self._try_load(
+            self._partial_settings_file, PartialPhotometrySettings
+        )
+        self._partial_settings_unreadable = partial_exc is not None
 
         # Now load full settings if they exist
-        if self._settings_file.exists():
-            try:
-                with self._settings_file.open(encoding=ENCODING) as f:
-                    content = f.read()
-                self._settings = PhotometrySettings.model_validate_json(content)
-            except (ValidationError, OSError, UnicodeDecodeError) as e:
-                self._full_settings_unreadable = True
-                errors.append(f"Error loading settings: {e}")
-                last_exc = e
+        self._settings, full_exc = self._try_load(
+            self._settings_file, PhotometrySettings
+        )
+        self._full_settings_unreadable = full_exc is not None
 
         # Both files are parsed before any error is raised so that the
         # in-memory settings reflect every file that could be read; save()
-        # relies on that to merge into readable settings and to rename only
-        # genuinely unreadable files to .bak.
+        # relies on that to merge into readable settings and to set aside
+        # only genuinely unreadable files as .bak.
+        errors = []
+        if partial_exc is not None:
+            errors.append(f"Error loading partial settings: {partial_exc}")
+        if full_exc is not None:
+            errors.append(f"Error loading settings: {full_exc}")
         if errors:
-            raise ValueError("\n".join(errors)) from last_exc
+            # An OS-level or encoding failure means the settings themselves
+            # may be perfectly valid, so it is reported with a distinct
+            # (ValueError-subclass) exception type.
+            exceptions = [e for e in (partial_exc, full_exc) if e is not None]
+            error_class = (
+                SettingsFileReadError
+                if any(isinstance(e, (OSError, UnicodeDecodeError)) for e in exceptions)
+                else ValueError
+            )
+            raise error_class("\n".join(errors)) from exceptions[-1]
 
         # Handle case where we have valid partial and valid full settings
         self._resolve_full_partial_conflict()
         return self._settings or self._partial_settings
+
+    @staticmethod
+    def _try_load(path, model_cls):
+        """
+        Parse one settings file.
+
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            The settings file to parse.
+
+        model_cls : type
+            The pydantic model class to validate the file contents against.
+
+        Returns
+        -------
+        model, exception : (``model_cls`` or None, Exception or None)
+            The parsed settings and ``None`` on success; ``None`` and the
+            exception when the file is missing or cannot be read (the
+            exception is ``None`` for a missing file).
+        """
+        if not path.exists():
+            return None, None
+        try:
+            with path.open(encoding=ENCODING) as f:
+                return model_cls.model_validate_json(f.read()), None
+        except (ValidationError, OSError, UnicodeDecodeError) as e:
+            return None, e
 
     def _resolve_full_partial_conflict(self):
         """

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -14,11 +14,18 @@ from stellarphot.settings import (
     PhotometrySettings,
     PhotometryWorkingDirSettings,
     SavedSettings,
+    SettingsFileReadError,
     settings_files,  # This import is needed for mocking -- see TestSavedSettings
 )
 from stellarphot.settings.constants import TEST_PHOTOMETRY_SETTINGS
 
 TEST_PHOTOMETRY_SETTINGS = deepcopy(TEST_PHOTOMETRY_SETTINGS)
+
+
+def bak_path(path, suffix=".bak"):
+    """Return the backup name save() uses when setting aside ``path``."""
+    return path.with_name(path.name + suffix)
+
 
 CAMERA = """
 {
@@ -489,9 +496,7 @@ class TestPhotometryWorkingDirSettings:
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
         assert not settings_file.settings_file.exists()
-        backup_file = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.settings_file)
         assert backup_file.read_text() == bad_content
 
     def test_save_partial_with_unreadable_partial_settings_makes_backup(self):
@@ -508,9 +513,7 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
-        backup_file = settings_file.partial_settings_file.with_name(
-            settings_file.partial_settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.partial_settings_file)
         assert backup_file.read_text() == bad_content
 
     def test_save_full_with_unreadable_full_settings_makes_backup(self):
@@ -527,9 +530,7 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.settings_file.exists()
         assert settings_file.settings == settings
-        backup_file = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.settings_file)
         assert backup_file.read_text() == bad_content
 
     def test_save_full_with_unreadable_partial_settings_makes_backup(self):
@@ -546,9 +547,7 @@ class TestPhotometryWorkingDirSettings:
         assert settings_file.settings_file.exists()
         assert settings_file.settings == full_settings
         assert not settings_file.partial_settings_file.exists()
-        backup_file = settings_file.partial_settings_file.with_name(
-            settings_file.partial_settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.partial_settings_file)
         assert backup_file.read_text() == bad_content
 
     def test_save_partial_update_with_corrupt_partial_and_valid_full(self):
@@ -578,9 +577,7 @@ class TestPhotometryWorkingDirSettings:
 
         # Assert: corrupt partial file is renamed to .bak
         assert not settings_file.partial_settings_file.exists()
-        backup_file = settings_file.partial_settings_file.with_name(
-            settings_file.partial_settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.partial_settings_file)
         assert backup_file.exists()
         assert backup_file.read_text() == corrupt_partial_content
 
@@ -624,9 +621,7 @@ class TestPhotometryWorkingDirSettings:
 
         # Assert: corrupt full file was set aside as .bak, content preserved
         assert not settings_file.settings_file.exists()
-        backup_file = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.settings_file)
         assert backup_file.read_text() == corrupt_full_content
 
         # Assert: with the corrupt file out of the way, load() succeeds and
@@ -642,9 +637,7 @@ class TestPhotometryWorkingDirSettings:
         # than overwriting the existing .bak.
         settings_file = PhotometryWorkingDirSettings()
         old_backup_content = '{"pasta": "amatriciana"}'
-        backup_file = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.settings_file)
         backup_file.write_text(old_backup_content)
 
         bad_content = '{"pasta": "carbonara"}'
@@ -656,9 +649,7 @@ class TestPhotometryWorkingDirSettings:
         # The earlier backup is untouched and the unreadable file went to
         # the next available numbered name.
         assert backup_file.read_text() == old_backup_content
-        numbered_backup = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak1"
-        )
+        numbered_backup = bak_path(settings_file.settings_file, ".bak1")
         assert numbered_backup.read_text() == bad_content
         assert settings_file.settings == full_settings
 
@@ -703,9 +694,9 @@ class TestPhotometryWorkingDirSettings:
             PhotometryWorkingDirSettings().save(full_settings)
 
         assert settings_file.settings_file.read_text() == original
-        assert not settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".tmp"
-        ).exists()
+        # The temporary file has a randomized name, so check that nothing
+        # matching its pattern was left behind.
+        assert not list(settings_file.settings_file.parent.glob("*.tmp"))
 
     def test_failed_write_leaves_unreadable_file_in_place(self, mocker):
         # If writing the new settings fails, an unreadable file at the
@@ -721,20 +712,72 @@ class TestPhotometryWorkingDirSettings:
             settings_file.save(full_settings)
 
         assert settings_file.settings_file.read_text() == bad_content
-        assert not settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        ).exists()
+        assert not bak_path(settings_file.settings_file).exists()
+
+    def test_failed_replace_leaves_unreadable_file_in_place(self, mocker):
+        # If the atomic replace of the target file itself fails, the
+        # unreadable file being set aside must still be present under its
+        # original name -- the backup is a copy, not a rename, until the
+        # new settings are actually in place.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+
+        # Fail only the replace whose target is the settings file, so any
+        # rename to a backup name still succeeds.
+        real_replace = Path.replace
+
+        def flaky_replace(self, target):
+            if target == settings_file.settings_file:
+                raise OSError("sharing violation")
+            return real_replace(self, target)
+
+        mocker.patch.object(Path, "replace", flaky_replace)
+        with pytest.raises(OSError, match="sharing violation"):
+            settings_file.save(full_settings)
+
+        assert settings_file.settings_file.read_text() == bad_content
+        # The backup copy made before the replace is still around, and no
+        # temporary file is left behind.
+        assert bak_path(settings_file.settings_file).read_text() == bad_content
+        assert not list(settings_file.settings_file.parent.glob("*.tmp"))
+
+    def test_load_oserror_raises_settings_file_read_error(self, mocker):
+        # An OS-level failure to read a settings file is a different
+        # situation than a file with bad contents: the settings may be
+        # perfectly valid. load() signals that with SettingsFileReadError,
+        # which subclasses ValueError so existing callers are unaffected.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        mocker.patch.object(Path, "open", side_effect=PermissionError("denied"))
+        with pytest.raises(SettingsFileReadError, match="denied"):
+            settings_file.load()
+
+    def test_load_corrupt_json_raises_plain_value_error(self):
+        # A file that can be read but contains invalid settings is not a
+        # read error; it raises plain ValueError, not SettingsFileReadError.
+        settings_file = PhotometryWorkingDirSettings()
+        settings_file.settings_file.write_text('{"pasta": "carbonara"}')
+
+        with pytest.raises(ValueError, match="Error loading settings") as exc_info:
+            settings_file.load()
+
+        assert not isinstance(exc_info.value, SettingsFileReadError)
 
     def test_load_settings_file_invalid_utf8(self):
-        # A settings file that is not valid UTF-8 should be treated the same
-        # as a ValidationError: load() reports it as a readable-but-bad file,
-        # and a subsequent save preserves the original bytes as a .bak rather
+        # A settings file that is not valid UTF-8 cannot be read at all, so
+        # load() raises SettingsFileReadError (a ValueError subclass), and a
+        # subsequent save preserves the original bytes as a .bak rather
         # than silently overwriting them.
         settings_file = PhotometryWorkingDirSettings()
         bad_bytes = b"\xff\xfe not utf8"
         settings_file.settings_file.write_bytes(bad_bytes)
 
-        with pytest.raises(ValueError, match="Error loading settings"):
+        with pytest.raises(SettingsFileReadError, match="Error loading settings"):
             settings_file.load()
 
         full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
@@ -742,9 +785,7 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.settings_file.exists()
         assert settings_file.settings == full_settings
-        backup_file = settings_file.settings_file.with_name(
-            settings_file.settings_file.name + ".bak"
-        )
+        backup_file = bak_path(settings_file.settings_file)
         assert backup_file.read_bytes() == bad_bytes
 
     def test_load_conflicting_partial_and_full_settings(self):

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -364,7 +364,9 @@ class TestPhotometryWorkingDirSettings:
         # Need to accept the second argument, but don't use it.
         self.original_wdir = Path.cwd()
         os.chdir(self.temp_dir.name)
-        for file in Path.cwd().glob("*.json"):
+        # The glob pattern also matches the .json.bak and .json.tmp files
+        # some tests leave behind.
+        for file in Path.cwd().glob("*.json*"):
             file.unlink()
 
     def teardown_method(self, _):
@@ -472,8 +474,10 @@ class TestPhotometryWorkingDirSettings:
         # An existing full settings file that cannot be read used to make
         # save(partial, update=True) crash with an AttributeError, because
         # the failed load left self._settings as None. There is nothing to
-        # merge the partial settings into in that case, so they are saved
-        # on their own and the unreadable file is left in place.
+        # merge the partial settings into in that case, so the partial
+        # settings are saved on their own and the unreadable file is set
+        # aside as .bak -- a save never leaves behind a file it knows is
+        # unreadable.
         settings_file = PhotometryWorkingDirSettings()
         bad_content = '{"pasta": "carbonara"}'
         settings_file.settings_file.write_text(bad_content)
@@ -484,7 +488,264 @@ class TestPhotometryWorkingDirSettings:
 
         assert settings_file.partial_settings_file.exists()
         assert settings_file.partial_settings == partial_settings
+        assert not settings_file.settings_file.exists()
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_partial_with_unreadable_partial_settings_makes_backup(self):
+        # An existing partial settings file that cannot be read should not be
+        # overwritten by a partial save. The new partial settings are written
+        # and the unreadable original is preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.partial_settings_file.write_text(bad_content)
+
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.save(partial_settings, update=True)
+
+        assert settings_file.partial_settings_file.exists()
+        assert settings_file.partial_settings == partial_settings
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_full_with_unreadable_full_settings_makes_backup(self):
+        # An existing full settings file that cannot be read should not be
+        # overwritten when partial settings that are actually complete are
+        # saved to the full settings file. The new full settings are written
+        # and the unreadable original is preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "amatriciana"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(settings, update=True)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == settings
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_full_with_unreadable_partial_settings_makes_backup(self):
+        # Saving full settings normally deletes any partial settings file. If
+        # the partial settings file cannot be read it should instead be
+        # preserved with a .bak suffix.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "puttanesca"}'
+        settings_file.partial_settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == bad_content
+
+    def test_save_partial_update_with_corrupt_partial_and_valid_full(self):
+        # Test that when both a valid full settings file and a corrupt partial
+        # settings file exist, a partial save with update=True will:
+        # 1. Rename the corrupt partial file to .bak
+        # 2. Merge the new partial into the valid full settings
+        # 3. Save the result as a full settings file (since the partial is
+        #    compatible with full)
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a valid full settings file
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.settings_file.write_text(full_settings.model_dump_json(indent=4))
+
+        # Write a corrupt partial settings file
+        corrupt_partial_content = '{"pasta": "carbonara"}'
+        settings_file.partial_settings_file.write_text(corrupt_partial_content)
+
+        # Create a fresh instance to trigger load()
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Save a new partial settings with a different camera
+        camera = Camera.model_validate_json(CAMERA)
+        new_partial = PartialPhotometrySettings(camera=camera)
+        settings_file.save(new_partial, update=True)
+
+        # Assert: corrupt partial file is renamed to .bak
+        assert not settings_file.partial_settings_file.exists()
+        backup_file = settings_file.partial_settings_file.with_name(
+            settings_file.partial_settings_file.name + ".bak"
+        )
+        assert backup_file.exists()
+        assert backup_file.read_text() == corrupt_partial_content
+
+        # Assert: subsequent load succeeds and returns merged settings
+        fresh_instance = PhotometryWorkingDirSettings()
+        loaded = fresh_instance.load()
+        # The loaded settings should have the new camera and all other fields
+        # from the original full settings
+        assert loaded.camera == camera
+        assert (
+            loaded.observatory
+            == PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS).observatory
+        )
+
+    def test_save_partial_update_with_corrupt_full_and_valid_partial(self):
+        # Test that when both a corrupt full settings file and a valid partial
+        # settings file exist, a partial save with update=True will:
+        # 1. Set the corrupt full file aside as .bak, content preserved
+        # 2. Merge into the valid partial and save the result
+        # 3. Leave the directory loadable again
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Write a valid partial settings file with a camera
+        camera = Camera.model_validate_json(CAMERA)
+        partial_settings = PartialPhotometrySettings(camera=camera)
+        settings_file.partial_settings_file.write_text(
+            partial_settings.model_dump_json(indent=4)
+        )
+
+        # Write a corrupt full settings file
+        corrupt_full_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(corrupt_full_content)
+
+        # Create a fresh instance
+        settings_file = PhotometryWorkingDirSettings()
+
+        # Save a new partial settings with an observatory
+        observatory = Observatory(**TEST_PHOTOMETRY_SETTINGS["observatory"])
+        new_partial = PartialPhotometrySettings(observatory=observatory)
+        settings_file.save(new_partial, update=True)
+
+        # Assert: corrupt full file was set aside as .bak, content preserved
+        assert not settings_file.settings_file.exists()
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_text() == corrupt_full_content
+
+        # Assert: with the corrupt file out of the way, load() succeeds and
+        # returns the merged settings (old camera + new observatory).
+        loaded = PhotometryWorkingDirSettings().load()
+        assert loaded.camera == camera
+        assert loaded.observatory == observatory
+
+    def test_save_does_not_overwrite_existing_backup(self):
+        # A .bak file may hold the only copy of settings from an earlier
+        # corruption, so a save that needs to set aside another unreadable
+        # file must use a numbered backup name (.bak1, .bak2, ...) rather
+        # than overwriting the existing .bak.
+        settings_file = PhotometryWorkingDirSettings()
+        old_backup_content = '{"pasta": "amatriciana"}'
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        backup_file.write_text(old_backup_content)
+
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        # The earlier backup is untouched and the unreadable file went to
+        # the next available numbered name.
+        assert backup_file.read_text() == old_backup_content
+        numbered_backup = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak1"
+        )
+        assert numbered_backup.read_text() == bad_content
+        assert settings_file.settings == full_settings
+
+    def test_failed_write_preserves_partial_settings_file(self, mocker):
+        # Saving full settings disposes of the partial settings file, whose
+        # non-None values may exist nowhere else if the write of the full
+        # settings then fails. The disposal must therefore happen only after
+        # the full settings are safely on disk.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        # The partial camera matches the full settings being saved, which is
+        # the case where save() would simply delete (not back up) the
+        # partial settings file.
+        partial_content = PartialPhotometrySettings(
+            camera=full_settings.camera
+        ).model_dump_json()
+        settings_file.partial_settings_file.write_text(partial_content)
+
+        # Serialization happens before the settings file is opened for
+        # writing, so this failure stands in for any failure to get the new
+        # settings onto disk.
+        mocker.patch.object(
+            PhotometrySettings, "model_dump_json", side_effect=RuntimeError("disk full")
+        )
+        with pytest.raises(RuntimeError, match="disk full"):
+            settings_file.save(full_settings)
+
+        assert settings_file.partial_settings_file.read_text() == partial_content
+
+    def test_failed_write_leaves_existing_settings_intact(self, mocker):
+        # A failure partway through writing the new settings must not
+        # truncate or destroy the existing readable settings file; the
+        # write goes to a temporary file that atomically replaces the
+        # target only on success.
+        settings_file = PhotometryWorkingDirSettings()
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+        original = settings_file.settings_file.read_text()
+
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            PhotometryWorkingDirSettings().save(full_settings)
+
+        assert settings_file.settings_file.read_text() == original
+        assert not settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".tmp"
+        ).exists()
+
+    def test_failed_write_leaves_unreadable_file_in_place(self, mocker):
+        # If writing the new settings fails, an unreadable file at the
+        # target name must remain in place under its original name -- not
+        # be renamed to .bak with nothing left in its place.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_content = '{"pasta": "carbonara"}'
+        settings_file.settings_file.write_text(bad_content)
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            settings_file.save(full_settings)
+
         assert settings_file.settings_file.read_text() == bad_content
+        assert not settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        ).exists()
+
+    def test_load_settings_file_invalid_utf8(self):
+        # A settings file that is not valid UTF-8 should be treated the same
+        # as a ValidationError: load() reports it as a readable-but-bad file,
+        # and a subsequent save preserves the original bytes as a .bak rather
+        # than silently overwriting them.
+        settings_file = PhotometryWorkingDirSettings()
+        bad_bytes = b"\xff\xfe not utf8"
+        settings_file.settings_file.write_bytes(bad_bytes)
+
+        with pytest.raises(ValueError, match="Error loading settings"):
+            settings_file.load()
+
+        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+        settings_file.save(full_settings)
+
+        assert settings_file.settings_file.exists()
+        assert settings_file.settings == full_settings
+        backup_file = settings_file.settings_file.with_name(
+            settings_file.settings_file.name + ".bak"
+        )
+        assert backup_file.read_bytes() == bad_bytes
 
     def test_load_conflicting_partial_and_full_settings(self):
         # Make a valid partial settings file and a valid full settings file

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -170,6 +170,27 @@ class TestSavedSettings:
         ):
             saved_settings.add_item(item)
 
+    def test_failed_write_leaves_saved_item_file_intact(self, mocker):
+        # An interrupted write of cameras.json (or the other saved-item
+        # files) must not truncate the existing file; the write goes to a
+        # temporary file that atomically replaces the target only on
+        # success.
+        saved_settings = SavedSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        saved_settings.add_item(camera)
+        file_path = saved_settings.settings_path / "cameras.json"
+        original = file_path.read_text()
+
+        camera2 = Camera.model_validate_json(
+            CAMERA.replace("Aspen CG 16m", "Aspen CG 16m 2")
+        )
+        mocker.patch.object(Path, "write_text", side_effect=OSError("disk full"))
+        with pytest.raises(OSError, match="disk full"):
+            saved_settings.add_item(camera2)
+
+        assert file_path.read_text() == original
+        assert not list(file_path.parent.glob("*.tmp"))
+
     def test_adding_multiple_types_of_items(self):
         # Test that adding multiple types of items works.
         saved_settings = SavedSettings()
@@ -756,6 +777,40 @@ class TestPhotometryWorkingDirSettings:
         mocker.patch.object(Path, "open", side_effect=PermissionError("denied"))
         with pytest.raises(SettingsFileReadError, match="denied"):
             settings_file.load()
+
+    def test_save_partial_update_with_conflicting_partial_and_full(self):
+        # When a valid full settings file and a conflicting valid partial
+        # file both exist, a partial save with update=True merges into the
+        # full settings. The conflicting partial's values must not leak into
+        # the result -- a field the full settings legitimately set to None
+        # must stay None -- and the conflicting partial file, whose
+        # differing values are being discarded, is set aside as .bak rather
+        # than deleted.
+        settings_file = PhotometryWorkingDirSettings()
+        full_dict = deepcopy(TEST_PHOTOMETRY_SETTINGS)
+        full_dict["passband_map"] = None
+        full_settings = PhotometrySettings(**full_dict)
+        settings_file.settings_file.write_text(full_settings.model_dump_json(indent=4))
+
+        stale_partial = PartialPhotometrySettings(
+            passband_map=PassbandMap.model_validate_json(PASSBAND_MAP)
+        )
+        stale_content = stale_partial.model_dump_json(indent=4)
+        settings_file.partial_settings_file.write_text(stale_content)
+
+        settings_file = PhotometryWorkingDirSettings()
+        camera = Camera.model_validate_json(CAMERA)
+        settings_file.save(PartialPhotometrySettings(camera=camera), update=True)
+
+        loaded = PhotometryWorkingDirSettings().load()
+        assert loaded.camera == camera
+        # The stale partial's passband_map must not be resurrected.
+        assert loaded.passband_map is None
+        # The conflicting partial file is preserved, not deleted.
+        assert not settings_file.partial_settings_file.exists()
+        assert (
+            bak_path(settings_file.partial_settings_file).read_text() == stale_content
+        )
 
     def test_load_corrupt_json_raises_plain_value_error(self):
         # A file that can be read but contains invalid settings is not a

--- a/stellarphot/settings/tests/test_settings_file.py
+++ b/stellarphot/settings/tests/test_settings_file.py
@@ -381,6 +381,73 @@ class TestSavedSettings:
         assert loaded_camera == camera
 
 
+class TestCopyAside:
+    # _copy_aside must never leave a partial backup behind: an empty or
+    # truncated .bak would make later set-asides skip to .bak1 while a
+    # user recovering by hand finds the useless .bak first.
+
+    def test_read_failure_creates_no_backup(self, tmp_path, mocker):
+        # The source is read before the backup is created, so a source
+        # that cannot be read leaves nothing behind.
+        source = tmp_path / "settings.json"
+        source.write_text("important stuff")
+
+        mocker.patch.object(Path, "read_bytes", side_effect=PermissionError("denied"))
+        with pytest.raises(PermissionError, match="denied"):
+            settings_files._copy_aside(source)
+
+        assert not bak_path(source).exists()
+
+    def test_write_failure_removes_partial_backup(self, tmp_path, mocker):
+        source = tmp_path / "settings.json"
+        source.write_text("important stuff")
+
+        real_open = Path.open
+
+        class FailingWriter:
+            def __init__(self, handle):
+                self._handle = handle
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                self._handle.close()
+                return False
+
+            def write(self, _data):
+                raise OSError("no space left on device")
+
+        def failing_open(self, mode="r", *args, **kwargs):
+            handle = real_open(self, mode, *args, **kwargs)
+            return FailingWriter(handle) if "x" in mode else handle
+
+        mocker.patch.object(Path, "open", failing_open)
+        with pytest.raises(OSError, match="no space"):
+            settings_files._copy_aside(source)
+
+        assert not bak_path(source).exists()
+        assert source.read_text() == "important stuff"
+
+    def test_lost_backup_name_race_does_not_delete_existing_backup(
+        self, tmp_path, mocker
+    ):
+        # If another writer claims the chosen backup name between
+        # _backup_path and the exclusive open, the FileExistsError that
+        # results must not delete the other writer's file -- only a
+        # backup this call actually created may be cleaned up.
+        source = tmp_path / "settings.json"
+        source.write_text("new corruption")
+        existing = bak_path(source)
+        existing.write_text("previous backup")
+
+        mocker.patch.object(settings_files, "_backup_path", return_value=existing)
+        with pytest.raises(FileExistsError):
+            settings_files._copy_aside(source)
+
+        assert existing.read_text() == "previous backup"
+
+
 class TestPhotometryWorkingDirSettings:
     def setup_class(cls):
         cls.temp_dir = TemporaryDirectory()
@@ -498,78 +565,60 @@ class TestPhotometryWorkingDirSettings:
         else:
             assert settings_file.settings.camera.name == full_settings.camera.name
 
-    def test_save_partial_update_with_unreadable_full_settings(self):
-        # An existing full settings file that cannot be read used to make
-        # save(partial, update=True) crash with an AttributeError, because
-        # the failed load left self._settings as None. There is nothing to
-        # merge the partial settings into in that case, so the partial
-        # settings are saved on their own and the unreadable file is set
-        # aside as .bak -- a save never leaves behind a file it knows is
-        # unreadable.
+    # Each case corrupts one settings file, saves new settings, and checks
+    # that the save lands in the right file while the corrupt content is
+    # preserved as a .bak backup rather than overwritten or deleted. The
+    # first case is also a regression test: an unreadable full settings
+    # file used to make save(partial, update=True) crash with an
+    # AttributeError because the failed load left self._settings as None.
+    @pytest.mark.parametrize(
+        "corrupt, saved, expect_full",
+        [
+            # unreadable full + incomplete partial save: partial written,
+            # full set aside
+            ("full", "partial", False),
+            # unreadable partial + incomplete partial save: new partial
+            # written, old partial set aside
+            ("partial", "partial", False),
+            # unreadable full + complete partial save: full written
+            ("full", "complete", True),
+            # unreadable partial + full save: full written, partial set
+            # aside instead of the usual deletion
+            ("partial", "full", True),
+        ],
+    )
+    def test_save_with_unreadable_settings_file_makes_backup(
+        self, corrupt, saved, expect_full
+    ):
         settings_file = PhotometryWorkingDirSettings()
         bad_content = '{"pasta": "carbonara"}'
-        settings_file.settings_file.write_text(bad_content)
+        corrupt_path = (
+            settings_file.settings_file
+            if corrupt == "full"
+            else settings_file.partial_settings_file
+        )
+        corrupt_path.write_text(bad_content)
 
-        camera = Camera.model_validate_json(CAMERA)
-        partial_settings = PartialPhotometrySettings(camera=camera)
-        settings_file.save(partial_settings, update=True)
+        if saved == "full":
+            to_save = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+            settings_file.save(to_save)
+        else:
+            to_save = (
+                PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
+                if saved == "complete"
+                else PartialPhotometrySettings(
+                    camera=Camera.model_validate_json(CAMERA)
+                )
+            )
+            settings_file.save(to_save, update=True)
 
-        assert settings_file.partial_settings_file.exists()
-        assert settings_file.partial_settings == partial_settings
-        assert not settings_file.settings_file.exists()
-        backup_file = bak_path(settings_file.settings_file)
-        assert backup_file.read_text() == bad_content
-
-    def test_save_partial_with_unreadable_partial_settings_makes_backup(self):
-        # An existing partial settings file that cannot be read should not be
-        # overwritten by a partial save. The new partial settings are written
-        # and the unreadable original is preserved with a .bak suffix.
-        settings_file = PhotometryWorkingDirSettings()
-        bad_content = '{"pasta": "carbonara"}'
-        settings_file.partial_settings_file.write_text(bad_content)
-
-        camera = Camera.model_validate_json(CAMERA)
-        partial_settings = PartialPhotometrySettings(camera=camera)
-        settings_file.save(partial_settings, update=True)
-
-        assert settings_file.partial_settings_file.exists()
-        assert settings_file.partial_settings == partial_settings
-        backup_file = bak_path(settings_file.partial_settings_file)
-        assert backup_file.read_text() == bad_content
-
-    def test_save_full_with_unreadable_full_settings_makes_backup(self):
-        # An existing full settings file that cannot be read should not be
-        # overwritten when partial settings that are actually complete are
-        # saved to the full settings file. The new full settings are written
-        # and the unreadable original is preserved with a .bak suffix.
-        settings_file = PhotometryWorkingDirSettings()
-        bad_content = '{"pasta": "amatriciana"}'
-        settings_file.settings_file.write_text(bad_content)
-
-        settings = PartialPhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
-        settings_file.save(settings, update=True)
-
-        assert settings_file.settings_file.exists()
-        assert settings_file.settings == settings
-        backup_file = bak_path(settings_file.settings_file)
-        assert backup_file.read_text() == bad_content
-
-    def test_save_full_with_unreadable_partial_settings_makes_backup(self):
-        # Saving full settings normally deletes any partial settings file. If
-        # the partial settings file cannot be read it should instead be
-        # preserved with a .bak suffix.
-        settings_file = PhotometryWorkingDirSettings()
-        bad_content = '{"pasta": "puttanesca"}'
-        settings_file.partial_settings_file.write_text(bad_content)
-
-        full_settings = PhotometrySettings(**TEST_PHOTOMETRY_SETTINGS)
-        settings_file.save(full_settings)
-
-        assert settings_file.settings_file.exists()
-        assert settings_file.settings == full_settings
-        assert not settings_file.partial_settings_file.exists()
-        backup_file = bak_path(settings_file.partial_settings_file)
-        assert backup_file.read_text() == bad_content
+        assert settings_file.settings_file.exists() == expect_full
+        assert settings_file.partial_settings_file.exists() != expect_full
+        if expect_full:
+            assert settings_file.settings == to_save
+        else:
+            assert settings_file.partial_settings == to_save
+        assert bak_path(corrupt_path).read_text() == bad_content
 
     def test_save_partial_update_with_corrupt_partial_and_valid_full(self):
         # Test that when both a valid full settings file and a corrupt partial


### PR DESCRIPTION
Extracted from #657 as part of decomposing that PR into small, reviewable pieces. Built on top of #661 (the first two commits here are that PR; this one should be rebased or merged after it lands).

On `main`, three write paths can silently destroy a user's settings:

1. `save()` opens the settings file with `open("w")` **before** serializing, so a pydantic serialization error, a full disk, or a killed process leaves a zero-length or half-written settings file.
2. Saving full settings **unlinks the partial settings file before writing**, so a failed write can leave the directory with no settings at all.
3. A settings file that exists but cannot be parsed is silently overwritten by the next save — including the autosave `ReviewSettings.__init__` performs, so simply opening the widget can destroy a hand-recoverable file.

This PR makes those paths safe:

- Settings are serialized first and written to a **temporary file that atomically replaces** the target.
- The partial settings file is disposed of **only after** new full settings are safely on disk.
- An unreadable settings file is **renamed to `.bak`** (numbered `.bak1`, `.bak2`, ... — existing backups are never overwritten) instead of being overwritten or deleted, and a save sets aside an unreadable full settings file even after a partial-only write, so a save never leaves the directory unloadable.
- `load()` now parses **both** settings files before raising and latches which were unreadable, so `save()` merges into whichever file was readable; encoding and OS errors during a read are reported as `ValueError` like corrupt JSON instead of escaping raw.

No widget/UI changes. The larger banner/load-error UX from #657 is deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184JRanBeqVLwzTW11UbTvg