### PR TITLE
Apply one match cut to everything the catalog match produces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,17 +152,11 @@ Bug Fixes
   aborts the calibration; output columns are written after all images are
   processed. [#682]
 + ``transform_to_catalog()`` now applies one match-distance cut to everything
-  it derives from the catalog match. ``mag_cat`` and ``color_cat`` used to be
-  taken from the nearest catalog entry however far away it was, and
-  ``mag_cal_error`` was reported for every row with a usable input error, so
-  both could describe an unrelated star on a row whose ``mag_cal`` was NaN.
-  All of them are now NaN beyond 1.5 arcsec, the same limit ``mag_cal``
-  follows, and ``mag_cal_error`` is NaN wherever ``mag_cal`` is -- including
-  for a star with no instrumental magnitude, which previously got a finite
-  calibrated error. A star is also no longer required to have a catalog color
-  unless a color term (``"c"`` or ``"d"``) is actually being fit, so stars the
-  catalog has no color for can be fit and calibrated when ``vary`` does not
-  include one. [#678, #681]
+  it derives from the catalog match: ``mag_cat``, ``color_cat`` and
+  ``mag_cal_error`` are NaN wherever ``mag_cal`` is, instead of reporting the
+  nearest catalog star's values however far away it was. [#678]
++ ``transform_to_catalog()`` no longer requires a star to have a catalog
+  color unless a color term (``"c"`` or ``"d"``) is actually being fit. [#681]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,18 @@ Bug Fixes
   messages instead of warnings, so running with warnings-as-errors no longer
   aborts the calibration; output columns are written after all images are
   processed. [#682]
++ ``transform_to_catalog()`` now applies one match-distance cut to everything
+  it derives from the catalog match. ``mag_cat`` and ``color_cat`` used to be
+  taken from the nearest catalog entry however far away it was, and
+  ``mag_cal_error`` was reported for every row with a usable input error, so
+  both could describe an unrelated star on a row whose ``mag_cal`` was NaN.
+  All of them are now NaN beyond 1.5 arcsec, the same limit ``mag_cal``
+  follows, and ``mag_cal_error`` is NaN wherever ``mag_cal`` is -- including
+  for a star with no instrumental magnitude, which previously got a finite
+  calibrated error. A star is also no longer required to have a catalog color
+  unless a color term (``"c"`` or ``"d"``) is actually being fit, so stars the
+  catalog has no color for can be fit and calibrated when ``vary`` does not
+  include one. [#678, #681]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -35,6 +35,18 @@ _DEFAULT_EXPECTED = {"z": (18.0, 22.0)}
 _CAL_MAG_COLUMN = "mag_cal"
 _CAL_MAG_ERROR_COLUMN = "mag_cal_error"
 
+# How close an observed star must be to a catalog entry, in arcseconds. Two
+# limits rather than one: a star must match tightly to be allowed to influence
+# the fit, and less tightly to be given values derived from its match.
+#
+# The band between the two is deliberate. A limit of 1 arcsec everywhere can
+# stop a variable that really is in the catalog from matching at all -- V2480
+# Cyg's VSX position is about 1.3 arcsec from its APASS DR9 position -- and a
+# star in that band is well enough matched to calibrate, just not well enough
+# to calibrate everything else against.
+_FIT_MATCH_ARCSEC = 1.0
+_CAL_MATCH_ARCSEC = 1.5
+
 # How strongly the terms of the fit may be correlated with each other before
 # their individual values stop meaning anything. See `_underdetermined_reason`,
 # which explains how this was arrived at.
@@ -456,6 +468,12 @@ def transform_to_catalog(
         ``"d"``, the linear and quadratic dependence on color, and ``"z"``,
         the zero point.
 
+        A star is required to have a catalog color only when ``"c"`` or
+        ``"d"`` is being fit. With neither of them in ``vary`` the color does
+        not enter the model at all, so stars the catalog has no color for take
+        part in the fit and are calibrated like any other; their ``color_cat``
+        is still NaN, because their color really is unknown.
+
     expected : dict, optional
         Range each term is expected to fall in, as ``{term: (low, high)}``.
         These are **not** constraints on the fit: a value outside its range is
@@ -485,9 +503,12 @@ def transform_to_catalog(
         could not be fit and for rows in other passbands that had no value
         already.
 
-        ``mag_cat`` and ``color_cat`` are taken from the nearest catalog entry
-        whatever its distance, so they can hold the values of an unrelated
-        star on rows whose ``mag_cal`` is NaN.
+        Every column that comes from the catalog match -- ``mag_cal``,
+        ``mag_cal_error``, ``mag_cat`` and ``color_cat`` -- is NaN for a star
+        whose nearest catalog entry is more than 1.5 arcsec away, so none of
+        them can hold the values of an unrelated star. ``mag_cal_error`` is
+        NaN wherever ``mag_cal`` is, for whatever reason, so a finite
+        calibrated error always has a calibrated magnitude to go with it.
 
     Notes
     -----
@@ -522,6 +543,11 @@ def transform_to_catalog(
             f"the terms are {list(_COEFF_NAMES)}."
         )
 
+    # Whether a star needs a catalog color at all. Only the color terms use
+    # one, and ``vary`` is fixed for the whole call, so this is settled once
+    # rather than per image.
+    fitting_color = bool({"c", "d"} & set(vary))
+
     # Checked against every term, varied or not. A term that is not fit sits
     # at exactly zero, and a fixed term sitting outside the range it is
     # expected in is precisely what the caller needs to hear about -- leaving
@@ -549,6 +575,7 @@ def transform_to_catalog(
     # written keep the NaN they start with.
     coefficients = {name: np.full(n_rows, np.nan) for name in _COEFF_NAMES}
     cal_mags = np.full(n_rows, np.nan)
+    cal_errors = np.full(n_rows, np.nan)
     cat_mags = np.full(n_rows, np.nan)
     cat_colors = np.full(n_rows, np.nan)
 
@@ -615,8 +642,23 @@ def transform_to_catalog(
         cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
         color = _to_float_array(cat["color"][cat_idx])
 
+        # The color the model is evaluated with. When no color term is
+        # being fit the color is multiplied by zero, but ``0.0 * np.nan``
+        # is NaN, which would poison both the residual and the calibrated
+        # magnitude of every star the catalog has no color for. A neutral
+        # zero stands in for the missing colors instead. `numpy.where`
+        # rather than `numpy.nan_to_num`, which would also turn an
+        # infinite color into a very large finite one. The raw ``color``
+        # is what goes into the ``color_cat`` output column, so a star
+        # with no color still reports none.
+        model_color = (
+            color if fitting_color else np.where(np.isfinite(color), color, 0.0)
+        )
+
         # Impose some constraints on what is included in the fit
-        good_cat = np.isfinite(cat_mag) & np.isfinite(color) & (d2d.arcsecond < 1)
+        good_cat = np.isfinite(cat_mag) & (d2d.arcsecond < _FIT_MATCH_ARCSEC)
+        if fitting_color:
+            good_cat = good_cat & np.isfinite(color)
         good_dat = (mag_inst < -3) & (mag_inst > -20) & np.isfinite(mag_inst)
 
         if obs_error_column is not None:
@@ -645,7 +687,7 @@ def transform_to_catalog(
 
         # Prep for fitting
         fit_mag = mag_inst[good]
-        fit_color = color[good]
+        fit_color = model_color[good]
         offset = fit_mag if fit_diff else 0.0
         fit_data = cat_mag[good] - offset
         weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
@@ -707,48 +749,62 @@ def transform_to_catalog(
         # Calculate calibrated magnitudes for every star in the image, not
         # just the ones the fit used.
         model_coefficients = [values[name] for name in _COEFF_NAMES]
-        cal_mag = calibrated_from_instrumental((mag_inst, color), *model_coefficients)
+        cal_mag = calibrated_from_instrumental(
+            (mag_inst, model_color), *model_coefficients
+        )
         if fit_diff:
             cal_mag = cal_mag + mag_inst
 
-        # A limit of 1 arcsec here can cause a variable that really is in
-        # APASS to not match. An example is V2480 Cyg, whose VSX position is
-        # about 1.3 arcsec from its APASS DR9 position.
-        cal_mag[d2d.arcsecond > 1.5] = np.nan
+        # One cut for everything that comes from the match: a star matched
+        # closely enough to be given a calibrated magnitude keeps the
+        # catalog magnitude and color it was calibrated against, and a
+        # star matched no better than this keeps none of them rather than
+        # reporting an unrelated star's values. The comparison is ``<=``
+        # so that the boundary stays where it has always been.
+        matched = d2d.arcsecond <= _CAL_MATCH_ARCSEC
+        cal_mag[~matched] = np.nan
 
         for name in _COEFF_NAMES:
             coefficients[name][rows] = values[name]
 
         cal_mags[rows] = cal_mag
-        cat_mags[rows] = cat_mag
-        cat_colors[rows] = color
+        cat_mags[rows] = np.where(matched, cat_mag, np.nan)
+        cat_colors[rows] = np.where(matched, color, np.nan)
+
+        if obs_error_column is not None:
+            # How much the calibrated magnitude moves when the instrumental
+            # one does. With fit_diff the instrumental magnitude is added
+            # back to the model result, so that sensitivity is 1 + a;
+            # without it the model is the calibrated magnitude outright and
+            # a itself is the factor -- it fits to about 1 rather than
+            # about 0. Using the same factor for both would double the
+            # reported uncertainty in one of the two modes.
+            sensitivity = 1 + values["a"] if fit_diff else values["a"]
+            cal_error = sensitivity * errors
+
+            # An error that is not a positive, finite number is kept out of
+            # the fit above, and must not come back out as a calibrated
+            # error either: the AAVSO writer turns only non-finite errors
+            # into "na", so a zero would be submitted as a real uncertainty.
+            cal_error[~(np.isfinite(errors) & (errors > 0))] = np.nan
+
+            # A star with no calibrated magnitude has no calibrated error
+            # either, whatever the reason it has no magnitude. That is
+            # stronger than repeating the distance cut -- it also covers a
+            # star with no instrumental magnitude -- and it is what makes a
+            # finite mag_cal_error safe to select rows on.
+            cal_error[~np.isfinite(cal_mag)] = np.nan
+
+            cal_errors[rows] = cal_error
 
     # The keys are inserted in the order the columns are added to the table in.
     output_columns = {}
 
+    # The calibrated errors are worked out in the loop, where the per-star
+    # distances and calibrated magnitudes they depend on live. Only the
+    # column order is decided here, and it puts them first.
     if obs_error_column is not None:
-        # How much the calibrated magnitude moves when the instrumental one
-        # does. With fit_diff the instrumental magnitude is added back to
-        # the model result, so that sensitivity is 1 + a; without it the
-        # model is the calibrated magnitude outright and a itself is the
-        # factor -- it fits to about 1 rather than about 0. Using the same
-        # factor for both would double the reported uncertainty in one of
-        # the two modes.
-        sensitivity = 1 + coefficients["a"] if fit_diff else coefficients["a"]
-
-        # Scaled from the raw per-call coefficients rather than the merged
-        # column, so that rows in other passbands are handled by the merge
-        # below instead of being recomputed from another passband's fit.
-        raw_errors = _to_float_array(result[obs_error_column])
-        scaled_errors = sensitivity * raw_errors
-
-        # An error that is not a positive, finite number is kept out of the
-        # fit above, and must not come back out as a calibrated error
-        # either: the AAVSO writer turns only non-finite errors into "na",
-        # so a zero would be submitted as a real uncertainty.
-        scaled_errors[~(np.isfinite(raw_errors) & (raw_errors > 0))] = np.nan
-
-        output_columns[_CAL_MAG_ERROR_COLUMN] = scaled_errors
+        output_columns[_CAL_MAG_ERROR_COLUMN] = cal_errors
 
     output_columns[_CAL_MAG_COLUMN] = cal_mags
     output_columns.update(coefficients)

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -635,9 +635,11 @@ def transform_to_catalog(
 
         cat_idx, d2d, _ = our_coords.match_to_catalog_sky(cat_coords)
 
-        # Masked catalog entries become NaN here, which both keeps them out
-        # of the fit and makes the calibrated magnitudes that depend on
-        # them NaN.
+        # Masked catalog entries become NaN here, which keeps them out of the
+        # fit. A star's own calibrated magnitude never involves its catalog
+        # magnitude, and a missing color only makes ``mag_cal`` NaN when a
+        # color term is being fit -- ``model_color`` below covers the case
+        # where none is.
         mag_inst = _to_float_array(one_image[obs_mag_col])
         cat_mag = _to_float_array(cat[f"mag_{cat_filter}"][cat_idx])
         color = _to_float_array(cat["color"][cat_idx])

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -403,6 +403,13 @@ def _run_transform_to_catalog(
     return transform_to_catalog(observed, obs_filter, cat_name=cat_name, **call_kwargs)
 
 
+# Every output column whose value comes from the catalog entry a star was
+# matched to. All of them stand or fall together: a star matched closely
+# enough to be calibrated keeps the catalog magnitude and color it was
+# calibrated against, and a star that is not gets none of them.
+_CATALOG_DERIVED_COLUMNS = ("mag_cal", "mag_cal_error", "mag_cat", "color_cat")
+
+
 def test_transform_to_catalog_excludes_distant_matches(mocker):
     # A star whose nearest catalog match is far away (much more than
     # 1 arcsec) should be excluded from the fit for the transform
@@ -431,9 +438,12 @@ def test_transform_to_catalog_excludes_distant_matches(mocker):
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
 
-    # The distant star has no real match, so its calibrated
-    # magnitude should be NaN.
-    assert np.isnan(result["mag_cal"][-1])
+    # The distant star has no real match, so nothing derived from that match
+    # should come back with a value -- the catalog magnitude and color are of
+    # an unrelated star, and an error without a magnitude to go with it is
+    # worse than no error at all. See issue #678.
+    for column in _CATALOG_DERIVED_COLUMNS:
+        assert np.isnan(result[column][-1]), column
 
     # With the distant star excluded from the fit, the good stars are
     # an exact fit, so their calibrated magnitudes should match the
@@ -485,13 +495,22 @@ def test_transform_to_catalog_match_tolerance(mocker, offset, expect_nan):
     result = _run_transform_to_catalog(mocker, catalog, observed)
 
     # The offset star gets a calibrated magnitude only if its match is close
-    # enough. The fit is exact, so that magnitude is just the instrumental
-    # magnitude plus the zero point.
-    if expect_nan:
-        assert np.isnan(result["mag_cal"][-1])
-    else:
+    # enough -- and everything else derived from that match goes with it,
+    # rather than mag_cat and color_cat being kept for a match too distant to
+    # calibrate against. This is where that decision is pinned. See issue #678.
+    for column in _CATALOG_DERIVED_COLUMNS:
+        assert np.isnan(result[column][-1]) == expect_nan, column
+
+    if not expect_nan:
+        # The fit is exact, so the calibrated magnitude is just the
+        # instrumental magnitude plus the zero point, and the catalog values
+        # are those of the star it was matched to.
         assert result["mag_cal"][-1] == pytest.approx(
             offset_mag + _FAKE_CATALOG_ZERO_POINT, abs=1e-6
+        )
+        assert result["mag_cat"][-1] == pytest.approx(catalog["mag_R"][0], abs=1e-12)
+        assert result["color_cat"][-1] == pytest.approx(
+            catalog["mag_R"][0] - catalog["mag_I"][0], abs=1e-12
         )
 
     # Either way the offset star is more than an arcsec from its catalog
@@ -1208,6 +1227,99 @@ def test_transform_to_catalog_excludes_masked_catalog_entries(mocker):
     )
 
 
+def _catalog_without_color(n_stars, no_color, **kwargs):
+    """
+    Build a synthetic catalog in which some stars have no color.
+
+    Masking ``mag_I`` is how a real catalog says it has no measurement in that
+    band. The color `transform_to_catalog` works out is masked in turn, and
+    reaches the fit as NaN, so nothing in `_generate_fake_catalog` has to
+    change to produce a star with no color.
+
+    Parameters
+    ----------
+
+    n_stars : int
+        Number of stars to generate.
+
+    no_color : `numpy.ndarray`
+        Boolean mask, `True` for the stars that should have no color.
+
+    **kwargs
+        Passed on to `_generate_fake_catalog`.
+
+    Returns
+    -------
+    Whatever `_generate_fake_catalog` returns, with ``mag_I`` masked.
+    """
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, **kwargs)
+    catalog["mag_I"] = np.ma.masked_array(catalog["mag_I"], mask=no_color)
+
+    return catalog, ra, dec, instrumental
+
+
+def test_transform_to_catalog_fits_colorless_stars_when_no_color_term(mocker, caplog):
+    # A star with no catalog color has nothing missing as far as a fit with no
+    # color term in it is concerned, so demanding a color of it throws away
+    # data for no reason. See issue #681.
+    n_stars = 20
+
+    catalog, ra, dec, instrumental = _catalog_without_color(
+        n_stars, np.ones(n_stars, dtype=bool)
+    )
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
+        result = _run_transform_to_catalog(mocker, catalog, observed, vary=("a", "z"))
+
+    assert not any("No good data" in r.message for r in caplog.records)
+
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-6)
+    # The color is genuinely unknown, and the output column still says so.
+    assert np.isnan(result["color_cat"]).all()
+
+
+def test_transform_to_catalog_still_needs_color_when_fitting_a_color_term(
+    mocker, caplog
+):
+    # The other half of the relaxation above, which is what keeps it from being
+    # unconditional: a color term fit to stars with no color is not a fit.
+    n_stars = 20
+
+    catalog, ra, dec, instrumental = _catalog_without_color(
+        n_stars, np.ones(n_stars, dtype=bool)
+    )
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
+        result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert any("No good data" in r.message for r in caplog.records)
+    assert np.isnan(result["mag_cal"]).all()
+
+
+def test_transform_to_catalog_mixes_stars_with_and_without_color(mocker):
+    # The realistic case: a catalog with a color for some stars and not others.
+    # With no color term being fit, all of them belong in the fit, and the
+    # color column is what says which ones had a color to begin with.
+    n_stars = 20
+
+    no_color = np.zeros(n_stars, dtype=bool)
+    no_color[::2] = True
+
+    catalog, ra, dec, instrumental = _catalog_without_color(n_stars, no_color)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed, vary=("a", "z"))
+
+    # Every star is calibrated, color or no color...
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    # ...and the color column reports exactly the ones that had none.
+    assert np.isnan(result["color_cat"][no_color]).all()
+    assert np.isfinite(result["color_cat"][~no_color]).all()
+
+
 def _two_passband_observations(ra, dec, instrumental, i_offset=0.5):
     """
     Observations of one image containing two passbands.
@@ -1493,27 +1605,97 @@ def test_transform_to_catalog_warns_when_fixed_term_outside_expected(mocker, cap
     assert (result["z"] == 0.0).all()
 
 
+# Number of leading rows `_observations_with_unusable_rows` spoils.
+_N_UNUSABLE_ROWS = 2
+
+
+def _observations_with_unusable_rows(case, ra, dec, instrumental):
+    """
+    Observations whose first `_N_UNUSABLE_ROWS` rows cannot carry an error.
+
+    The rest of the rows are untouched, so the fit still has plenty to work
+    with and the spoiled rows are the only thing under test.
+
+    Parameters
+    ----------
+
+    case : str
+        What is wrong with those rows: ``"bad_error"`` for magnitude errors
+        that are not positive finite numbers, or ``"no_magnitude"`` for rows
+        with no instrumental magnitude at all.
+
+    ra, dec : `astropy.units.Quantity`
+        Position of each star.
+
+    instrumental : `numpy.ndarray`
+        Instrumental magnitude of each star.
+
+    Returns
+    -------
+    `astropy.table.Table`
+        Observations, grouped by file name.
+    """
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    match case:
+        case "bad_error":
+            # Zero and negative are the two ways an error can be meaningless.
+            observed["mag_error"][0] = 0.0
+            observed["mag_error"][1] = -0.02
+        case "no_magnitude":
+            observed["mag_inst"][:_N_UNUSABLE_ROWS] = np.nan
+        case _:  # pragma: no cover
+            raise ValueError(f"Unknown case {case!r}")
+
+    return observed
+
+
 def test_transform_to_catalog_nans_error_for_unusable_input_error(mocker):
     # An error that is zero or negative is meaningless, and the fit already
     # excludes those stars. The calibrated error must not be finite for them
     # either: the AAVSO writer only turns non-finite errors into "na", so a
     # zero would be written into a submission as a real uncertainty -- and an
     # error of zero is infinite weight in any downstream average.
-    n_bad = 2
-
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    observed = _generate_observed_table(ra, dec, instrumental)
-    observed["mag_error"][0] = 0.0
-    observed["mag_error"][1] = -0.02
+    observed = _observations_with_unusable_rows("bad_error", ra, dec, instrumental)
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
 
-    assert np.isnan(result["mag_cal_error"][:n_bad]).all()
-    np.testing.assert_allclose(result["mag_cal_error"][n_bad:], 0.01, rtol=0, atol=1e-8)
+    assert np.isnan(result["mag_cal_error"][:_N_UNUSABLE_ROWS]).all()
+    np.testing.assert_allclose(
+        result["mag_cal_error"][_N_UNUSABLE_ROWS:], 0.01, rtol=0, atol=1e-8
+    )
 
     # The stars are only left out of the *fit*. They still have perfectly good
     # instrumental magnitudes, so they still get calibrated magnitudes.
     np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+
+
+def test_transform_to_catalog_nans_error_where_there_is_no_magnitude(mocker):
+    # A calibrated error with no calibrated magnitude beside it is a trap:
+    # selecting rows on a finite mag_cal_error keeps them, and whatever reads
+    # mag_cal next gets NaN. A finite error must always mean there is a
+    # magnitude for it to be the error of, whatever the reason the magnitude
+    # is missing -- here an unmeasured star rather than a distant match. See
+    # issue #678.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _observations_with_unusable_rows("no_magnitude", ra, dec, instrumental)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert np.isnan(result["mag_cal"][:_N_UNUSABLE_ROWS]).all()
+    assert np.isnan(result["mag_cal_error"][:_N_UNUSABLE_ROWS]).all()
+
+    # The stars that were measured are unaffected.
+    np.testing.assert_allclose(
+        result["mag_cal"][_N_UNUSABLE_ROWS:],
+        np.asarray(catalog["mag_R"])[_N_UNUSABLE_ROWS:],
+        rtol=0,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        result["mag_cal_error"][_N_UNUSABLE_ROWS:], 0.01, rtol=0, atol=1e-8
+    )
 
 
 def test_transform_to_catalog_default_catalog_columns(mocker):


### PR DESCRIPTION
Closes #678. Closes #681.

Stacked on #682 — please merge that first; this branch contains its commit.

Two issues that rewrite the same twenty lines. Split, they conflict line for
line, and #681 itself says they are best fixed together.

### #678 — one cut for everything the match produces

`mag_cal` was NaN'd beyond 1.5 arcsec but `mag_cat`, `color_cat` and
`mag_cal_error` were not, so a star whose nearest catalog entry is a degree away
still came back with that unrelated star's catalog magnitude and colour, and
with a finite calibrated error attached to a NaN calibrated magnitude — which
makes `mag_cal_error` unsafe to select rows on.

Now a single `matched = d2d.arcsecond <= 1.5` decides all of them. The two bare
literals become `_FIT_MATCH_ARCSEC = 1.0` and `_CAL_MATCH_ARCSEC = 1.5`, with
the reason the band between them exists — V2480 Cyg's VSX position is ~1.3
arcsec from its APASS DR9 position — written down next to them rather than
buried in a comment further down.

`mag_cal_error` moves into the per-image loop, where the distances and
calibrated magnitudes it depends on actually live, and gains the invariant that
makes the complaint go away:

```python
# A star with no calibrated magnitude has no calibrated error either,
# whatever the reason it has no magnitude.
cal_error[~np.isfinite(cal_mag)] = np.nan
```

That is stronger than repeating the distance cut — it also covers a star with no
instrumental magnitude — and gives the rule worth relying on: **a finite
`mag_cal_error` always has a finite `mag_cal`.**

### #681 — do not demand a colour nobody asked for

A star with no catalog colour was dropped from the fit even when no colour term
was being fit, and its `mag_cal` came out NaN because `0.0 * np.nan` is NaN. So
a catalog with sparse colours could produce "No good data" for an image whose
fit never needed a colour at all.

A star is now required to have a colour only when `c` or `d` is in `vary`, and
the model is evaluated with a neutral zero standing in for missing colours
(`np.where`, not `np.nan_to_num`, which would turn an infinite colour into a
very large finite one). The raw colour is what still goes into `color_cat`, so a
star whose colour is genuinely unknown reports NaN.

### Behaviour change worth noting

Rows with a NaN `mag_inst` now get NaN `mag_cal_error` instead of a scaled
instrumental error. No test asserted the old value, but it is a real change and
is in `CHANGES.rst`.

---

*This PR description was written by Claude at @mwcraig's direction.*
