### PR TITLE
Report per-image transform problems as log messages instead of warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -146,6 +146,11 @@ Bug Fixes
   and a partial save no longer resurrects stale values from a conflicting
   partial settings file. Encoding and OS errors while reading settings now
   raise ``SettingsFileReadError``, a ``ValueError`` subclass. [#662]
++ ``transform_to_catalog()`` now writes its results to the table before any of
+  the warnings about individual images are raised, so running with warnings as
+  errors (``-W error``) no longer discards the results of every image that was
+  fit successfully. With ``in_place=True`` the caller's table is complete even
+  when a deferred warning escalates and the call raises. [#679]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -146,11 +146,11 @@ Bug Fixes
   and a partial save no longer resurrects stale values from a conflicting
   partial settings file. Encoding and OS errors while reading settings now
   raise ``SettingsFileReadError``, a ``ValueError`` subclass. [#662]
-+ ``transform_to_catalog()`` now writes its results to the table before any of
-  the warnings about individual images are raised, so running with warnings as
-  errors (``-W error``) no longer discards the results of every image that was
-  fit successfully. With ``in_place=True`` the caller's table is complete even
-  when a deferred warning escalates and the call raises. [#679]
++ ``transform_to_catalog()`` now reports per-image fitting problems (no usable
+  stars, underdetermined or failed fits, out-of-expected-range terms) as log
+  messages instead of warnings, so running with warnings-as-errors no longer
+  aborts the calibration; output columns are written after all images are
+  processed. [#682]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 
 import lmfit
@@ -8,6 +9,8 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from ..catalogs import apass_dr9, refcat2
 from .magnitude_system_transforms import transform_apass_bands, transform_refcat2_bands
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "calibrated_from_instrumental",
@@ -465,15 +468,6 @@ def transform_to_catalog(
         If ``True``, add the calibrated magnitude to the input table, otherwise return
         a copy.
 
-        Warnings about an individual image are held until every image's
-        results have been written, so a warning does not cost the images that
-        were fit successfully their results. That does not stop the call
-        raising when warnings are errors -- under ``-W error`` the deferred
-        warnings still escalate, only after the columns have been written. So
-        with ``in_place=True`` the table the caller handed in is complete when
-        the call raises, while with ``in_place=False`` the copy that would
-        have been returned is lost.
-
     fit_diff : bool, optional
         If ``True``, fit the difference between the instrumental and catalog magnitude
         instead of the treating the catalog mag as the dependent variable.
@@ -589,203 +583,178 @@ def transform_to_catalog(
     group_bounds = observed_mags_grouped.groups.indices
 
     # Made before the loop rather than after it so that the results can be
-    # written to it in the ``finally`` below. The loop reads only
-    # ``observed_mags_grouped`` and never this table, and the invariant
-    # documented just above is what makes writing by row index legal.
+    # written to it. The loop reads only ``observed_mags_grouped`` and never
+    # this table, and the invariant documented just above is what makes
+    # writing by row index legal.
     result = observed_mags_grouped if in_place else observed_mags_grouped.copy()
 
-    # Warnings about one image are held until every image's results are in the
-    # table. Under -W error -- which this package's own test suite uses -- a
-    # warning raised inside the loop would otherwise throw away the results of
-    # every image already fit. See issue #679.
-    #
-    # Every warning raised in the loop is an AstropyUserWarning, so the message
-    # alone is enough to defer. Adding one of another category would make this
-    # a list of (message, category) tuples.
-    deferred_warnings = []
+    for group_number, (file, one_image_all_bands) in enumerate(
+        zip(
+            observed_mags_grouped.groups.keys,
+            observed_mags_grouped.groups,
+            strict=True,
+        )
+    ):
+        group_start = group_bounds[group_number]
+        in_this_group = in_passband[group_start : group_bounds[group_number + 1]]
+        rows = group_start + np.flatnonzero(in_this_group)
 
-    try:
-        for group_number, (file, one_image_all_bands) in enumerate(
-            zip(
-                observed_mags_grouped.groups.keys,
-                observed_mags_grouped.groups,
-                strict=True,
-            )
-        ):
-            group_start = group_bounds[group_number]
-            in_this_group = in_passband[group_start : group_bounds[group_number + 1]]
-            rows = group_start + np.flatnonzero(in_this_group)
+        if rows.size == 0:
+            # Nothing in this image was taken in this passband.
+            continue
 
-            if rows.size == 0:
-                # Nothing in this image was taken in this passband.
-                continue
+        one_image = one_image_all_bands[in_this_group]
+        our_coords = SkyCoord(one_image["ra"], one_image["dec"], unit="degree")
 
-            one_image = one_image_all_bands[in_this_group]
-            our_coords = SkyCoord(one_image["ra"], one_image["dec"], unit="degree")
+        cat_idx, d2d, _ = our_coords.match_to_catalog_sky(cat_coords)
 
-            cat_idx, d2d, _ = our_coords.match_to_catalog_sky(cat_coords)
+        # Masked catalog entries become NaN here, which both keeps them out
+        # of the fit and makes the calibrated magnitudes that depend on
+        # them NaN.
+        mag_inst = _to_float_array(one_image[obs_mag_col])
+        cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
+        color = _to_float_array(cat["color"][cat_idx])
 
-            # Masked catalog entries become NaN here, which both keeps them out
-            # of the fit and makes the calibrated magnitudes that depend on
-            # them NaN.
-            mag_inst = _to_float_array(one_image[obs_mag_col])
-            cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
-            color = _to_float_array(cat["color"][cat_idx])
-
-            # Impose some constraints on what is included in the fit
-            good_cat = np.isfinite(cat_mag) & np.isfinite(color) & (d2d.arcsecond < 1)
-            good_dat = (mag_inst < -3) & (mag_inst > -20) & np.isfinite(mag_inst)
-
-            if obs_error_column is not None:
-                errors = _to_float_array(one_image[obs_error_column])
-                # A non-positive or non-finite error gives a meaningless weight.
-                good_dat = good_dat & np.isfinite(errors) & (errors > 0)
-
-            # Both halves have to be good for the *same* star. Checking each on
-            # its own is not enough: the two sets can be disjoint, which leaves
-            # nothing to take the median of below.
-            usable = good_dat & good_cat
-
-            if not usable.any():
-                deferred_warnings.append(f"No good data in {file[0]}")
-                continue
-
-            # Drop stars more than a magnitude away from the median difference
-            # between the catalog and instrumental magnitudes -- either a bad
-            # match or a bad measurement.
-            mag_diff = cat_mag - mag_inst
-            good = usable & (np.abs(mag_diff - np.median(mag_diff[usable])) < 1)
-
-            if not good.any():
-                deferred_warnings.append(f"No good data in {file[0]}")
-                continue
-
-            # Prep for fitting
-            fit_mag = mag_inst[good]
-            fit_color = color[good]
-            offset = fit_mag if fit_diff else 0.0
-            fit_data = cat_mag[good] - offset
-            weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
-
-            # Fewer stars than terms has to be caught before the fit rather than
-            # after it: with nothing left to fit, lmfit takes the square root of
-            # a negative number working out the uncertainties, and the
-            # RuntimeWarning that produces is an outright exception for anyone
-            # running with warnings as errors. Whether the terms can be told
-            # apart from *each other* is a question about the fit and is asked
-            # of it below.
-            if fit_mag.size <= len(vary):
-                deferred_warnings.append(
-                    f"Fit for {file[0]} is underdetermined: {fit_mag.size} usable "
-                    f"star(s) cannot determine {len(vary)} term(s) {list(vary)}; "
-                    "the fit has no degrees of freedom left"
-                )
-                continue
-
-            params = base_params.copy()
-            if params["z"].vary:
-                # With every other term at its starting value of zero the model
-                # is just the zero point, so the median of the data being fit is
-                # the best starting guess available.
-                params["z"].set(value=float(np.median(fit_data)))
-
-            fit_result = lmfit.minimize(
-                _transform_residual,
-                params,
-                method="least_squares",
-                args=(fit_mag, fit_color, fit_data, weights),
-            )
-
-            if not fit_result.success:
-                deferred_warnings.append(
-                    f"Fit did not succeed for {file[0]}: {fit_result.message}"
-                )
-                continue
-
-            # A fit reports success whether or not the data can tell the terms
-            # being fit apart from each other, and the coefficients it lands on
-            # are applied to every star in the image, so a successful fit still
-            # has to be checked before its results are used.
-            underdetermined = _underdetermined_reason(fit_result, vary)
-            if underdetermined is not None:
-                deferred_warnings.append(
-                    f"Fit for {file[0]} is underdetermined: {underdetermined}"
-                )
-                continue
-
-            values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
-
-            # The expected ranges are a check on the answer, not a constraint on
-            # the fit, so a value outside its range is reported and kept.
-            out_of_range = [
-                f"{term}={values[term]:.4f} is outside the expected range "
-                f"{tuple(expected[term])}"
-                for term in expected
-                if not expected[term][0] <= values[term] <= expected[term][1]
-            ]
-            if out_of_range:
-                deferred_warnings.append(
-                    f"Fit for {file[0]}: " + "; ".join(out_of_range)
-                )
-
-            # Calculate calibrated magnitudes for every star in the image, not
-            # just the ones the fit used.
-            model_coefficients = [values[name] for name in _COEFF_NAMES]
-            cal_mag = calibrated_from_instrumental(
-                (mag_inst, color), *model_coefficients
-            )
-            if fit_diff:
-                cal_mag = cal_mag + mag_inst
-
-            # A limit of 1 arcsec here can cause a variable that really is in
-            # APASS to not match. An example is V2480 Cyg, whose VSX position is
-            # about 1.3 arcsec from its APASS DR9 position.
-            cal_mag[d2d.arcsecond > 1.5] = np.nan
-
-            for name in _COEFF_NAMES:
-                coefficients[name][rows] = values[name]
-
-            cal_mags[rows] = cal_mag
-            cat_mags[rows] = cat_mag
-            cat_colors[rows] = color
-    finally:
-        # In `finally` so the images fit before anything went wrong still reach
-        # the table, even if what went wrong was not a warning. The keys are
-        # inserted in the order the columns are added to the table in.
-        output_columns = {}
+        # Impose some constraints on what is included in the fit
+        good_cat = np.isfinite(cat_mag) & np.isfinite(color) & (d2d.arcsecond < 1)
+        good_dat = (mag_inst < -3) & (mag_inst > -20) & np.isfinite(mag_inst)
 
         if obs_error_column is not None:
-            # How much the calibrated magnitude moves when the instrumental one
-            # does. With fit_diff the instrumental magnitude is added back to
-            # the model result, so that sensitivity is 1 + a; without it the
-            # model is the calibrated magnitude outright and a itself is the
-            # factor -- it fits to about 1 rather than about 0. Using the same
-            # factor for both would double the reported uncertainty in one of
-            # the two modes.
-            sensitivity = 1 + coefficients["a"] if fit_diff else coefficients["a"]
+            errors = _to_float_array(one_image[obs_error_column])
+            # A non-positive or non-finite error gives a meaningless weight.
+            good_dat = good_dat & np.isfinite(errors) & (errors > 0)
 
-            # Scaled from the raw per-call coefficients rather than the merged
-            # column, so that rows in other passbands are handled by the merge
-            # below instead of being recomputed from another passband's fit.
-            raw_errors = _to_float_array(result[obs_error_column])
-            scaled_errors = sensitivity * raw_errors
+        # Both halves have to be good for the *same* star. Checking each on
+        # its own is not enough: the two sets can be disjoint, which leaves
+        # nothing to take the median of below.
+        usable = good_dat & good_cat
 
-            # An error that is not a positive, finite number is kept out of the
-            # fit above, and must not come back out as a calibrated error
-            # either: the AAVSO writer turns only non-finite errors into "na",
-            # so a zero would be submitted as a real uncertainty.
-            scaled_errors[~(np.isfinite(raw_errors) & (raw_errors > 0))] = np.nan
+        if not usable.any():
+            logger.warning(f"No good data in {file[0]}")
+            continue
 
-            output_columns[_CAL_MAG_ERROR_COLUMN] = scaled_errors
+        # Drop stars more than a magnitude away from the median difference
+        # between the catalog and instrumental magnitudes -- either a bad
+        # match or a bad measurement.
+        mag_diff = cat_mag - mag_inst
+        good = usable & (np.abs(mag_diff - np.median(mag_diff[usable])) < 1)
 
-        output_columns[_CAL_MAG_COLUMN] = cal_mags
-        output_columns.update(coefficients)
-        output_columns["mag_cat"] = cat_mags
-        output_columns["color_cat"] = cat_colors
+        if not good.any():
+            logger.warning(f"No good data in {file[0]}")
+            continue
 
-        _write_output_columns(result, output_columns, in_passband)
+        # Prep for fitting
+        fit_mag = mag_inst[good]
+        fit_color = color[good]
+        offset = fit_mag if fit_diff else 0.0
+        fit_data = cat_mag[good] - offset
+        weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
 
-    for message in deferred_warnings:
-        warnings.warn(message, AstropyUserWarning, stacklevel=2)
+        # Fewer stars than terms has to be caught before the fit rather than
+        # after it: with nothing left to fit, lmfit takes the square root of
+        # a negative number working out the uncertainties, and the
+        # RuntimeWarning that produces is an outright exception for anyone
+        # running with warnings as errors. Whether the terms can be told
+        # apart from *each other* is a question about the fit and is asked
+        # of it below.
+        if fit_mag.size <= len(vary):
+            logger.warning(
+                f"Fit for {file[0]} is underdetermined: {fit_mag.size} usable "
+                f"star(s) cannot determine {len(vary)} term(s) {list(vary)}"
+            )
+            continue
+
+        params = base_params.copy()
+        if params["z"].vary:
+            # With every other term at its starting value of zero the model
+            # is just the zero point, so the median of the data being fit is
+            # the best starting guess available.
+            params["z"].set(value=float(np.median(fit_data)))
+
+        fit_result = lmfit.minimize(
+            _transform_residual,
+            params,
+            method="least_squares",
+            args=(fit_mag, fit_color, fit_data, weights),
+        )
+
+        if not fit_result.success:
+            logger.warning(f"Fit did not succeed for {file[0]}: {fit_result.message}")
+            continue
+
+        # A fit reports success whether or not the data can tell the terms
+        # being fit apart from each other, and the coefficients it lands on
+        # are applied to every star in the image, so a successful fit still
+        # has to be checked before its results are used.
+        underdetermined = _underdetermined_reason(fit_result, vary)
+        if underdetermined is not None:
+            logger.warning(f"Fit for {file[0]} is underdetermined: {underdetermined}")
+            continue
+
+        values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
+
+        # The expected ranges are a check on the answer, not a constraint on
+        # the fit, so a value outside its range is reported and kept.
+        out_of_range = [
+            f"{term}={values[term]:.4f} is outside the expected range "
+            f"{tuple(expected[term])}"
+            for term in expected
+            if not expected[term][0] <= values[term] <= expected[term][1]
+        ]
+        if out_of_range:
+            logger.warning(f"Fit for {file[0]}: " + "; ".join(out_of_range))
+
+        # Calculate calibrated magnitudes for every star in the image, not
+        # just the ones the fit used.
+        model_coefficients = [values[name] for name in _COEFF_NAMES]
+        cal_mag = calibrated_from_instrumental((mag_inst, color), *model_coefficients)
+        if fit_diff:
+            cal_mag = cal_mag + mag_inst
+
+        # A limit of 1 arcsec here can cause a variable that really is in
+        # APASS to not match. An example is V2480 Cyg, whose VSX position is
+        # about 1.3 arcsec from its APASS DR9 position.
+        cal_mag[d2d.arcsecond > 1.5] = np.nan
+
+        for name in _COEFF_NAMES:
+            coefficients[name][rows] = values[name]
+
+        cal_mags[rows] = cal_mag
+        cat_mags[rows] = cat_mag
+        cat_colors[rows] = color
+
+    # The keys are inserted in the order the columns are added to the table in.
+    output_columns = {}
+
+    if obs_error_column is not None:
+        # How much the calibrated magnitude moves when the instrumental one
+        # does. With fit_diff the instrumental magnitude is added back to
+        # the model result, so that sensitivity is 1 + a; without it the
+        # model is the calibrated magnitude outright and a itself is the
+        # factor -- it fits to about 1 rather than about 0. Using the same
+        # factor for both would double the reported uncertainty in one of
+        # the two modes.
+        sensitivity = 1 + coefficients["a"] if fit_diff else coefficients["a"]
+
+        # Scaled from the raw per-call coefficients rather than the merged
+        # column, so that rows in other passbands are handled by the merge
+        # below instead of being recomputed from another passband's fit.
+        raw_errors = _to_float_array(result[obs_error_column])
+        scaled_errors = sensitivity * raw_errors
+
+        # An error that is not a positive, finite number is kept out of the
+        # fit above, and must not come back out as a calibrated error
+        # either: the AAVSO writer turns only non-finite errors into "na",
+        # so a zero would be submitted as a real uncertainty.
+        scaled_errors[~(np.isfinite(raw_errors) & (raw_errors > 0))] = np.nan
+
+        output_columns[_CAL_MAG_ERROR_COLUMN] = scaled_errors
+
+    output_columns[_CAL_MAG_COLUMN] = cal_mags
+    output_columns.update(coefficients)
+    output_columns["mag_cat"] = cat_mags
+    output_columns["color_cat"] = cat_colors
+
+    _write_output_columns(result, output_columns, in_passband)
 
     return result

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -256,6 +256,34 @@ def _merge_with_existing(table, column_name, new_values, in_passband):
     return np.where(in_passband, new_values, old_values)
 
 
+def _write_output_columns(table, columns, in_passband):
+    """
+    Write a set of output columns to the table, keeping other passbands' values.
+
+    Each column goes through `_merge_with_existing`, so the rows this call is
+    not responsible for keep whatever they already had. Columns are written in
+    the order they appear in ``columns``, which is the order a new column is
+    added to the table in.
+
+    Parameters
+    ----------
+
+    table : `astropy.table.Table`
+        Table the columns will be written to.
+
+    columns : dict
+        Values to write, as ``{column_name: values}``. Each array is the
+        length of the whole table, NaN outside the passband that was fit.
+
+    in_passband : `numpy.ndarray`
+        Boolean mask, `True` for the rows this call is responsible for.
+    """
+    for column_name, new_values in columns.items():
+        table[column_name] = _merge_with_existing(
+            table, column_name, new_values, in_passband
+        )
+
+
 def filter_transform(mag_data, output_filter, g=None, r=None, i=None, transform=None):
     """
     Transform SDSS magnitudes to BVRI using either the transforms from
@@ -437,6 +465,15 @@ def transform_to_catalog(
         If ``True``, add the calibrated magnitude to the input table, otherwise return
         a copy.
 
+        Warnings about an individual image are held until every image's
+        results have been written, so a warning does not cost the images that
+        were fit successfully their results. That does not stop the call
+        raising when warnings are errors -- under ``-W error`` the deferred
+        warnings still escalate, only after the columns have been written. So
+        with ``in_place=True`` the table the caller handed in is complete when
+        the call raises, while with ``in_place=False`` the copy that would
+        have been returned is lost.
+
     fit_diff : bool, optional
         If ``True``, fit the difference between the instrumental and catalog magnitude
         instead of the treating the catalog mag as the dependent variable.
@@ -551,197 +588,204 @@ def transform_to_catalog(
     # is always rows ``group_bounds[i]:group_bounds[i + 1]`` of the output.
     group_bounds = observed_mags_grouped.groups.indices
 
-    for group_number, (file, one_image_all_bands) in enumerate(
-        zip(
-            observed_mags_grouped.groups.keys,
-            observed_mags_grouped.groups,
-            strict=True,
-        )
-    ):
-        group_start = group_bounds[group_number]
-        in_this_group = in_passband[group_start : group_bounds[group_number + 1]]
-        rows = group_start + np.flatnonzero(in_this_group)
-
-        if rows.size == 0:
-            # Nothing in this image was taken in this passband.
-            continue
-
-        one_image = one_image_all_bands[in_this_group]
-        our_coords = SkyCoord(one_image["ra"], one_image["dec"], unit="degree")
-
-        cat_idx, d2d, _ = our_coords.match_to_catalog_sky(cat_coords)
-
-        # Masked catalog entries become NaN here, which both keeps them out of
-        # the fit and makes the calibrated magnitudes that depend on them NaN.
-        mag_inst = _to_float_array(one_image[obs_mag_col])
-        cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
-        color = _to_float_array(cat["color"][cat_idx])
-
-        # Impose some constraints on what is included in the fit
-        good_cat = np.isfinite(cat_mag) & np.isfinite(color) & (d2d.arcsecond < 1)
-        good_dat = (mag_inst < -3) & (mag_inst > -20) & np.isfinite(mag_inst)
-
-        if obs_error_column is not None:
-            errors = _to_float_array(one_image[obs_error_column])
-            # A non-positive or non-finite error gives a meaningless weight.
-            good_dat = good_dat & np.isfinite(errors) & (errors > 0)
-
-        # Both halves have to be good for the *same* star. Checking each on
-        # its own is not enough: the two sets can be disjoint, which leaves
-        # nothing to take the median of below.
-        usable = good_dat & good_cat
-
-        if not usable.any():
-            warnings.warn(
-                f"No good data in {file[0]}", AstropyUserWarning, stacklevel=2
-            )
-            continue
-
-        # Drop stars more than a magnitude away from the median difference
-        # between the catalog and instrumental magnitudes -- either a bad
-        # match or a bad measurement.
-        mag_diff = cat_mag - mag_inst
-        good = usable & (np.abs(mag_diff - np.median(mag_diff[usable])) < 1)
-
-        if not good.any():
-            warnings.warn(
-                f"No good data in {file[0]}", AstropyUserWarning, stacklevel=2
-            )
-            continue
-
-        # Prep for fitting
-        fit_mag = mag_inst[good]
-        fit_color = color[good]
-        offset = fit_mag if fit_diff else 0.0
-        fit_data = cat_mag[good] - offset
-        weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
-
-        # Fewer stars than terms has to be caught before the fit rather than
-        # after it: with nothing left to fit, lmfit takes the square root of a
-        # negative number working out the uncertainties, and the RuntimeWarning
-        # that produces is an outright exception for anyone running with
-        # warnings as errors. Whether the terms can be told apart from *each
-        # other* is a question about the fit and is asked of it below.
-        if fit_mag.size <= len(vary):
-            warnings.warn(
-                f"Fit for {file[0]} is underdetermined: {fit_mag.size} usable "
-                f"star(s) cannot determine {len(vary)} term(s) {list(vary)}; "
-                "the fit has no degrees of freedom left",
-                AstropyUserWarning,
-                stacklevel=2,
-            )
-            continue
-
-        params = base_params.copy()
-        if params["z"].vary:
-            # With every other term at its starting value of zero the model is
-            # just the zero point, so the median of the data being fit is the
-            # best starting guess available.
-            params["z"].set(value=float(np.median(fit_data)))
-
-        fit_result = lmfit.minimize(
-            _transform_residual,
-            params,
-            method="least_squares",
-            args=(fit_mag, fit_color, fit_data, weights),
-        )
-
-        if not fit_result.success:
-            warnings.warn(
-                f"Fit did not succeed for {file[0]}: {fit_result.message}",
-                AstropyUserWarning,
-                stacklevel=2,
-            )
-            continue
-
-        # A fit reports success whether or not the data can tell the terms
-        # being fit apart from each other, and the coefficients it lands on
-        # are applied to every star in the image, so a successful fit still
-        # has to be checked before its results are used.
-        underdetermined = _underdetermined_reason(fit_result, vary)
-        if underdetermined is not None:
-            warnings.warn(
-                f"Fit for {file[0]} is underdetermined: {underdetermined}",
-                AstropyUserWarning,
-                stacklevel=2,
-            )
-            continue
-
-        values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
-
-        # The expected ranges are a check on the answer, not a constraint on
-        # the fit, so a value outside its range is reported and kept.
-        out_of_range = [
-            f"{term}={values[term]:.4f} is outside the expected range "
-            f"{tuple(expected[term])}"
-            for term in expected
-            if not expected[term][0] <= values[term] <= expected[term][1]
-        ]
-        if out_of_range:
-            warnings.warn(
-                f"Fit for {file[0]}: " + "; ".join(out_of_range),
-                AstropyUserWarning,
-                stacklevel=2,
-            )
-
-        # Calculate calibrated magnitudes for every star in the image, not
-        # just the ones the fit used.
-        model_coefficients = [values[name] for name in _COEFF_NAMES]
-        cal_mag = calibrated_from_instrumental((mag_inst, color), *model_coefficients)
-        if fit_diff:
-            cal_mag = cal_mag + mag_inst
-
-        # A limit of 1 arcsec here can cause a variable that really is in APASS to not
-        # match. An example is V2480 Cyg, whose VSX position is about 1.3 arcsec from
-        # its APASS DR9 position.
-        cal_mag[d2d.arcsecond > 1.5] = np.nan
-
-        for name in _COEFF_NAMES:
-            coefficients[name][rows] = values[name]
-
-        cal_mags[rows] = cal_mag
-        cat_mags[rows] = cat_mag
-        cat_colors[rows] = color
-
+    # Made before the loop rather than after it so that the results can be
+    # written to it in the ``finally`` below. The loop reads only
+    # ``observed_mags_grouped`` and never this table, and the invariant
+    # documented just above is what makes writing by row index legal.
     result = observed_mags_grouped if in_place else observed_mags_grouped.copy()
 
-    if obs_error_column is not None:
-        # How much the calibrated magnitude moves when the instrumental one
-        # does. With fit_diff the instrumental magnitude is added back to the
-        # model result, so that sensitivity is 1 + a; without it the model is
-        # the calibrated magnitude outright and a itself is the factor -- it
-        # fits to about 1 rather than about 0. Using the same factor for both
-        # would double the reported uncertainty in one of the two modes.
-        sensitivity = 1 + coefficients["a"] if fit_diff else coefficients["a"]
+    # Warnings about one image are held until every image's results are in the
+    # table. Under -W error -- which this package's own test suite uses -- a
+    # warning raised inside the loop would otherwise throw away the results of
+    # every image already fit. See issue #679.
+    #
+    # Every warning raised in the loop is an AstropyUserWarning, so the message
+    # alone is enough to defer. Adding one of another category would make this
+    # a list of (message, category) tuples.
+    deferred_warnings = []
 
-        # Scaled from the raw per-call coefficients rather than the merged
-        # column, so that rows in other passbands are handled by the merge
-        # below instead of being recomputed from another passband's fit.
-        raw_errors = _to_float_array(result[obs_error_column])
-        scaled_errors = sensitivity * raw_errors
+    try:
+        for group_number, (file, one_image_all_bands) in enumerate(
+            zip(
+                observed_mags_grouped.groups.keys,
+                observed_mags_grouped.groups,
+                strict=True,
+            )
+        ):
+            group_start = group_bounds[group_number]
+            in_this_group = in_passband[group_start : group_bounds[group_number + 1]]
+            rows = group_start + np.flatnonzero(in_this_group)
 
-        # An error that is not a positive, finite number is kept out of the
-        # fit above, and must not come back out as a calibrated error either:
-        # the AAVSO writer turns only non-finite errors into "na", so a zero
-        # would be submitted as a real uncertainty.
-        scaled_errors[~(np.isfinite(raw_errors) & (raw_errors > 0))] = np.nan
+            if rows.size == 0:
+                # Nothing in this image was taken in this passband.
+                continue
 
-        result[_CAL_MAG_ERROR_COLUMN] = _merge_with_existing(
-            result, _CAL_MAG_ERROR_COLUMN, scaled_errors, in_passband
-        )
+            one_image = one_image_all_bands[in_this_group]
+            our_coords = SkyCoord(one_image["ra"], one_image["dec"], unit="degree")
 
-    result[_CAL_MAG_COLUMN] = _merge_with_existing(
-        result, _CAL_MAG_COLUMN, cal_mags, in_passband
-    )
+            cat_idx, d2d, _ = our_coords.match_to_catalog_sky(cat_coords)
 
-    for name in _COEFF_NAMES:
-        result[name] = _merge_with_existing(
-            result, name, coefficients[name], in_passband
-        )
+            # Masked catalog entries become NaN here, which both keeps them out
+            # of the fit and makes the calibrated magnitudes that depend on
+            # them NaN.
+            mag_inst = _to_float_array(one_image[obs_mag_col])
+            cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
+            color = _to_float_array(cat["color"][cat_idx])
 
-    result["mag_cat"] = _merge_with_existing(result, "mag_cat", cat_mags, in_passband)
-    result["color_cat"] = _merge_with_existing(
-        result, "color_cat", cat_colors, in_passband
-    )
+            # Impose some constraints on what is included in the fit
+            good_cat = np.isfinite(cat_mag) & np.isfinite(color) & (d2d.arcsecond < 1)
+            good_dat = (mag_inst < -3) & (mag_inst > -20) & np.isfinite(mag_inst)
+
+            if obs_error_column is not None:
+                errors = _to_float_array(one_image[obs_error_column])
+                # A non-positive or non-finite error gives a meaningless weight.
+                good_dat = good_dat & np.isfinite(errors) & (errors > 0)
+
+            # Both halves have to be good for the *same* star. Checking each on
+            # its own is not enough: the two sets can be disjoint, which leaves
+            # nothing to take the median of below.
+            usable = good_dat & good_cat
+
+            if not usable.any():
+                deferred_warnings.append(f"No good data in {file[0]}")
+                continue
+
+            # Drop stars more than a magnitude away from the median difference
+            # between the catalog and instrumental magnitudes -- either a bad
+            # match or a bad measurement.
+            mag_diff = cat_mag - mag_inst
+            good = usable & (np.abs(mag_diff - np.median(mag_diff[usable])) < 1)
+
+            if not good.any():
+                deferred_warnings.append(f"No good data in {file[0]}")
+                continue
+
+            # Prep for fitting
+            fit_mag = mag_inst[good]
+            fit_color = color[good]
+            offset = fit_mag if fit_diff else 0.0
+            fit_data = cat_mag[good] - offset
+            weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
+
+            # Fewer stars than terms has to be caught before the fit rather than
+            # after it: with nothing left to fit, lmfit takes the square root of
+            # a negative number working out the uncertainties, and the
+            # RuntimeWarning that produces is an outright exception for anyone
+            # running with warnings as errors. Whether the terms can be told
+            # apart from *each other* is a question about the fit and is asked
+            # of it below.
+            if fit_mag.size <= len(vary):
+                deferred_warnings.append(
+                    f"Fit for {file[0]} is underdetermined: {fit_mag.size} usable "
+                    f"star(s) cannot determine {len(vary)} term(s) {list(vary)}; "
+                    "the fit has no degrees of freedom left"
+                )
+                continue
+
+            params = base_params.copy()
+            if params["z"].vary:
+                # With every other term at its starting value of zero the model
+                # is just the zero point, so the median of the data being fit is
+                # the best starting guess available.
+                params["z"].set(value=float(np.median(fit_data)))
+
+            fit_result = lmfit.minimize(
+                _transform_residual,
+                params,
+                method="least_squares",
+                args=(fit_mag, fit_color, fit_data, weights),
+            )
+
+            if not fit_result.success:
+                deferred_warnings.append(
+                    f"Fit did not succeed for {file[0]}: {fit_result.message}"
+                )
+                continue
+
+            # A fit reports success whether or not the data can tell the terms
+            # being fit apart from each other, and the coefficients it lands on
+            # are applied to every star in the image, so a successful fit still
+            # has to be checked before its results are used.
+            underdetermined = _underdetermined_reason(fit_result, vary)
+            if underdetermined is not None:
+                deferred_warnings.append(
+                    f"Fit for {file[0]} is underdetermined: {underdetermined}"
+                )
+                continue
+
+            values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
+
+            # The expected ranges are a check on the answer, not a constraint on
+            # the fit, so a value outside its range is reported and kept.
+            out_of_range = [
+                f"{term}={values[term]:.4f} is outside the expected range "
+                f"{tuple(expected[term])}"
+                for term in expected
+                if not expected[term][0] <= values[term] <= expected[term][1]
+            ]
+            if out_of_range:
+                deferred_warnings.append(
+                    f"Fit for {file[0]}: " + "; ".join(out_of_range)
+                )
+
+            # Calculate calibrated magnitudes for every star in the image, not
+            # just the ones the fit used.
+            model_coefficients = [values[name] for name in _COEFF_NAMES]
+            cal_mag = calibrated_from_instrumental(
+                (mag_inst, color), *model_coefficients
+            )
+            if fit_diff:
+                cal_mag = cal_mag + mag_inst
+
+            # A limit of 1 arcsec here can cause a variable that really is in
+            # APASS to not match. An example is V2480 Cyg, whose VSX position is
+            # about 1.3 arcsec from its APASS DR9 position.
+            cal_mag[d2d.arcsecond > 1.5] = np.nan
+
+            for name in _COEFF_NAMES:
+                coefficients[name][rows] = values[name]
+
+            cal_mags[rows] = cal_mag
+            cat_mags[rows] = cat_mag
+            cat_colors[rows] = color
+    finally:
+        # In `finally` so the images fit before anything went wrong still reach
+        # the table, even if what went wrong was not a warning. The keys are
+        # inserted in the order the columns are added to the table in.
+        output_columns = {}
+
+        if obs_error_column is not None:
+            # How much the calibrated magnitude moves when the instrumental one
+            # does. With fit_diff the instrumental magnitude is added back to
+            # the model result, so that sensitivity is 1 + a; without it the
+            # model is the calibrated magnitude outright and a itself is the
+            # factor -- it fits to about 1 rather than about 0. Using the same
+            # factor for both would double the reported uncertainty in one of
+            # the two modes.
+            sensitivity = 1 + coefficients["a"] if fit_diff else coefficients["a"]
+
+            # Scaled from the raw per-call coefficients rather than the merged
+            # column, so that rows in other passbands are handled by the merge
+            # below instead of being recomputed from another passband's fit.
+            raw_errors = _to_float_array(result[obs_error_column])
+            scaled_errors = sensitivity * raw_errors
+
+            # An error that is not a positive, finite number is kept out of the
+            # fit above, and must not come back out as a calibrated error
+            # either: the AAVSO writer turns only non-finite errors into "na",
+            # so a zero would be submitted as a real uncertainty.
+            scaled_errors[~(np.isfinite(raw_errors) & (raw_errors > 0))] = np.nan
+
+            output_columns[_CAL_MAG_ERROR_COLUMN] = scaled_errors
+
+        output_columns[_CAL_MAG_COLUMN] = cal_mags
+        output_columns.update(coefficients)
+        output_columns["mag_cat"] = cat_mags
+        output_columns["color_cat"] = cat_colors
+
+        _write_output_columns(result, output_columns, in_passband)
+
+    for message in deferred_warnings:
+        warnings.warn(message, AstropyUserWarning, stacklevel=2)
 
     return result

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -459,7 +459,7 @@ def transform_to_catalog(
     expected : dict, optional
         Range each term is expected to fall in, as ``{term: (low, high)}``.
         These are **not** constraints on the fit: a value outside its range is
-        reported in a warning, not clamped. Terms that are not in ``vary`` are
+        reported in a log message, not clamped. Terms that are not in ``vary`` are
         checked too -- a term held at zero when it should be near 20 is the
         most useful thing this can tell you. Pass an empty dict to check
         nothing. The default is ``{"z": (18, 22)}``.

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -1068,13 +1069,34 @@ def test_transform_to_catalog_no_good_data_warns_and_nans(mocker, case):
         assert np.isnan(result[term]).all()
 
 
-def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
-    # A night's data can easily contain one unusable image. That image should
-    # cost its own results and nothing else -- the fits for the other images
-    # still have to come back.
-    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+def _one_good_one_bad_image(catalog, ra, dec, instrumental):
+    """
+    Observations of two images, the first usable and the second not.
 
-    observed = _combine_observed_tables(
+    The unusable image is unusable in a way that makes `transform_to_catalog`
+    give up on it partway through the loop over images, warning and naming
+    ``image_2.fit`` as it does. That is the setup both for "one bad image does
+    not cost the others their results" and for "those results are in the table
+    even when the warning is escalated to an error".
+
+    Parameters
+    ----------
+
+    catalog : `_FakeCatalogTable`
+        Catalog the observations will be matched against.
+
+    ra, dec : `astropy.units.Quantity`
+        Position of each star. Both images observe the same stars.
+
+    instrumental : `numpy.ndarray`
+        Instrumental magnitudes of the usable image.
+
+    Returns
+    -------
+    `astropy.table.Table`
+        Observations of both images, grouped by file name.
+    """
+    return _combine_observed_tables(
         _generate_observed_table(ra, dec, instrumental, file_name="image_1.fit"),
         _make_unusable_observations(
             "out_of_range",
@@ -1086,6 +1108,15 @@ def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
         ),
     )
 
+
+def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
+    # A night's data can easily contain one unusable image. That image should
+    # cost its own results and nothing else -- the fits for the other images
+    # still have to come back.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+
+    observed = _one_good_one_bad_image(catalog, ra, dec, instrumental)
+
     with pytest.warns(AstropyUserWarning, match="image_2.fit"):
         result = _run_transform_to_catalog(mocker, catalog, observed)
 
@@ -1095,6 +1126,53 @@ def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
         result["mag_cal"][good], catalog["mag_R"], rtol=0, atol=1e-6
     )
     assert np.isnan(result["mag_cal"][~good]).all()
+
+
+def test_transform_to_catalog_writes_results_before_warnings_escalate(mocker):
+    # Anyone running with warnings as errors -- which includes this package's
+    # own test suite -- used to lose every image's results to a warning about
+    # one image, because the columns were not written until after the loop.
+    # The warning still escalates; what is new is that the table it was handed
+    # is complete when it does. See issue #679.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+
+    observed = _one_good_one_bad_image(catalog, ra, dec, instrumental)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(AstropyUserWarning, match="image_2.fit"):
+            _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
+
+    # The call raised, but the table it was handed is complete.
+    assert _TRANSFORM_OUTPUT_COLUMNS <= set(observed.colnames)
+
+    good = observed["file"] == "image_1.fit"
+
+    np.testing.assert_allclose(
+        observed["mag_cal"][good], catalog["mag_R"], rtol=0, atol=1e-6
+    )
+    assert np.isnan(observed["mag_cal"][~good]).all()
+
+
+def test_transform_to_catalog_writes_results_before_expected_warning_escalates(mocker):
+    # The warning about a term outside its expected range is not a bail-out:
+    # the fit succeeded and every star has a calibrated magnitude. Escalated to
+    # an error it nevertheless used to discard all of it, which makes it the
+    # most wasteful of the deferred warnings. See issue #679.
+    true_zero_point = 25.0
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20, z=true_zero_point)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(AstropyUserWarning, match=r"z=25\.0000 is outside"):
+            _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
+
+    assert _TRANSFORM_OUTPUT_COLUMNS <= set(observed.colnames)
+
+    np.testing.assert_allclose(observed["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    np.testing.assert_allclose(observed["z"], true_zero_point, rtol=0, atol=1e-6)
 
 
 def test_transform_to_catalog_excludes_masked_catalog_entries(mocker):

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1138,9 +1138,10 @@ def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker, caplo
     assert np.isnan(result["mag_cal"][~good]).all()
 
 
-def test_transform_to_catalog_writes_results_before_warnings_escalate(mocker, caplog):
-    # Bad images now log warnings instead of raising them, so the table is
-    # always completed and the call returns normally. See issue #679.
+def test_transform_to_catalog_bad_image_logs_instead_of_raising(mocker, caplog):
+    # Problems with one image are log messages, not warnings, so the call
+    # completes and the table is written even with warnings escalated to
+    # errors -- which this suite's own configuration does. See issue #679.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
 
     observed = _one_good_one_bad_image(catalog, ra, dec, instrumental)
@@ -1161,12 +1162,11 @@ def test_transform_to_catalog_writes_results_before_warnings_escalate(mocker, ca
     assert np.isnan(result["mag_cal"][~good]).all()
 
 
-def test_transform_to_catalog_writes_results_before_expected_warning_escalates(
-    mocker, caplog
-):
-    # The message about a term outside its expected range is now logged, not
-    # raised as a warning. The fit succeeded and every star has a calibrated
-    # magnitude. See issue #679.
+def test_transform_to_catalog_out_of_range_term_logs_instead_of_raising(mocker, caplog):
+    # A term outside its expected range is a report on a fit that succeeded,
+    # so it is a log message rather than a warning: every star keeps its
+    # calibrated magnitude even with warnings escalated to errors. See
+    # issue #679.
     true_zero_point = 25.0
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(20, z=true_zero_point)

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1,5 +1,4 @@
-import re
-import warnings
+import logging
 
 import numpy as np
 import pytest
@@ -15,6 +14,9 @@ from ..magnitude_transforms import (
     filter_transform,
     transform_to_catalog,
 )
+
+# Logger name for magnitude_transforms module
+_MAGNITUDE_TRANSFORMS_LOGGER = "stellarphot.utils.magnitude_transforms"
 
 
 def _generate_star_coordinates(
@@ -918,11 +920,11 @@ def test_transform_to_catalog_bad_vary_raises(mocker, bad_vary):
     ],
 )
 def test_transform_to_catalog_warns_when_term_outside_expected(
-    mocker, term, true_value, expected
+    mocker, term, true_value, expected, caplog
 ):
     # A zero point outside the expected range used to rail at the bound and
     # report a confident wrong answer. Every term should now be fit freely and
-    # merely warned about, by name and by the value it reached. See issue #601.
+    # merely logged about, by name and by the value it reached. See issue #601.
     coefficients = {term: true_value}
     if term != "z":
         coefficients["z"] = _FAKE_CATALOG_ZERO_POINT
@@ -930,9 +932,11 @@ def test_transform_to_catalog_warns_when_term_outside_expected(
     catalog, ra, dec, instrumental = _generate_fake_catalog(20, **coefficients)
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    message = re.escape(f"{term}={true_value:.4f} is outside")
-    with pytest.warns(AstropyUserWarning, match=message):
+    message_pattern = f"{term}={true_value:.4f} is outside"
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed, expected=expected)
+
+    assert any(message_pattern in r.message for r in caplog.records)
 
     # The value is reported, not clamped to the edge of the expected range.
     np.testing.assert_allclose(result[term], true_value, rtol=0, atol=1e-6)
@@ -963,7 +967,7 @@ def test_transform_to_catalog_empty_expected_disables_check(mocker):
     np.testing.assert_allclose(result["z"], true_zero_point, rtol=0, atol=1e-6)
 
 
-def test_transform_to_catalog_warns_when_fit_fails(mocker):
+def test_transform_to_catalog_warns_when_fit_fails(mocker, caplog):
     # A fit that does not converge is not reliably reproducible, so mock one.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
     observed = _generate_observed_table(ra, dec, instrumental)
@@ -973,8 +977,10 @@ def test_transform_to_catalog_warns_when_fit_fails(mocker):
     failed_fit.message = "the fitter gave up"
     mocker.patch.object(magnitude_transforms.lmfit, "minimize", return_value=failed_fit)
 
-    with pytest.warns(AstropyUserWarning, match="did not succeed"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("did not succeed" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
 
@@ -1053,7 +1059,7 @@ def _make_unusable_observations(case, catalog, ra, dec, instrumental, **kwargs):
 
 
 @pytest.mark.parametrize("case", ["out_of_range", "nan", "masked_catalog"])
-def test_transform_to_catalog_no_good_data_warns_and_nans(mocker, case):
+def test_transform_to_catalog_no_good_data_warns_and_nans(mocker, case, caplog):
     # An image can be unusable from either side -- bad measurements or no
     # catalog to compare them to -- and the answer is the same either way: say
     # which image it was, and leave its outputs NaN rather than reporting
@@ -1061,8 +1067,10 @@ def test_transform_to_catalog_no_good_data_warns_and_nans(mocker, case):
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
     observed = _make_unusable_observations(case, catalog, ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="image_1.fit"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("image_1.fit" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
     for term in ("a", "b", "c", "d", "z"):
@@ -1109,7 +1117,7 @@ def _one_good_one_bad_image(catalog, ra, dec, instrumental):
     )
 
 
-def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
+def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker, caplog):
     # A night's data can easily contain one unusable image. That image should
     # cost its own results and nothing else -- the fits for the other images
     # still have to come back.
@@ -1117,8 +1125,10 @@ def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
 
     observed = _one_good_one_bad_image(catalog, ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="image_2.fit"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("image_2.fit" in r.message for r in caplog.records)
 
     good = result["file"] == "image_1.fit"
 
@@ -1128,51 +1138,48 @@ def test_transform_to_catalog_one_bad_image_does_not_poison_others(mocker):
     assert np.isnan(result["mag_cal"][~good]).all()
 
 
-def test_transform_to_catalog_writes_results_before_warnings_escalate(mocker):
-    # Anyone running with warnings as errors -- which includes this package's
-    # own test suite -- used to lose every image's results to a warning about
-    # one image, because the columns were not written until after the loop.
-    # The warning still escalates; what is new is that the table it was handed
-    # is complete when it does. See issue #679.
+def test_transform_to_catalog_writes_results_before_warnings_escalate(mocker, caplog):
+    # Bad images now log warnings instead of raising them, so the table is
+    # always completed and the call returns normally. See issue #679.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
 
     observed = _one_good_one_bad_image(catalog, ra, dec, instrumental)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        with pytest.raises(AstropyUserWarning, match="image_2.fit"):
-            _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
+        result = _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
 
-    # The call raised, but the table it was handed is complete.
-    assert _TRANSFORM_OUTPUT_COLUMNS <= set(observed.colnames)
+    assert any("image_2.fit" in r.message for r in caplog.records)
 
-    good = observed["file"] == "image_1.fit"
+    # The call completed and the table is complete.
+    assert _TRANSFORM_OUTPUT_COLUMNS <= set(result.colnames)
+
+    good = result["file"] == "image_1.fit"
 
     np.testing.assert_allclose(
-        observed["mag_cal"][good], catalog["mag_R"], rtol=0, atol=1e-6
+        result["mag_cal"][good], catalog["mag_R"], rtol=0, atol=1e-6
     )
-    assert np.isnan(observed["mag_cal"][~good]).all()
+    assert np.isnan(result["mag_cal"][~good]).all()
 
 
-def test_transform_to_catalog_writes_results_before_expected_warning_escalates(mocker):
-    # The warning about a term outside its expected range is not a bail-out:
-    # the fit succeeded and every star has a calibrated magnitude. Escalated to
-    # an error it nevertheless used to discard all of it, which makes it the
-    # most wasteful of the deferred warnings. See issue #679.
+def test_transform_to_catalog_writes_results_before_expected_warning_escalates(
+    mocker, caplog
+):
+    # The message about a term outside its expected range is now logged, not
+    # raised as a warning. The fit succeeded and every star has a calibrated
+    # magnitude. See issue #679.
     true_zero_point = 25.0
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(20, z=true_zero_point)
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        with pytest.raises(AstropyUserWarning, match=r"z=25\.0000 is outside"):
-            _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
+        result = _run_transform_to_catalog(mocker, catalog, observed, in_place=True)
 
-    assert _TRANSFORM_OUTPUT_COLUMNS <= set(observed.colnames)
+    assert any("z=25.0000 is outside" in r.message for r in caplog.records)
+    assert _TRANSFORM_OUTPUT_COLUMNS <= set(result.colnames)
 
-    np.testing.assert_allclose(observed["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
-    np.testing.assert_allclose(observed["z"], true_zero_point, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    np.testing.assert_allclose(result["z"], true_zero_point, rtol=0, atol=1e-6)
 
 
 def test_transform_to_catalog_excludes_masked_catalog_entries(mocker):
@@ -1306,7 +1313,7 @@ def test_transform_to_catalog_skips_image_without_the_passband(mocker):
     assert np.isnan(result["mag_cal"][~has_the_passband]).all()
 
 
-def test_transform_to_catalog_warns_when_outlier_cut_removes_everything(mocker):
+def test_transform_to_catalog_warns_when_outlier_cut_removes_everything(mocker, caplog):
     # Stars more than a magnitude from the median offset between the catalog
     # and instrumental magnitudes are dropped. Here every star is, which
     # leaves nothing to fit even though the data and the catalog matches are
@@ -1316,13 +1323,15 @@ def test_transform_to_catalog_warns_when_outlier_cut_removes_everything(mocker):
     scattered = instrumental + np.array([2.5, -2.5])
     observed = _generate_observed_table(ra, dec, scattered)
 
-    with pytest.warns(AstropyUserWarning, match="No good data"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("No good data" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
 
 
-def test_transform_to_catalog_disjoint_good_data_and_catalog(mocker):
+def test_transform_to_catalog_disjoint_good_data_and_catalog(mocker, caplog):
     # The stars with usable instrumental magnitudes and the stars with usable
     # catalog entries can be two entirely different sets. Checking that each is
     # non-empty on its own is not enough: the median offset used for the
@@ -1345,16 +1354,14 @@ def test_transform_to_catalog_disjoint_good_data_and_catalog(mocker):
 
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="No good data") as recorded:
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
 
-    assert not [
-        warning for warning in recorded if issubclass(warning.category, RuntimeWarning)
-    ], "taking the median of an empty selection should not be attempted at all"
+    assert any("No good data" in r.message for r in caplog.records)
     assert np.isnan(result["mag_cal"]).all()
 
 
-def test_transform_to_catalog_warns_when_too_few_stars_to_fit(mocker):
+def test_transform_to_catalog_warns_when_too_few_stars_to_fit(mocker, caplog):
     # Three stars cannot pin down three coefficients: the fit has no degrees of
     # freedom left, so it reproduces those three stars exactly and says nothing
     # at all about any other star in the image. lmfit reports success anyway,
@@ -1364,15 +1371,17 @@ def test_transform_to_catalog_warns_when_too_few_stars_to_fit(mocker):
     catalog, ra, dec, instrumental = _generate_fake_catalog(3)
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="underdetermined"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("underdetermined" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
     for term in ("a", "b", "c", "d", "z"):
         assert np.isnan(result[term]).all()
 
 
-def test_transform_to_catalog_warns_when_terms_are_degenerate(mocker):
+def test_transform_to_catalog_warns_when_terms_are_degenerate(mocker, caplog):
     # Plenty of stars is not enough if they carry no independent information. A
     # color that is a linear function of instrumental magnitude makes a, c and
     # z exactly degenerate -- infinitely many combinations fit equally well --
@@ -1385,13 +1394,15 @@ def test_transform_to_catalog_warns_when_terms_are_degenerate(mocker):
     )
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="underdetermined"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("underdetermined" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
 
 
-def test_transform_to_catalog_warns_when_terms_are_nearly_degenerate(mocker):
+def test_transform_to_catalog_warns_when_terms_are_nearly_degenerate(mocker, caplog):
     # Exactly degenerate data is a synthetic construct: it takes a color that is
     # a linear function of instrumental magnitude to the last bit, which real
     # stars never are. What real data does produce is *near* degeneracy -- a
@@ -1411,13 +1422,15 @@ def test_transform_to_catalog_warns_when_terms_are_nearly_degenerate(mocker):
     )
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="underdetermined"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("underdetermined" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
 
 
-def test_transform_to_catalog_warns_when_a_term_has_no_leverage(mocker):
+def test_transform_to_catalog_warns_when_a_term_has_no_leverage(mocker, caplog):
     # The extreme end of the same problem: if the two catalog bands the color
     # is built from are identical, every star's color is zero and the color
     # term does nothing whatever -- any value of c fits exactly as well as any
@@ -1432,8 +1445,10 @@ def test_transform_to_catalog_warns_when_a_term_has_no_leverage(mocker):
     )
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="cannot be told apart"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("cannot be told apart" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
 
@@ -1462,7 +1477,7 @@ def test_transform_to_catalog_fits_correlated_but_usable_data(mocker):
     np.testing.assert_allclose(result["c"], 0.15, rtol=0, atol=1e-4)
 
 
-def test_transform_to_catalog_warns_when_fixed_term_outside_expected(mocker):
+def test_transform_to_catalog_warns_when_fixed_term_outside_expected(mocker, caplog):
     # Leaving z out of vary pins it at zero, which is nowhere near the expected
     # zero point of a real image. A term held at a wrong value is exactly what
     # the caller needs to be told about, so the expected ranges are checked for
@@ -1470,8 +1485,10 @@ def test_transform_to_catalog_warns_when_fixed_term_outside_expected(mocker):
     catalog, ra, dec, instrumental = _generate_fake_catalog(20, a=0.02, c=0.15)
     observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match=r"z=0\.0000 is outside"):
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed, vary=("a", "c"))
+
+    assert any("z=0.0000 is outside" in r.message for r in caplog.records)
 
     assert (result["z"] == 0.0).all()
 


### PR DESCRIPTION
Closes #679.

`transform_to_catalog` reported problems with individual images -- no usable
stars, an underdetermined or failed fit, a term outside its expected range --
as warnings raised inside the per-image loop. Under `-W error` any one of them
aborted the whole calibration, discarding the results of every image already
fit (issue #679).

Review discussion here landed on a simpler position than the deferral this PR
originally implemented: these messages are per-image data-quality notes, not
API-misuse warnings, so they are now `logger.warning` calls -- the same
pattern `single_image_photometry` and `multi_image_photometry` already use.
With nothing in the loop able to escalate, #679's failure mode no longer
exists, and the deferral machinery and `try/finally` from earlier revisions of
this branch are gone with it.

The split this leaves, matching the rest of the package:

- **Anticipated per-image data problems** are logged and the image is skipped;
  its rows stay NaN and every other image keeps its results.
- **Unanticipated exceptions** (e.g. lmfit crashing on data that passed the
  checks) are bugs, and crash loudly with no salvage attempt -- partial
  results are not worth preserving, since the fix is to re-run anyway.
- The pre-loop warning about calling with no `obs_error_column` stays a real
  warning: it is advice about the call itself, fires before any work is done,
  and escalating it discards nothing.

### Also

`_write_output_columns` is a new helper next to `_merge_with_existing`; output
column order is unchanged. This is groundwork -- four follow-up PRs (#678,
#681, #677, #674) each add columns, and this turns each of those into one dict
entry instead of another edit to the same straight-line block.

This is the first of five stacked PRs off the #676 follow-ups; the rest build
on this branch.

---

*This PR description was written by Claude at @mwcraig's direction.*
