### PR TITLE
Report how well each image's transform fit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,16 @@ New Features
   to the variable-aperture defaults (multiples of the measured FWHM, not
   pixels), with a warning (see issue ``#654``). A file written by a
   newer stellarphot raises ``NewerFormatError``. [#656]
++ ``transform_to_catalog()`` now reports how good each image's fit was, in six
+  new columns repeated down every row of that image alongside the coefficients
+  themselves: ``a_error`` through ``z_error``, the uncertainty of each
+  coefficient, and ``fit_redchi``. A term that is not being fit is held at
+  exactly zero and its uncertainty is exactly zero; the uncertainties are NaN,
+  while the coefficients are still reported, for a fit that converged but left
+  no usable covariance behind. ``fit_redchi`` is a reduced chi-square only
+  when ``obs_error_column`` is given -- unweighted it is the mean squared
+  residual in mag squared -- and, because ``lmfit`` scales the covariance by
+  it, it and the ``*_error`` columns are not independent diagnostics. [#677]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,16 +18,12 @@ New Features
   to the variable-aperture defaults (multiples of the measured FWHM, not
   pixels), with a warning (see issue ``#654``). A file written by a
   newer stellarphot raises ``NewerFormatError``. [#656]
-+ ``transform_to_catalog()`` now reports how good each image's fit was, in six
-  new columns repeated down every row of that image alongside the coefficients
-  themselves: ``a_error`` through ``z_error``, the uncertainty of each
-  coefficient, and ``fit_redchi``. A term that is not being fit is held at
-  exactly zero and its uncertainty is exactly zero; the uncertainties are NaN,
-  while the coefficients are still reported, for a fit that converged but left
-  no usable covariance behind. ``fit_redchi`` is a reduced chi-square only
-  when ``obs_error_column`` is given -- unweighted it is the mean squared
-  residual in mag squared -- and, because ``lmfit`` scales the covariance by
-  it, it and the ``*_error`` columns are not independent diagnostics. [#677]
++ ``transform_to_catalog()`` now reports how well each image's transform
+  fit, in six new columns repeated down the image's rows like the
+  coefficients themselves: ``a_error`` through ``z_error``, the uncertainty
+  of each coefficient, and ``fit_redchi``, the summed squared residuals per
+  degree of freedom -- in units of the supplied errors, or in mag² when no
+  ``obs_error_column`` is given. [#677]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -214,59 +214,6 @@ def _underdetermined_reason(fit_result, vary):
     return None
 
 
-def _coefficient_uncertainties(fit_result):
-    """
-    Uncertainty of each coefficient of a fit, when the fit can supply them.
-
-    This is the single place the question "does this fit have a usable
-    covariance?" is answered, so that everything derived from the covariance
-    agrees about whether there is one to derive anything from.
-
-    Note that ``fit_result.errorbars`` is deliberately *not* what is checked.
-    `lmfit` clears that flag whenever any varied term comes out with a
-    standard error of exactly zero, and that is what a perfect fit gives:
-    data that follows the model to the last bit has a covariance that really
-    is zero, and zero is the right answer there rather than a missing one.
-    What makes the uncertainties unavailable is ``covar`` being absent
-    altogether, or having non-finite entries -- an inverse that came back with
-    NaN in it looks like a matrix and is not one, and anything that reads it
-    without checking reports a confident wrong number instead of failing.
-
-    Parameters
-    ----------
-
-    fit_result : `lmfit.minimizer.MinimizerResult`
-        Result of fitting one image.
-
-    Returns
-    -------
-    uncertainties : dict
-        Standard error of each term of the transform model, keyed by term
-        name. A term that was not varied was held at exactly zero and is
-        therefore known exactly, so its uncertainty is ``0.0``. Every value is
-        NaN if the covariance cannot be used.
-
-    covar : `numpy.ndarray` or None
-        The covariance matrix, or `None` if it cannot be used. Anything that
-        needs the correlations between the terms as well as their individual
-        uncertainties should take the matrix from here rather than asking the
-        fit result again, so that there is only ever one verdict.
-    """
-    covar = fit_result.covar
-
-    if covar is None or not np.all(np.isfinite(covar)):
-        return {name: np.nan for name in _COEFF_NAMES}, None
-
-    return {
-        name: (
-            np.nan
-            if fit_result.params[name].stderr is None
-            else float(fit_result.params[name].stderr)
-        )
-        for name in _COEFF_NAMES
-    }, covar
-
-
 def _check_known_terms(terms, argument_name):
     """
     Raise if any of ``terms`` is not a coefficient of the transform model.
@@ -579,18 +526,19 @@ def transform_to_catalog(
     for one image rather than any one star, so each of them is the same on
     every row of that image. A term that is not in ``vary`` is held at exactly
     zero and is therefore known exactly, so its uncertainty is exactly zero
-    rather than a small number. The uncertainties are NaN, while the
-    coefficients themselves are still reported, for an image whose fit
-    converged but left no usable covariance behind.
+    rather than a small number.
 
-    ``fit_redchi`` is a reduced chi-square only when ``obs_error_column`` is
-    given, because only then is anything dividing the residuals: it is the
-    mean squared residual in units of the errors that were supplied, and a
-    value near one says the model misses the stars by about as much as they
-    claim to be uncertain. Without an error column the fit is unweighted and
-    the same column holds the mean squared residual in **mag squared** -- the
-    same name and a completely different scale, so values from a weighted and
-    an unweighted fit must not be compared with each other.
+    ``fit_redchi`` is `lmfit`'s reduced chi-square: the summed squared
+    residuals per degree of freedom, i.e. divided by the number of stars fit
+    minus the number of terms varied. It is a chi-square only when
+    ``obs_error_column`` is given, because only then is anything dividing the
+    residuals: the residuals are in units of the errors that were supplied,
+    and a value near one says the model misses the stars by about as much as
+    they claim to be uncertain. Without an error column the fit is unweighted
+    and the same column holds the summed squared residuals per degree of
+    freedom in **mag squared** -- the same name and a completely different
+    scale, so values from a weighted and an unweighted fit must not be
+    compared with each other.
 
     The reported uncertainties are scaled by ``fit_redchi``, because `lmfit`'s
     ``scale_covar`` is left on. They therefore describe the scatter actually
@@ -829,15 +777,18 @@ def transform_to_catalog(
 
         values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
 
-        # How well the fit pinned each term down, and how well the model it
-        # landed on describes the stars. Both are answers about the image
-        # rather than about any one star, and both are reported even when
-        # they are the only thing that would tell a caller the coefficients
-        # below are not worth applying.
-        # The covariance matrix comes back too, but nothing here needs the
-        # correlations between the terms -- only the individual
-        # uncertainties, which are its diagonal.
-        uncertainties, _ = _coefficient_uncertainties(fit_result)
+        # How well the fit pinned each term down. lmfit's stderr is exactly
+        # 0.0 for a term that was not varied -- held at zero, so known
+        # exactly -- and None in the states where no uncertainty could be
+        # worked out at all.
+        uncertainties = {
+            name: (
+                np.nan
+                if fit_result.params[name].stderr is None
+                else float(fit_result.params[name].stderr)
+            )
+            for name in _COEFF_NAMES
+        }
 
         # The expected ranges are a check on the answer, not a constraint on
         # the fit, so a value outside its range is reported and kept.

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -35,6 +35,14 @@ _DEFAULT_EXPECTED = {"z": (18.0, 22.0)}
 _CAL_MAG_COLUMN = "mag_cal"
 _CAL_MAG_ERROR_COLUMN = "mag_cal_error"
 
+# Suffix of the column reporting the uncertainty of a fit coefficient, so that
+# ``a`` is reported alongside ``a_error``. Matches the mag/mag_error and
+# mag_cal/mag_cal_error pairs already in the table.
+_COEFF_ERROR_SUFFIX = "_error"
+
+# Name of the column reporting how well one image's transform fit its stars.
+_FIT_REDCHI_COLUMN = "fit_redchi"
+
 # How close an observed star must be to a catalog entry, in arcseconds. Two
 # limits rather than one: a star must match tightly to be allowed to influence
 # the fit, and less tightly to be given values derived from its match.
@@ -204,6 +212,59 @@ def _underdetermined_reason(fit_result, vary):
         )
 
     return None
+
+
+def _coefficient_uncertainties(fit_result):
+    """
+    Uncertainty of each coefficient of a fit, when the fit can supply them.
+
+    This is the single place the question "does this fit have a usable
+    covariance?" is answered, so that everything derived from the covariance
+    agrees about whether there is one to derive anything from.
+
+    Note that ``fit_result.errorbars`` is deliberately *not* what is checked.
+    `lmfit` clears that flag whenever any varied term comes out with a
+    standard error of exactly zero, and that is what a perfect fit gives:
+    data that follows the model to the last bit has a covariance that really
+    is zero, and zero is the right answer there rather than a missing one.
+    What makes the uncertainties unavailable is ``covar`` being absent
+    altogether, or having non-finite entries -- an inverse that came back with
+    NaN in it looks like a matrix and is not one, and anything that reads it
+    without checking reports a confident wrong number instead of failing.
+
+    Parameters
+    ----------
+
+    fit_result : `lmfit.minimizer.MinimizerResult`
+        Result of fitting one image.
+
+    Returns
+    -------
+    uncertainties : dict
+        Standard error of each term of the transform model, keyed by term
+        name. A term that was not varied was held at exactly zero and is
+        therefore known exactly, so its uncertainty is ``0.0``. Every value is
+        NaN if the covariance cannot be used.
+
+    covar : `numpy.ndarray` or None
+        The covariance matrix, or `None` if it cannot be used. Anything that
+        needs the correlations between the terms as well as their individual
+        uncertainties should take the matrix from here rather than asking the
+        fit result again, so that there is only ever one verdict.
+    """
+    covar = fit_result.covar
+
+    if covar is None or not np.all(np.isfinite(covar)):
+        return {name: np.nan for name in _COEFF_NAMES}, None
+
+    return {
+        name: (
+            np.nan
+            if fit_result.params[name].stderr is None
+            else float(fit_result.params[name].stderr)
+        )
+        for name in _COEFF_NAMES
+    }, covar
 
 
 def _check_known_terms(terms, argument_name):
@@ -497,11 +558,12 @@ def transform_to_catalog(
         Table containing the calibrated magnitudes and the fit parameters. The
         columns added are ``mag_cal`` and, if ``obs_error_column`` was given,
         ``mag_cal_error``; the fit coefficients ``a``, ``b``, ``c``, ``d`` and
-        ``z``; and ``mag_cat`` and ``color_cat``, the matched catalog
-        magnitude and color. ``mag_cal`` is NaN for rows with no usable
-        catalog match, as are all of the columns for rows in an image that
-        could not be fit and for rows in other passbands that had no value
-        already.
+        ``z``, with their uncertainties ``a_error`` through ``z_error`` and
+        the goodness of fit ``fit_redchi``; and ``mag_cat`` and ``color_cat``,
+        the matched catalog magnitude and color. ``mag_cal`` is NaN for rows
+        with no usable catalog match, as are all of the columns for rows in an
+        image that could not be fit and for rows in other passbands that had
+        no value already.
 
         Every column that comes from the catalog match -- ``mag_cal``,
         ``mag_cal_error``, ``mag_cat`` and ``color_cat`` -- is NaN for a star
@@ -513,11 +575,39 @@ def transform_to_catalog(
     Notes
     -----
 
+    The coefficients, their uncertainties and ``fit_redchi`` describe the fit
+    for one image rather than any one star, so each of them is the same on
+    every row of that image. A term that is not in ``vary`` is held at exactly
+    zero and is therefore known exactly, so its uncertainty is exactly zero
+    rather than a small number. The uncertainties are NaN, while the
+    coefficients themselves are still reported, for an image whose fit
+    converged but left no usable covariance behind.
+
+    ``fit_redchi`` is a reduced chi-square only when ``obs_error_column`` is
+    given, because only then is anything dividing the residuals: it is the
+    mean squared residual in units of the errors that were supplied, and a
+    value near one says the model misses the stars by about as much as they
+    claim to be uncertain. Without an error column the fit is unweighted and
+    the same column holds the mean squared residual in **mag squared** -- the
+    same name and a completely different scale, so values from a weighted and
+    an unweighted fit must not be compared with each other.
+
+    The reported uncertainties are scaled by ``fit_redchi``, because `lmfit`'s
+    ``scale_covar`` is left on. They therefore describe the scatter actually
+    observed about the fit rather than the instrumental errors that were
+    quoted, which is the more robust of the two: it stays right when the
+    quoted errors are systematically wrong. The price is that ``fit_redchi``
+    and the ``*_error`` columns are not independent diagnostics. An image
+    whose stars scatter twice as far from the model as they claim reports both
+    a ``fit_redchi`` near four and coefficient uncertainties twice as large,
+    and that is one observation rather than two agreeing ones.
+
     The values in ``mag_cal_error`` are the instrumental errors scaled by how
     much the calibrated magnitude moves when the instrumental one does, which
     is ``1 + a`` when ``fit_diff`` is ``True`` and ``a`` when it is ``False``.
     That is not a propagation of the uncertainty in the fit itself, and so
-    understates the true uncertainty.
+    understates the true uncertainty; the ``*_error`` columns are where that
+    uncertainty can be read off in the meantime.
     """
     if obs_error_column is None:
         warnings.warn(
@@ -574,6 +664,8 @@ def transform_to_catalog(
     # this passband, and is written by row index below. Rows that are never
     # written keep the NaN they start with.
     coefficients = {name: np.full(n_rows, np.nan) for name in _COEFF_NAMES}
+    coefficient_errors = {name: np.full(n_rows, np.nan) for name in _COEFF_NAMES}
+    fit_redchis = np.full(n_rows, np.nan)
     cal_mags = np.full(n_rows, np.nan)
     cal_errors = np.full(n_rows, np.nan)
     cat_mags = np.full(n_rows, np.nan)
@@ -737,6 +829,16 @@ def transform_to_catalog(
 
         values = {name: fit_result.params[name].value for name in _COEFF_NAMES}
 
+        # How well the fit pinned each term down, and how well the model it
+        # landed on describes the stars. Both are answers about the image
+        # rather than about any one star, and both are reported even when
+        # they are the only thing that would tell a caller the coefficients
+        # below are not worth applying.
+        # The covariance matrix comes back too, but nothing here needs the
+        # correlations between the terms -- only the individual
+        # uncertainties, which are its diagonal.
+        uncertainties, _ = _coefficient_uncertainties(fit_result)
+
         # The expected ranges are a check on the answer, not a constraint on
         # the fit, so a value outside its range is reported and kept.
         out_of_range = [
@@ -768,6 +870,9 @@ def transform_to_catalog(
 
         for name in _COEFF_NAMES:
             coefficients[name][rows] = values[name]
+            coefficient_errors[name][rows] = uncertainties[name]
+
+        fit_redchis[rows] = fit_result.redchi
 
         cal_mags[rows] = cal_mag
         cat_mags[rows] = np.where(matched, cat_mag, np.nan)
@@ -812,6 +917,16 @@ def transform_to_catalog(
     output_columns.update(coefficients)
     output_columns["mag_cat"] = cat_mags
     output_columns["color_cat"] = cat_colors
+
+    # The fit's own account of how it did. Last, because the columns above
+    # are what a caller reaches for first and their order predates these.
+    output_columns.update(
+        {
+            name + _COEFF_ERROR_SUFFIX: errors_for_name
+            for name, errors_for_name in coefficient_errors.items()
+        }
+    )
+    output_columns[_FIT_REDCHI_COLUMN] = fit_redchis
 
     _write_output_columns(result, output_columns, in_passband)
 

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -261,7 +261,14 @@ def _generate_fake_catalog(
 
 
 def _generate_observed_table(
-    ra, dec, instrumental, file_name="image_1.fit", passband="R", mag_error=0.01
+    ra,
+    dec,
+    instrumental,
+    file_name="image_1.fit",
+    passband="R",
+    mag_error=None,
+    noise_sigma=0.0,
+    seed=None,
 ):
     """
     Generate observations in the form ``transform_to_catalog`` expects.
@@ -286,8 +293,24 @@ def _generate_observed_table(
         Passband to label every observation with.
 
     mag_error : float or array-like, optional
-        Uncertainty of each instrumental magnitude. A single value is used for
-        every star.
+        Uncertainty to report for each instrumental magnitude. Defaults to
+        ``noise_sigma`` when noise is being added, which is the truthful
+        value -- passing anything else alongside ``noise_sigma`` is how a
+        test says the reported errors are wrong -- and to 0.01 otherwise.
+
+    noise_sigma : float, optional
+        Standard deviation of Gaussian noise added to the instrumental
+        magnitudes. The default of zero adds none, so the observations fit a
+        catalog from `_generate_fake_catalog` essentially exactly. That is
+        what lets the recovery tests demand 1e-6 of the coefficients, but it
+        also means the fit's own view of how well it did -- the coefficient
+        uncertainties and the reduced chi-square -- comes out at the 1e-13
+        level and says nothing. Any test that asks what those numbers *mean*
+        needs data that scatters about the model by a realistic, known
+        amount instead.
+
+    seed : int, optional
+        Seed for the noise, so that a test gets the same numbers every run.
 
     Returns
     -------
@@ -296,6 +319,15 @@ def _generate_observed_table(
         ``file``, ``passband``, ``ra``, ``dec``, ``mag_inst`` and
         ``mag_error`` columns `transform_to_catalog` requires.
     """
+    if mag_error is None:
+        mag_error = noise_sigma if noise_sigma else 0.01
+
+    instrumental = np.asarray(instrumental, dtype=float)
+    if noise_sigma:
+        instrumental = instrumental + np.random.default_rng(seed).normal(
+            0.0, noise_sigma, size=instrumental.shape
+        )
+
     n_stars = len(instrumental)
 
     observed = Table(
@@ -304,7 +336,7 @@ def _generate_observed_table(
             "passband": [passband] * n_stars,
             "ra": ra.to_value("degree"),
             "dec": dec.to_value("degree"),
-            "mag_inst": np.asarray(instrumental, dtype=float),
+            "mag_inst": instrumental,
             "mag_error": np.broadcast_to(
                 np.asarray(mag_error, dtype=float), (n_stars,)
             ).copy(),
@@ -312,59 +344,6 @@ def _generate_observed_table(
     )
 
     return observed.group_by("file")
-
-
-def _noisy_observations(ra, dec, instrumental, sigma, seed, mag_error=None, **kwargs):
-    """
-    Generate observations that miss the catalog by a known amount.
-
-    A catalog from `_generate_fake_catalog` follows the transform model to
-    within `_FAKE_CATALOG_SCATTER`, so observations of it taken straight from
-    the magnitudes it was built from fit essentially exactly. That is what
-    makes the recovery tests above able to demand 1e-6, but it also means the
-    fit's own view of how well it did -- the coefficient uncertainties and the
-    reduced chi-square -- comes out at the 1e-13 level and says nothing. Any
-    test that asks what those numbers *mean* needs data that scatters about
-    the model by a realistic, known amount instead.
-
-    Parameters
-    ----------
-
-    ra, dec : `astropy.units.Quantity`
-        Position of each star.
-
-    instrumental : `numpy.ndarray`
-        Noiseless instrumental magnitude of each star, i.e. the magnitudes the
-        catalog was generated from.
-
-    sigma : float
-        Standard deviation of the Gaussian noise added to those magnitudes.
-
-    seed : int
-        Seed for the noise, so that a test gets the same numbers every run.
-
-    mag_error : float or array-like, optional
-        Uncertainty to report for each magnitude. Defaults to ``sigma``, which
-        is the truthful value; passing anything else is how a test says the
-        reported errors are wrong.
-
-    **kwargs
-        Passed on to `_generate_observed_table`.
-
-    Returns
-    -------
-    `astropy.table.Table`
-        Observations of a single image, grouped by file name.
-    """
-    noise = np.random.default_rng(seed).normal(0.0, sigma, size=np.shape(instrumental))
-
-    return _generate_observed_table(
-        ra,
-        dec,
-        np.asarray(instrumental, dtype=float) + noise,
-        mag_error=sigma if mag_error is None else mag_error,
-        **kwargs,
-    )
 
 
 def _combine_observed_tables(*tables):
@@ -748,8 +727,8 @@ def test_transform_to_catalog_weights_by_inverse_error(mocker):
     # The noise is an order of magnitude below the tolerances asserted here, so
     # it changes nothing about what this test is asking; it is added only
     # because a residual of exactly zero is a state real data never reaches.
-    observed = _noisy_observations(
-        ra, dec, observed_mags, sigma, seed=8811, mag_error=errors
+    observed = _generate_observed_table(
+        ra, dec, observed_mags, noise_sigma=sigma, seed=8811, mag_error=errors
     )
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
@@ -768,7 +747,9 @@ def test_transform_to_catalog_reports_coefficient_uncertainties(mocker):
     sigma = 0.02
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, a=0.02, c=0.15)
-    observed = _noisy_observations(ra, dec, instrumental, sigma, seed=20260811)
+    observed = _generate_observed_table(
+        ra, dec, instrumental, noise_sigma=sigma, seed=20260811
+    )
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
 
@@ -814,7 +795,9 @@ def test_transform_to_catalog_uncertainty_falls_as_stars_are_added(mocker):
             _run_transform_to_catalog(
                 mocker,
                 catalog,
-                _noisy_observations(ra, dec, instrumental, sigma, seed=seed),
+                _generate_observed_table(
+                    ra, dec, instrumental, noise_sigma=sigma, seed=seed
+                ),
             )["z_error"][0]
             for seed in seeds
         ]
@@ -849,8 +832,13 @@ def test_transform_to_catalog_reports_reduced_chi_square(
     sigma = 0.02
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
-    observed = _noisy_observations(
-        ra, dec, instrumental, sigma, seed=13579, mag_error=error_scale * sigma
+    observed = _generate_observed_table(
+        ra,
+        dec,
+        instrumental,
+        noise_sigma=sigma,
+        seed=13579,
+        mag_error=error_scale * sigma,
     )
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
@@ -861,75 +849,28 @@ def test_transform_to_catalog_reports_reduced_chi_square(
     assert reported[0] == pytest.approx(expected_redchi, rel=0.3)
 
 
-def _break_the_covariance(mocker, how):
-    """
-    Make the fit come back with a covariance matrix that cannot be used.
-
-    Neither state is reachable from data. ``lmfit.minimize`` only leaves
-    ``covar`` unset when inverting the design matrix raises, which the
-    degeneracy check upstream of it rejects first, so this has to be arranged
-    rather than provoked -- otherwise the code that handles it is never run at
-    all. The real fit is still performed, so everything except the covariance
-    is exactly what the data gives.
-
-    Parameters
-    ----------
-
-    mocker : `pytest_mock.MockerFixture`
-        Fixture used to patch the fitter.
-
-    how : str
-        ``"missing"`` for no covariance at all, or ``"not_finite"`` for one
-        full of NaN.
-    """
-    real_minimize = magnitude_transforms.lmfit.minimize
-
-    def minimize_then_spoil_covariance(*args, **kwargs):
-        fit_result = real_minimize(*args, **kwargs)
-        match how:
-            case "missing":
-                fit_result.covar = None
-            case "not_finite":
-                fit_result.covar = np.full_like(fit_result.covar, np.nan)
-            case _:  # pragma: no cover
-                raise ValueError(f"Unknown case {how!r}")
-        return fit_result
-
-    mocker.patch.object(
-        magnitude_transforms.lmfit,
-        "minimize",
-        side_effect=minimize_then_spoil_covariance,
-    )
-
-
-@pytest.mark.parametrize("how", ["missing", "not_finite"])
-def test_transform_to_catalog_nans_uncertainties_without_a_covariance(mocker, how):
-    # A fit can converge and still leave nothing to work the uncertainties out
-    # from. The coefficients are real and are reported; the uncertainties are
-    # not available and say so, rather than being filled in from the diagonal
-    # of a matrix that is missing or full of NaN. A non-finite covariance has
-    # to be caught here as firmly as a missing one -- it is the shape that
-    # would otherwise be turned into a confident wrong answer downstream. See
-    # issue #677.
-    n_stars = 50
+def test_transform_to_catalog_reports_unweighted_fit_statistic(mocker):
+    # Without an error column nothing divides the residuals, so the same
+    # column holds the summed squared residuals per degree of freedom in mag
+    # squared -- for Gaussian noise, the noise variance. The weighted values
+    # above sit near one; this sits near 4e-4, which is the documented "same
+    # column, completely different scale" behavior.
+    n_stars = 100
     sigma = 0.02
 
-    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, a=0.02, c=0.15)
-    observed = _noisy_observations(ra, dec, instrumental, sigma, seed=246810)
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
+    observed = _generate_observed_table(
+        ra, dec, instrumental, noise_sigma=sigma, seed=13579
+    )
 
-    _break_the_covariance(mocker, how)
+    with pytest.warns(AstropyUserWarning, match="rror weighting"):
+        result = _run_transform_to_catalog(
+            mocker, catalog, observed, obs_error_column=None
+        )
 
-    result = _run_transform_to_catalog(mocker, catalog, observed)
-
-    for term in ("a", "b", "c", "d", "z"):
-        assert np.isnan(result[f"{term}_error"]).all(), term
-        # The fit itself succeeded, so its answers are all still there.
-        assert np.isfinite(result[term]).all(), term
-
-    assert np.isfinite(result["mag_cal"]).all()
-    # The reduced chi-square is worked out from the residuals, not from the
-    # covariance, so it survives.
-    assert np.isfinite(result["fit_redchi"]).all()
+    reported = np.asarray(result["fit_redchi"])
+    assert (reported == reported[0]).all()
+    assert reported[0] == pytest.approx(sigma**2, rel=0.3)
 
 
 def test_transform_to_catalog_fits_each_image_separately(mocker):

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -314,6 +314,59 @@ def _generate_observed_table(
     return observed.group_by("file")
 
 
+def _noisy_observations(ra, dec, instrumental, sigma, seed, mag_error=None, **kwargs):
+    """
+    Generate observations that miss the catalog by a known amount.
+
+    A catalog from `_generate_fake_catalog` follows the transform model to
+    within `_FAKE_CATALOG_SCATTER`, so observations of it taken straight from
+    the magnitudes it was built from fit essentially exactly. That is what
+    makes the recovery tests above able to demand 1e-6, but it also means the
+    fit's own view of how well it did -- the coefficient uncertainties and the
+    reduced chi-square -- comes out at the 1e-13 level and says nothing. Any
+    test that asks what those numbers *mean* needs data that scatters about
+    the model by a realistic, known amount instead.
+
+    Parameters
+    ----------
+
+    ra, dec : `astropy.units.Quantity`
+        Position of each star.
+
+    instrumental : `numpy.ndarray`
+        Noiseless instrumental magnitude of each star, i.e. the magnitudes the
+        catalog was generated from.
+
+    sigma : float
+        Standard deviation of the Gaussian noise added to those magnitudes.
+
+    seed : int
+        Seed for the noise, so that a test gets the same numbers every run.
+
+    mag_error : float or array-like, optional
+        Uncertainty to report for each magnitude. Defaults to ``sigma``, which
+        is the truthful value; passing anything else is how a test says the
+        reported errors are wrong.
+
+    **kwargs
+        Passed on to `_generate_observed_table`.
+
+    Returns
+    -------
+    `astropy.table.Table`
+        Observations of a single image, grouped by file name.
+    """
+    noise = np.random.default_rng(seed).normal(0.0, sigma, size=np.shape(instrumental))
+
+    return _generate_observed_table(
+        ra,
+        dec,
+        np.asarray(instrumental, dtype=float) + noise,
+        mag_error=sigma if mag_error is None else mag_error,
+        **kwargs,
+    )
+
+
 def _combine_observed_tables(*tables):
     """
     Stack several per-image observation tables and regroup them by file.
@@ -527,15 +580,30 @@ def test_transform_to_catalog_match_tolerance(mocker, offset, expect_nan):
     )
 
 
-# The columns transform_to_catalog adds to the table it is given.
-_TRANSFORM_OUTPUT_COLUMNS = {
-    "mag_cal",
-    "mag_cal_error",
+# Everything that describes the fit for one image rather than one star: the
+# coefficients, how well each of them was pinned down, and how well the model
+# came out fitting the data. All of them are repeated down every row of the
+# image, and all of them are NaN for an image that could not be fit, so the
+# tests for an unfittable image loop over the lot.
+_FIT_COLUMNS = (
     "a",
     "b",
     "c",
     "d",
     "z",
+    "a_error",
+    "b_error",
+    "c_error",
+    "d_error",
+    "z_error",
+    "fit_redchi",
+)
+
+# The columns transform_to_catalog adds to the table it is given.
+_TRANSFORM_OUTPUT_COLUMNS = {
+    "mag_cal",
+    "mag_cal_error",
+    *_FIT_COLUMNS,
     "mag_cat",
     "color_cat",
 }
@@ -665,6 +733,7 @@ def test_transform_to_catalog_weights_by_inverse_error(mocker):
     # and says so with a large error: weighted correctly it is ignored,
     # weighted backwards it takes over (z comes out near 18.5, not 20).
     n_stars = 20
+    sigma = 1e-4
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
 
@@ -676,13 +745,191 @@ def test_transform_to_catalog_weights_by_inverse_error(mocker):
     errors = np.full(n_stars, 0.001)
     errors[0] = 10.0
 
-    observed = _generate_observed_table(ra, dec, observed_mags, mag_error=errors)
+    # The noise is an order of magnitude below the tolerances asserted here, so
+    # it changes nothing about what this test is asking; it is added only
+    # because a residual of exactly zero is a state real data never reaches.
+    observed = _noisy_observations(
+        ra, dec, observed_mags, sigma, seed=8811, mag_error=errors
+    )
 
     result = _run_transform_to_catalog(mocker, catalog, observed)
 
     np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-3)
     np.testing.assert_allclose(result["a"], 0.0, rtol=0, atol=1e-3)
     np.testing.assert_allclose(result["c"], 0.0, rtol=0, atol=1e-3)
+
+
+def test_transform_to_catalog_reports_coefficient_uncertainties(mocker):
+    # How well the fit pinned each term down is what separates a transform
+    # worth applying from one fit to stars that could barely tell its terms
+    # apart, and until now the fit worked it out and threw it away. See issue
+    # #677.
+    n_stars = 50
+    sigma = 0.02
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, a=0.02, c=0.15)
+    observed = _noisy_observations(ra, dec, instrumental, sigma, seed=20260811)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    for term in ("a", "c", "z"):
+        reported = np.asarray(result[f"{term}_error"])
+        assert np.isfinite(reported).all(), term
+        assert (reported > 0).all(), term
+        # One fit per image, so every row of the image carries the same value.
+        assert (reported == reported[0]).all(), term
+
+    # A term that is not fit is held at exactly zero and is therefore known
+    # exactly. Its uncertainty is exactly zero -- not NaN, and not a small
+    # number, which is the same exact comparison
+    # test_transform_to_catalog_fixes_unvaried_terms makes of the value.
+    assert (np.asarray(result["b_error"]) == 0.0).all()
+    assert (np.asarray(result["d_error"]) == 0.0).all()
+
+    # The numbers are the right size, not merely positive: each term really is
+    # within a few of its reported uncertainties of the value the catalog was
+    # built from.
+    for term, truth in (("a", 0.02), ("c", 0.15), ("z", _FAKE_CATALOG_ZERO_POINT)):
+        assert abs(result[term][0] - truth) < 3 * result[f"{term}_error"][0], term
+
+
+def test_transform_to_catalog_uncertainty_falls_as_stars_are_added(mocker):
+    # The test that makes the numbers above uncertainties rather than arbitrary
+    # ones: ten times as many stars, each measured just as well, pin the zero
+    # point down about sqrt(10) times better. Nothing that was not a real
+    # uncertainty would scale that way. See issue #677.
+    sigma = 0.02
+
+    # lmfit scales the covariance by the reduced chi-square, so a single fit's
+    # reported uncertainty carries the scatter of its own noise realization --
+    # about 15% at 25 stars, which is most of the effect being measured.
+    # Averaging a handful of realizations makes this a statement about the
+    # design rather than about one draw.
+    seeds = (54321, 1, 2, 3, 7)
+    z_error = {}
+
+    for n_stars in (25, 250):
+        catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
+        reported = [
+            _run_transform_to_catalog(
+                mocker,
+                catalog,
+                _noisy_observations(ra, dec, instrumental, sigma, seed=seed),
+            )["z_error"][0]
+            for seed in seeds
+        ]
+        z_error[n_stars] = np.mean(reported)
+
+    # Roughly sqrt(10), not exactly: the 25-star fit is not an exactly scaled
+    # copy of the 250-star one, since its stars sample the same magnitude and
+    # color ranges more coarsely. The measured ratio is about 3.4 against a
+    # sqrt(10) of 3.16 -- what matters is that it is nowhere near 1, which is
+    # what a number that only looked like an uncertainty would give.
+    assert z_error[25] / z_error[250] == pytest.approx(np.sqrt(10), rel=0.2)
+
+
+@pytest.mark.parametrize(
+    "error_scale, expected_redchi",
+    [
+        # Errors that describe the data: the model is as far from the stars as
+        # they claim to be uncertain, which is what a reduced chi-square of one
+        # means.
+        (1.0, 1.0),
+        # Errors ten times too small. Chi-square goes as the square of that, so
+        # a hundred -- and that factor of a hundred is the whole reason to
+        # report the number.
+        (0.1, 100.0),
+    ],
+)
+def test_transform_to_catalog_reports_reduced_chi_square(
+    mocker, error_scale, expected_redchi
+):
+    # See issue #677.
+    n_stars = 100
+    sigma = 0.02
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
+    observed = _noisy_observations(
+        ra, dec, instrumental, sigma, seed=13579, mag_error=error_scale * sigma
+    )
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    reported = np.asarray(result["fit_redchi"])
+    # One fit per image, so this too is repeated down every row.
+    assert (reported == reported[0]).all()
+    assert reported[0] == pytest.approx(expected_redchi, rel=0.3)
+
+
+def _break_the_covariance(mocker, how):
+    """
+    Make the fit come back with a covariance matrix that cannot be used.
+
+    Neither state is reachable from data. ``lmfit.minimize`` only leaves
+    ``covar`` unset when inverting the design matrix raises, which the
+    degeneracy check upstream of it rejects first, so this has to be arranged
+    rather than provoked -- otherwise the code that handles it is never run at
+    all. The real fit is still performed, so everything except the covariance
+    is exactly what the data gives.
+
+    Parameters
+    ----------
+
+    mocker : `pytest_mock.MockerFixture`
+        Fixture used to patch the fitter.
+
+    how : str
+        ``"missing"`` for no covariance at all, or ``"not_finite"`` for one
+        full of NaN.
+    """
+    real_minimize = magnitude_transforms.lmfit.minimize
+
+    def minimize_then_spoil_covariance(*args, **kwargs):
+        fit_result = real_minimize(*args, **kwargs)
+        match how:
+            case "missing":
+                fit_result.covar = None
+            case "not_finite":
+                fit_result.covar = np.full_like(fit_result.covar, np.nan)
+            case _:  # pragma: no cover
+                raise ValueError(f"Unknown case {how!r}")
+        return fit_result
+
+    mocker.patch.object(
+        magnitude_transforms.lmfit,
+        "minimize",
+        side_effect=minimize_then_spoil_covariance,
+    )
+
+
+@pytest.mark.parametrize("how", ["missing", "not_finite"])
+def test_transform_to_catalog_nans_uncertainties_without_a_covariance(mocker, how):
+    # A fit can converge and still leave nothing to work the uncertainties out
+    # from. The coefficients are real and are reported; the uncertainties are
+    # not available and say so, rather than being filled in from the diagonal
+    # of a matrix that is missing or full of NaN. A non-finite covariance has
+    # to be caught here as firmly as a missing one -- it is the shape that
+    # would otherwise be turned into a confident wrong answer downstream. See
+    # issue #677.
+    n_stars = 50
+    sigma = 0.02
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, a=0.02, c=0.15)
+    observed = _noisy_observations(ra, dec, instrumental, sigma, seed=246810)
+
+    _break_the_covariance(mocker, how)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    for term in ("a", "b", "c", "d", "z"):
+        assert np.isnan(result[f"{term}_error"]).all(), term
+        # The fit itself succeeded, so its answers are all still there.
+        assert np.isfinite(result[term]).all(), term
+
+    assert np.isfinite(result["mag_cal"]).all()
+    # The reduced chi-square is worked out from the residuals, not from the
+    # covariance, so it survives.
+    assert np.isfinite(result["fit_redchi"]).all()
 
 
 def test_transform_to_catalog_fits_each_image_separately(mocker):
@@ -1092,8 +1339,8 @@ def test_transform_to_catalog_no_good_data_warns_and_nans(mocker, case, caplog):
     assert any("image_1.fit" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
-    for term in ("a", "b", "c", "d", "z"):
-        assert np.isnan(result[term]).all()
+    for column in _FIT_COLUMNS:
+        assert np.isnan(result[column]).all(), column
 
 
 def _one_good_one_bad_image(catalog, ra, dec, instrumental):
@@ -1489,8 +1736,8 @@ def test_transform_to_catalog_warns_when_too_few_stars_to_fit(mocker, caplog):
     assert any("underdetermined" in r.message for r in caplog.records)
 
     assert np.isnan(result["mag_cal"]).all()
-    for term in ("a", "b", "c", "d", "z"):
-        assert np.isnan(result[term]).all()
+    for column in _FIT_COLUMNS:
+        assert np.isnan(result[column]).all(), column
 
 
 def test_transform_to_catalog_warns_when_terms_are_degenerate(mocker, caplog):

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -294,20 +294,14 @@ def _generate_observed_table(
 
     mag_error : float or array-like, optional
         Uncertainty to report for each instrumental magnitude. Defaults to
-        ``noise_sigma`` when noise is being added, which is the truthful
-        value -- passing anything else alongside ``noise_sigma`` is how a
-        test says the reported errors are wrong -- and to 0.01 otherwise.
+        ``noise_sigma`` when noise is added -- the truthful value -- and to
+        0.01 otherwise.
 
     noise_sigma : float, optional
         Standard deviation of Gaussian noise added to the instrumental
-        magnitudes. The default of zero adds none, so the observations fit a
-        catalog from `_generate_fake_catalog` essentially exactly. That is
-        what lets the recovery tests demand 1e-6 of the coefficients, but it
-        also means the fit's own view of how well it did -- the coefficient
-        uncertainties and the reduced chi-square -- comes out at the 1e-13
-        level and says nothing. Any test that asks what those numbers *mean*
-        needs data that scatters about the model by a realistic, known
-        amount instead.
+        magnitudes. Tests of coefficient recovery leave this at zero; tests
+        of the fit diagnostics need data that misses the model by a known,
+        realistic amount.
 
     seed : int, optional
         Seed for the noise, so that a test gets the same numbers every run.


### PR DESCRIPTION
Closes #677.

`transform_to_catalog` reported the transform coefficients but nothing about how
well they were determined, so there was no way to tell a tight fit from a
hopeless one except by eye. Six new columns, repeated down every row like
`a`…`z` already are: **`a_error`, `b_error`, `c_error`, `d_error`, `z_error`,
`fit_redchi`**. No change to the return contract.

The uncertainties are lmfit's own, read straight off the fit result: a term not
in `vary` is held at exactly zero so its uncertainty is exactly `0.0`, and an
image that was never fit stays NaN. `fit_redchi` is the summed squared
residuals per degree of freedom (stars fit minus terms varied).

### Two things the docstring has to say

**`fit_redchi` means two different things.** It is a reduced chi-square only
when `obs_error_column` is given. Unweighted, the weights are the scalar 1.0
and the same column holds the residual scatter in **mag²** — same name,
completely different scale.

**`scale_covar` is on**, so every `*_error` is scaled by `redchi`. The reported
coefficient uncertainties therefore reflect the *observed* scatter rather than
the quoted instrumental errors — robust when the quoted errors are wrong, but
it means `a_error` and `fit_redchi` are not independent diagnostics. Whether to
keep that convention is #690.

### The numbers are real uncertainties, and the tests say so

- **`z_error` falls by ~√10 from 25 to 250 stars**: measured 0.02311 → 0.006706,
  ratio **3.45** against √10 = 3.162, averaged over 5 noise seeds — at 25 stars
  a single seed's `√redchi` fluctuates ~15%, so a single-seed assertion would
  have been a statement about one draw.
- **`fit_redchi` = 1.008** when `mag_error` matches the injected 0.02 mag noise,
  **100.83** when `mag_error` is 10× too small, and **≈ (0.02 mag)² in mag²**
  when no error column is given at all.

### Changed in review round 1

The first version gated the uncertainties on the covariance being present and
finite, and tested that gate with mocked fit results. Review pointed out,
correctly, that neither state is reachable past the guards upstream, so the
gate, the helper that held it, and both mocked tests are gone; the
covariance-usability verdict returns with the #674 follow-up, where the matrix
is actually consumed. Also from review: the changelog entry was cut to size,
the redchi wording fixed (lmfit divides by `nfree`, not `N`), and the noisy
test helper folded into `_generate_observed_table`.

---

*This PR description was written by Claude at @mwcraig's direction.*
