### PR TITLE
Show settings-migration warnings in a banner in ReviewSettings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,14 +47,12 @@ Other Changes and Additions
   assertions to the settings JSON/table round-trip tests; and pinned the
   ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
   test at the maximum allowed planet radius. [#653]
-+ Added a ``stellarphot.settings.PhotometrySettingsWarning`` category for
-  user-actionable problems with saved photometry settings files.
-  ``ReviewSettings`` now shows warnings of that category raised while
-  loading the working-directory settings in a banner above the settings,
-  instead of letting them disappear into the notebook log; other warning
-  categories stay out of the banner. Nothing emits the warning yet -- the
-  settings-format version field and load-time migration that will produce
-  it are being added separately (#656). [#663]
++ ``ReviewSettings`` now displays warnings of the new
+  ``stellarphot.settings.PhotometrySettingsWarning`` category, raised while
+  loading the working-directory settings, in a dismissible banner above the
+  settings instead of letting them disappear into the notebook log. Nothing
+  emits the warning yet; the settings-format migration that will is being
+  added in #656. [#663]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,14 @@ Other Changes and Additions
   assertions to the settings JSON/table round-trip tests; and pinned the
   ``klims`` workaround for pytransit's ``RoadRunnerModel`` with a regression
   test at the maximum allowed planet radius. [#653]
++ Added a ``stellarphot.settings.PhotometrySettingsWarning`` category for
+  user-actionable problems with saved photometry settings files.
+  ``ReviewSettings`` now shows warnings of that category raised while
+  loading the working-directory settings in a banner above the settings,
+  instead of letting them disappear into the notebook log; other warning
+  categories stay out of the banner. Nothing emits the warning yet -- the
+  settings-format version field and load-time migration that will produce
+  it are being added separately (#656). [#663]
 
 Bug Fixes
 ^^^^^^^^^

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -32,6 +32,12 @@ __all__ = ["ChooseOrMakeNew", "Confirm", "SettingWithTitle"]
 
 DEFAULT_BUTTON_WIDTH = "300px"
 
+# Colors for the settings-warning banner in ReviewSettings; the dismiss
+# button is styled to match the banner border.
+_BANNER_BORDER_COLOR = "#ffc107"
+_BANNER_TEXT_COLOR = "#664d03"
+_BANNER_BACKGROUND_COLOR = "#fff3cd"
+
 
 class ChooseOrMakeNew(ipw.VBox):
     """
@@ -768,19 +774,36 @@ class ReviewSettings(ipw.VBox):
     `~stellarphot.settings.PhotometrySettingsWarning` category (e.g. a
     settings-format migration), the warning is displayed in a banner above
     the settings instead of being lost in the notebook log. Other warning
-    categories stay out of the banner.
+    categories stay out of the banner. The banner stays up until the user
+    dismisses it, even though later reloads of the settings -- which happen
+    on every tab selection -- may no longer raise the warning.
     """
 
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Banner for messages about the saved settings. It is hidden unless
-        # there is a message to show.
-        self._banner = ipw.HTML()
-        self._banner.layout.display = "none"
-        self._banner_messages = []
+        # there is a message to show, and once shown it stays up until the
+        # user dismisses it.
+        self._banner_html = ipw.HTML()
+        self._banner_dismiss = ipw.Button(
+            description="✕",
+            tooltip="Dismiss this message",
+            layout=ipw.Layout(width="2.5em"),
+        )
+        self._banner_dismiss.style.button_color = _BANNER_BORDER_COLOR
+        self._banner_dismiss.style.text_color = _BANNER_TEXT_COLOR
+        self._banner = ipw.HBox([self._banner_html, self._banner_dismiss])
 
-        # Get a copy of whatever settings may have already been saved.
-        self._current_settings = self._load_working_dir_settings()
+        def dismiss_banner(_):
+            self._banner.layout.display = "none"
+
+        self._banner_dismiss.on_click(dismiss_banner)
+
+        # Get a copy of whatever settings may have already been saved,
+        # showing any warnings the load raised in the banner. This is the
+        # only place the banner is set: reloads by the current_settings
+        # property must not clear a notice the user has not yet dismissed.
+        self._update_banner(self._load_working_dir_settings())
 
         self._setting_widgets = []
         self._plain_names = []
@@ -899,16 +922,16 @@ class ReviewSettings(ipw.VBox):
         """
         The current settings in the widget.
         """
-        self._current_settings = self._load_working_dir_settings()
+        self._load_working_dir_settings()
         return self._current_settings
 
     def _load_working_dir_settings(self):
         """
-        Load settings from the working directory, routing any
-        `~stellarphot.settings.PhotometrySettingsWarning` the load generates
-        into the banner instead of letting it be lost in the notebook log.
+        Load settings from the working directory into
+        ``self._current_settings`` and return the messages of any
+        `~stellarphot.settings.PhotometrySettingsWarning` the load
+        generated, for display in the banner instead of the notebook log.
         """
-        recorded = []
         try:
             # Only PhotometrySettingsWarning -- the category for
             # user-actionable problems with the saved settings, such as a
@@ -922,29 +945,30 @@ class ReviewSettings(ipw.VBox):
                 loaded = PhotometryWorkingDirSettings().load()
         except ValueError:
             # No readable settings in the working directory; start from
-            # defaults, keeping any warnings recorded before the error.
+            # defaults, keeping any warnings recorded before the error --
+            # recorded is bound by the with statement before anything in
+            # its body can raise.
             loaded = PartialPhotometrySettings()
 
-        self._banner_messages = [str(warning.message) for warning in recorded]
-        self._update_banner()
-        return loaded
+        self._current_settings = loaded
+        return [str(warning.message) for warning in recorded]
 
-    def _update_banner(self):
+    def _update_banner(self, messages):
         """
         Show the banner if there are messages, hide it if there are none.
         """
-        if self._banner_messages:
-            content = "".join(
-                f"<p>⚠️ {html.escape(msg)}</p>" for msg in self._banner_messages
-            )
-            self._banner.value = (
-                "<div style='border: 2px solid #ffc107; border-radius: 4px; "
-                "background-color: #fff3cd; color: #664d03; "
+        if messages:
+            content = "".join(f"<p>⚠️ {html.escape(msg)}</p>" for msg in messages)
+            self._banner_html.value = (
+                f"<div style='border: 2px solid {_BANNER_BORDER_COLOR}; "
+                f"border-radius: 4px; "
+                f"background-color: {_BANNER_BACKGROUND_COLOR}; "
+                f"color: {_BANNER_TEXT_COLOR}; "
                 f"padding: 0.25em 1em;'>{content}</div>"
             )
             self._banner.layout.display = "flex"
         else:
-            self._banner.value = ""
+            self._banner_html.value = ""
             self._banner.layout.display = "none"
 
     def _observe_tab_selection(self, change):
@@ -1026,8 +1050,14 @@ def _add_saving_to_widget(setting_widget):
             # This can happen while making a new item, or while in the process of
             # editing one
             return
-        # We have a validated setting so save it.
-        wd_settings.save(pps, update=True)
+        # We have a validated setting so save it. The save does a
+        # bookkeeping load of the settings file, which can re-raise a
+        # PhotometrySettingsWarning that the ReviewSettings banner has
+        # already displayed; suppress that category, and only that
+        # category, so the repeat stays out of the notebook log.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PhotometrySettingsWarning)
+            wd_settings.save(pps, update=True)
 
     if hasattr(setting_widget, "_choose_existing"):
         setting_widget._choose_existing.observe(save_wd, "value")

--- a/stellarphot/gui/custom_widgets.py
+++ b/stellarphot/gui/custom_widgets.py
@@ -1,6 +1,8 @@
 # Some settings require custom widgets to be displayed in the GUI. These are defined in
 # this module.
 
+import html
+import warnings
 from enum import StrEnum
 
 import ipywidgets as ipw
@@ -21,6 +23,7 @@ from stellarphot.settings import (
     PartialPhotometrySettings,
     PassbandMap,
     PhotometryRunSettings,
+    PhotometrySettingsWarning,
     PhotometryWorkingDirSettings,
     SavedSettings,
 )
@@ -761,15 +764,23 @@ class ReviewSettings(ipw.VBox):
     4. Creating a new one of those saveable settings also saves it to the working
        directory settings.
 
+    If loading the saved settings raises a warning of the
+    `~stellarphot.settings.PhotometrySettingsWarning` category (e.g. a
+    settings-format migration), the warning is displayed in a banner above
+    the settings instead of being lost in the notebook log. Other warning
+    categories stay out of the banner.
     """
 
     def __init__(self, settings, style="tabs", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        # Banner for messages about the saved settings. It is hidden unless
+        # there is a message to show.
+        self._banner = ipw.HTML()
+        self._banner.layout.display = "none"
+        self._banner_messages = []
+
         # Get a copy of whatever settings may have already been saved.
-        try:
-            self._current_settings = PhotometryWorkingDirSettings().load()
-        except ValueError:
-            self._current_settings = PartialPhotometrySettings()
+        self._current_settings = self._load_working_dir_settings()
 
         self._setting_widgets = []
         self._plain_names = []
@@ -865,7 +876,7 @@ class ReviewSettings(ipw.VBox):
         self._container.children = self._setting_widgets
         self._container.titles = self._make_titles()
 
-        self.children = [self._container]
+        self.children = [self._banner, self._container]
 
         # Set up an observer to run when a tab is selected
         self._container.observe(self._observe_tab_selection, names="selected_index")
@@ -888,12 +899,53 @@ class ReviewSettings(ipw.VBox):
         """
         The current settings in the widget.
         """
-        try:
-            self._current_settings = PhotometryWorkingDirSettings().load()
-        except ValueError:
-            self._current_settings = PartialPhotometrySettings()
-
+        self._current_settings = self._load_working_dir_settings()
         return self._current_settings
+
+    def _load_working_dir_settings(self):
+        """
+        Load settings from the working directory, routing any
+        `~stellarphot.settings.PhotometrySettingsWarning` the load generates
+        into the banner instead of letting it be lost in the notebook log.
+        """
+        recorded = []
+        try:
+            # Only PhotometrySettingsWarning -- the category for
+            # user-actionable problems with the saved settings, such as a
+            # settings-format migration -- belongs in the banner. Warnings
+            # of other categories raised by libraries on the load path are
+            # not aimed at the user of this widget, so they are suppressed
+            # here rather than displayed.
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("ignore")
+                warnings.simplefilter("always", PhotometrySettingsWarning)
+                loaded = PhotometryWorkingDirSettings().load()
+        except ValueError:
+            # No readable settings in the working directory; start from
+            # defaults, keeping any warnings recorded before the error.
+            loaded = PartialPhotometrySettings()
+
+        self._banner_messages = [str(warning.message) for warning in recorded]
+        self._update_banner()
+        return loaded
+
+    def _update_banner(self):
+        """
+        Show the banner if there are messages, hide it if there are none.
+        """
+        if self._banner_messages:
+            content = "".join(
+                f"<p>⚠️ {html.escape(msg)}</p>" for msg in self._banner_messages
+            )
+            self._banner.value = (
+                "<div style='border: 2px solid #ffc107; border-radius: 4px; "
+                "background-color: #fff3cd; color: #664d03; "
+                f"padding: 0.25em 1em;'>{content}</div>"
+            )
+            self._banner.layout.display = "flex"
+        else:
+            self._banner.value = ""
+            self._banner.layout.display = "none"
 
     def _observe_tab_selection(self, change):
         """

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1386,6 +1386,8 @@ class TestReviewSettings:
         assert review_settings._banner.layout.display == "flex"
 
     def test_banner_dismiss_button_hides_banner(self, mocker):
+        # The banner never clears itself (it is sticky across reloads), so
+        # the dismiss button is the one way to hide it once it is shown.
         self._patch_load_to_warn(
             mocker, "Settings were migrated", PhotometrySettingsWarning
         )

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1289,29 +1289,39 @@ class TestReviewSettings:
         assert review_settings.badges[0] == SaveStatus.SETTING_NOT_SAVED
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[0]
 
+    @staticmethod
+    def _patch_load_to_warn(mocker, message, category, raise_after=False):
+        # Patch PhotometryWorkingDirSettings.load to warn with the given
+        # message and category; with raise_after, the load then fails with
+        # ValueError, mimicking a file that warns during parsing but is
+        # still unusable.
+        def fake_load(_self):
+            warnings.warn(message, category, stacklevel=2)
+            if raise_after:
+                raise ValueError("settings file is unreadable")
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+
     def test_banner_hidden_when_no_settings_files(self):
         # With no saved settings there is nothing to report, so the banner
         # is empty and hidden.
         review_settings = ReviewSettings([Camera])
-        assert review_settings._banner.value == ""
+        assert review_settings._banner_html.value == ""
         assert review_settings._banner.layout.display == "none"
 
     def test_banner_shows_warnings_from_loading_settings(self, mocker):
         # Warnings of the PhotometrySettingsWarning category generated while
         # loading settings (e.g. a settings-format migration) should be
         # displayed in the banner.
-        def fake_load(_self):
-            warnings.warn(
-                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
-            )
-            return PartialPhotometrySettings()
-
-        mocker.patch.object(
-            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        self._patch_load_to_warn(
+            mocker, "Settings were migrated", PhotometrySettingsWarning
         )
         review_settings = ReviewSettings([Camera])
 
-        assert "Settings were migrated" in review_settings._banner.value
+        assert "Settings were migrated" in review_settings._banner_html.value
         assert review_settings._banner.layout.display == "flex"
 
     @pytest.mark.parametrize("category", [DeprecationWarning, UserWarning])
@@ -1320,43 +1330,114 @@ class TestReviewSettings:
         # raised on the load path -- a DeprecationWarning from a library
         # internal, or a plain UserWarning such as a pydantic serializer
         # warning -- should stay out of the banner.
-        def fake_load(_self):
-            warnings.warn("some library warning", category, stacklevel=2)
-            return PartialPhotometrySettings()
-
-        mocker.patch.object(
-            settings_files.PhotometryWorkingDirSettings, "load", fake_load
-        )
+        self._patch_load_to_warn(mocker, "some library warning", category)
         review_settings = ReviewSettings([Camera])
 
-        assert review_settings._banner.value == ""
+        assert review_settings._banner_html.value == ""
         assert review_settings._banner.layout.display == "none"
 
     def test_banner_escapes_html_in_warning_text(self, mocker):
         # Warning text is escaped so markup in a message cannot inject HTML
         # into the banner.
-        def fake_load(_self):
-            warnings.warn(
-                "Settings were <b>migrated</b>",
-                PhotometrySettingsWarning,
-                stacklevel=2,
-            )
-            return PartialPhotometrySettings()
-
-        mocker.patch.object(
-            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        self._patch_load_to_warn(
+            mocker, "Settings were <b>migrated</b>", PhotometrySettingsWarning
         )
         review_settings = ReviewSettings([Camera])
 
-        assert "&lt;b&gt;migrated&lt;/b&gt;" in review_settings._banner.value
-        assert "<b>migrated</b>" not in review_settings._banner.value
+        assert "&lt;b&gt;migrated&lt;/b&gt;" in review_settings._banner_html.value
+        assert "<b>migrated</b>" not in review_settings._banner_html.value
+
+    def test_banner_shows_warning_recorded_before_load_raises(self, mocker):
+        # A warning recorded before the load raises ValueError still reaches
+        # the banner -- the path a settings file that is migrated but still
+        # unreadable will hit.
+        self._patch_load_to_warn(
+            mocker,
+            "Settings were migrated",
+            PhotometrySettingsWarning,
+            raise_after=True,
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert "Settings were migrated" in review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+        assert review_settings.current_settings == PartialPhotometrySettings()
+
+    def test_banner_is_sticky_across_reloads(self, mocker):
+        # Once shown, the banner stays up even after a later load emits no
+        # warning -- e.g. after an autosave has rewritten the settings file
+        # in a format that no longer warns. Selecting a tab reloads the
+        # settings and must not clear the notice.
+        self._patch_load_to_warn(
+            mocker, "Settings were migrated", PhotometrySettingsWarning
+        )
+        review_settings = ReviewSettings([Camera, PhotometryApertures])
+
+        # Later loads are clean, as they would be after the file was
+        # re-saved in the new format.
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings,
+            "load",
+            lambda _self: PartialPhotometrySettings(),
+        )
+        review_settings._container.selected_index = 1
+
+        assert "Settings were migrated" in review_settings._banner_html.value
+        assert review_settings._banner.layout.display == "flex"
+
+    def test_banner_dismiss_button_hides_banner(self, mocker):
+        self._patch_load_to_warn(
+            mocker, "Settings were migrated", PhotometrySettingsWarning
+        )
+        review_settings = ReviewSettings([Camera])
+        assert review_settings._banner.layout.display == "flex"
+
+        review_settings._banner_dismiss.click()
+
+        assert review_settings._banner.layout.display == "none"
+
+    def test_banner_dismiss_button_matches_banner_style(self, mocker):
+        # The dismiss button is styled with the same color as the banner
+        # border.
+        self._patch_load_to_warn(
+            mocker, "Settings were migrated", PhotometrySettingsWarning
+        )
+        review_settings = ReviewSettings([Camera])
+
+        button_color = review_settings._banner_dismiss.style.button_color
+        assert button_color is not None
+        assert f"solid {button_color}" in review_settings._banner_html.value
+
+    def test_widget_saves_do_not_leak_settings_warnings(self, mocker):
+        # Constructing the widget autosaves settings, and every save does a
+        # bookkeeping load that re-raises any settings warning. Those
+        # repeats must not escape to the notebook log -- the banner is the
+        # only display channel. PhotometryApertures is used because it is
+        # saveable from defaults, which triggers the autosave.
+        self._patch_load_to_warn(
+            mocker, "Settings were migrated", PhotometrySettingsWarning
+        )
+        with warnings.catch_warnings(record=True) as leaked:
+            warnings.simplefilter("always")
+            review_settings = ReviewSettings([PhotometryApertures])
+
+        assert not [
+            w for w in leaked if issubclass(w.category, PhotometrySettingsWarning)
+        ]
+        # The warning still reached the banner.
+        assert "Settings were migrated" in review_settings._banner_html.value
 
     def test_widget_children_structure(self):
-        # The banner rides above the settings container.
+        # The banner rides above the settings container and holds the
+        # message plus its dismiss button.
         review_settings = ReviewSettings([Camera])
         banner, container = review_settings.children
         assert banner is review_settings._banner
         assert container is review_settings._container
+        assert banner.children == (
+            review_settings._banner_html,
+            review_settings._banner_dismiss,
+        )
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/gui/tests/test_custom_widgets.py
+++ b/stellarphot/gui/tests/test_custom_widgets.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from pathlib import Path
 
@@ -26,6 +27,7 @@ from stellarphot.settings import (
     PassbandMap,
     PhotometryApertures,
     PhotometryOptionalSettings,
+    PhotometrySettingsWarning,
     PhotometryWorkingDirSettings,
     SavedSettings,
     SourceLocationSettings,
@@ -1286,6 +1288,75 @@ class TestReviewSettings:
         # the badge list and the tab title.
         assert review_settings.badges[0] == SaveStatus.SETTING_NOT_SAVED
         assert SaveStatus.SETTING_NOT_SAVED in review_settings._container.titles[0]
+
+    def test_banner_hidden_when_no_settings_files(self):
+        # With no saved settings there is nothing to report, so the banner
+        # is empty and hidden.
+        review_settings = ReviewSettings([Camera])
+        assert review_settings._banner.value == ""
+        assert review_settings._banner.layout.display == "none"
+
+    def test_banner_shows_warnings_from_loading_settings(self, mocker):
+        # Warnings of the PhotometrySettingsWarning category generated while
+        # loading settings (e.g. a settings-format migration) should be
+        # displayed in the banner.
+        def fake_load(_self):
+            warnings.warn(
+                "Settings were migrated", PhotometrySettingsWarning, stacklevel=2
+            )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert "Settings were migrated" in review_settings._banner.value
+        assert review_settings._banner.layout.display == "flex"
+
+    @pytest.mark.parametrize("category", [DeprecationWarning, UserWarning])
+    def test_banner_ignores_other_warning_categories(self, mocker, category):
+        # Only PhotometrySettingsWarning is user-actionable; anything else
+        # raised on the load path -- a DeprecationWarning from a library
+        # internal, or a plain UserWarning such as a pydantic serializer
+        # warning -- should stay out of the banner.
+        def fake_load(_self):
+            warnings.warn("some library warning", category, stacklevel=2)
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert review_settings._banner.value == ""
+        assert review_settings._banner.layout.display == "none"
+
+    def test_banner_escapes_html_in_warning_text(self, mocker):
+        # Warning text is escaped so markup in a message cannot inject HTML
+        # into the banner.
+        def fake_load(_self):
+            warnings.warn(
+                "Settings were <b>migrated</b>",
+                PhotometrySettingsWarning,
+                stacklevel=2,
+            )
+            return PartialPhotometrySettings()
+
+        mocker.patch.object(
+            settings_files.PhotometryWorkingDirSettings, "load", fake_load
+        )
+        review_settings = ReviewSettings([Camera])
+
+        assert "&lt;b&gt;migrated&lt;/b&gt;" in review_settings._banner.value
+        assert "<b>migrated</b>" not in review_settings._banner.value
+
+    def test_widget_children_structure(self):
+        # The banner rides above the settings container.
+        review_settings = ReviewSettings([Camera])
+        banner, container = review_settings.children
+        assert banner is review_settings._banner
+        assert container is review_settings._container
 
 
 def test_add_saving_with_unrecognized_widget():

--- a/stellarphot/settings/models.py
+++ b/stellarphot/settings/models.py
@@ -44,11 +44,22 @@ __all__ = [
     "PhotometryFileSettings",
     "PhotometryRunSettings",
     "PhotometrySettings",
+    "PhotometrySettingsWarning",
     "PhotometryOptionalSettings",
     "Exoplanet",
     "Observatory",
     "SourceLocationSettings",
 ]
+
+
+class PhotometrySettingsWarning(UserWarning):
+    """
+    Warning category for user-actionable problems with saved photometry
+    settings files (e.g. a settings-format migration). Warnings of this
+    category are shown to the user in the `~stellarphot.gui.ReviewSettings`
+    banner; plain `UserWarning`\\s from libraries on the load path are not.
+    """
+
 
 # Most models should use the default configuration, but it can be customized if needed.
 MODEL_DEFAULT_CONFIGURATION = ConfigDict(

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -18,6 +18,7 @@ from .models import (
 __all__ = [
     "SavedSettings",
     "SETTINGS_FILE_VERSION",
+    "PhotometrySettingsWarning",
     "PhotometryWorkingDirSettings",
     "SettingsFileReadError",
 ]
@@ -27,6 +28,15 @@ __all__ = [
 SETTINGS_FILE_VERSION = "2"  # value chosen to match major version of stellarphot
 
 ENCODING = "utf-8"
+
+
+class PhotometrySettingsWarning(UserWarning):
+    """
+    Warning category for user-actionable problems with saved photometry
+    settings files (e.g. a settings-format migration). Warnings of this
+    category are shown to the user in the `~stellarphot.gui.ReviewSettings`
+    banner; plain `UserWarning`\\s from libraries on the load path are not.
+    """
 
 
 class SettingsFileReadError(ValueError):

--- a/stellarphot/settings/settings_files.py
+++ b/stellarphot/settings/settings_files.py
@@ -18,7 +18,6 @@ from .models import (
 __all__ = [
     "SavedSettings",
     "SETTINGS_FILE_VERSION",
-    "PhotometrySettingsWarning",
     "PhotometryWorkingDirSettings",
     "SettingsFileReadError",
 ]
@@ -28,15 +27,6 @@ __all__ = [
 SETTINGS_FILE_VERSION = "2"  # value chosen to match major version of stellarphot
 
 ENCODING = "utf-8"
-
-
-class PhotometrySettingsWarning(UserWarning):
-    """
-    Warning category for user-actionable problems with saved photometry
-    settings files (e.g. a settings-format migration). Warnings of this
-    category are shown to the user in the `~stellarphot.gui.ReviewSettings`
-    banner; plain `UserWarning`\\s from libraries on the load path are not.
-    """
 
 
 class SettingsFileReadError(ValueError):


### PR DESCRIPTION
Extracted from #657 as part of decomposing that PR into small, reviewable pieces. This is the piece #657 was originally opened for: a banner in `ReviewSettings` for warning the user that their settings file was updated from an earlier version.

- Adds a `PhotometrySettingsWarning` category (exported from `stellarphot.settings`) for user-actionable problems with saved photometry settings files.
- `ReviewSettings` now captures warnings of that category raised while loading the working-directory settings and displays them in a banner above the settings, instead of letting them disappear into the notebook log. Other warning categories stay out of the banner, and warning text is HTML-escaped before display.

**This PR is a display channel only** — nothing emits `PhotometrySettingsWarning` yet. The settings-format version field and load-time migration that will produce the warning are being added in #656; once both are in, opening `ReviewSettings` on a directory with an old-format settings file will show the migration notice in the banner.

Independent of #661 and #662 (touches different code paths); only the changelog will need a trivial conflict resolution between these PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184JRanBeqVLwzTW11UbTvg