### PR TITLE
Calibrate against the observed band, weighted by both errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,24 +169,12 @@ Bug Fixes
   somewhat larger. When a fit leaves no usable covariance it is NaN, with
   a warning. Catalog magnitude uncertainty is still excluded -- see the
   docstring for why. [#674]
-+ ``transform_to_catalog()`` now raises when ``cat_filter`` names a different
-  band from ``obs_filter``. Calibrating observations in one band against
-  catalog magnitudes in another makes the color difference between the two
-  bands part of the fit, which then reports it as a transform coefficient and
-  applies it to every star, so a mismatched pair is always a mistake -- two
-  spellings of one band, such as ``"R"`` and ``"RC"``, are not one. Along with
-  that, ``cat_filter`` and ``cat_color`` now default to `None` and are
-  resolved to ``obs_filter`` and the color conventionally used with it,
-  instead of to the literals ``"R"`` and ``("R", "I")``, which would have made
-  every call that omitted them for another band an error. The fit is also now
-  weighted by the observed errors and the catalog's own errors combined in
-  quadrature wherever the catalog has a ``mag_error_<cat_filter>`` column, and
-  a star whose catalog error is missing or not positive is left out of the
-  fit, as one with an unusable observed error already was. Where the column is
-  absent -- which is the case for the Johnson-Cousins R and I, transformed
-  from a catalog's native bands by a transform that does not yet propagate
-  errors -- the fit is weighted by the observed errors alone, exactly as
-  before, and logs one message naming the band. See issue ``#685``. [#680]
++ ``transform_to_catalog()`` now warns loudly when ``cat_filter`` explicitly
+  names a band different from ``obs_filter`` instead of silently folding the
+  color difference into the fit. Passband spellings are canonicalized
+  (``"Rc"`` and ``"R"`` are one band), ``cat_filter``/``cat_color`` default
+  from ``obs_filter``, and the fit is weighted by observed and catalog errors
+  in quadrature where available, with the weighting recorded in ``.meta``. [#680]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,6 +169,24 @@ Bug Fixes
   somewhat larger. When a fit leaves no usable covariance it is NaN, with
   a warning. Catalog magnitude uncertainty is still excluded -- see the
   docstring for why. [#674]
++ ``transform_to_catalog()`` now raises when ``cat_filter`` names a different
+  band from ``obs_filter``. Calibrating observations in one band against
+  catalog magnitudes in another makes the color difference between the two
+  bands part of the fit, which then reports it as a transform coefficient and
+  applies it to every star, so a mismatched pair is always a mistake -- two
+  spellings of one band, such as ``"R"`` and ``"RC"``, are not one. Along with
+  that, ``cat_filter`` and ``cat_color`` now default to `None` and are
+  resolved to ``obs_filter`` and the color conventionally used with it,
+  instead of to the literals ``"R"`` and ``("R", "I")``, which would have made
+  every call that omitted them for another band an error. The fit is also now
+  weighted by the observed errors and the catalog's own errors combined in
+  quadrature wherever the catalog has a ``mag_error_<cat_filter>`` column, and
+  a star whose catalog error is missing or not positive is left out of the
+  fit, as one with an unusable observed error already was. Where the column is
+  absent -- which is the case for the Johnson-Cousins R and I, transformed
+  from a catalog's native bands by a transform that does not yet propagate
+  errors -- the fit is weighted by the observed errors alone, exactly as
+  before, and logs one message naming the band. See issue ``#685``. [#680]
 
 2.1.2 (2026-07-19)
 -------------------

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -58,6 +58,36 @@ _FIT_REDCHI_COLUMN = "fit_redchi"
 _FIT_MATCH_ARCSEC = 1.0
 _CAL_MATCH_ARCSEC = 1.5
 
+# Passband names that mean the same physical band. Cousins R and I are each
+# written several ways, and `transform_refcat2_bands` really does add ``mag_R``
+# and ``mag_RC`` as copies of one column, so matching R observations against a
+# catalog's RC is one band spelled two ways rather than the mistake the check
+# that uses this exists to catch.
+_SAME_BAND = (frozenset({"R", "RC", "Rc"}), frozenset({"I", "IC", "Ic"}))
+
+# The color conventionally used with each passband, for a caller who names a
+# band but no color. Which color goes with a band is a convention rather than
+# something derivable, so a band that is not here has to be asked about rather
+# than guessed at. Every spelling of Cousins R and I is a key of its own,
+# because the band is looked up as the caller wrote it and is never rewritten
+# into one preferred spelling.
+_CONVENTIONAL_COLOR = {
+    "U": ("U", "B"),
+    "B": ("B", "V"),
+    "V": ("B", "V"),
+    "R": ("R", "I"),
+    "RC": ("R", "I"),
+    "Rc": ("R", "I"),
+    "I": ("R", "I"),
+    "IC": ("R", "I"),
+    "Ic": ("R", "I"),
+    "SU": ("SU", "SG"),
+    "SG": ("SG", "SR"),
+    "SR": ("SR", "SI"),
+    "SI": ("SR", "SI"),
+    "SZ": ("SI", "SZ"),
+}
+
 # How strongly the terms of the fit may be correlated with each other before
 # their individual values stop meaning anything. See `_underdetermined_reason`,
 # which explains how this was arrived at.
@@ -393,6 +423,28 @@ def _calibrated_with_uncertainty(fit_result, covar, mag_inst, color, errors, fit
         return unumpy.nominal_values(calibrated), unumpy.std_devs(calibrated)
 
 
+def _is_same_band(one_filter, another_filter):
+    """
+    Whether two passband names name the same physical band.
+
+    Parameters
+    ----------
+
+    one_filter, another_filter : str
+        Passband names to compare.
+
+    Returns
+    -------
+    bool
+        `True` if the two names are the same, or are two spellings of one
+        band; see `_SAME_BAND`.
+    """
+    if one_filter == another_filter:
+        return True
+
+    return any(one_filter in band and another_filter in band for band in _SAME_BAND)
+
+
 def _check_known_terms(terms, argument_name):
     """
     Raise if any of ``terms`` is not a coefficient of the transform model.
@@ -593,8 +645,8 @@ def transform_to_catalog(
     obs_mag_col="mag_inst",
     obs_error_column=None,
     cat_name="apass_dr9",
-    cat_filter="R",
-    cat_color=("R", "I"),
+    cat_filter=None,
+    cat_color=None,
     vary=_DEFAULT_VARY,
     expected=None,
     in_place=True,
@@ -629,9 +681,10 @@ def transform_to_catalog(
 
     obs_error_column : str, optional
         Name of the column in ``observed_mags_grouped`` that contains the error in
-        the magnitude. The fit is weighted by these errors, so leaving this
-        out is rarely what you want and warns. Stars whose error is not a
-        positive, finite number are left out of the fit.
+        the magnitude. The fit is weighted by these errors, combined with the
+        catalog's own errors where it has them, so leaving this out is rarely
+        what you want and warns. Stars whose error is not a positive, finite
+        number are left out of the fit.
 
     cat_name : str, optional
         Name of the catalog to calibrate against, either ``"apass_dr9"`` or
@@ -641,12 +694,22 @@ def transform_to_catalog(
         Name of the passband in the catalog that should be matched to the
         instrumental magnitudes, e.g. ``"R"`` or ``"SR"``. This is a passband
         name, not a column name: the column used is ``mag_<cat_filter>``.
+        Defaults to ``obs_filter``, and naming a different band raises, since
+        calibrating observations in one band against catalog magnitudes in
+        another folds the color difference between the two bands into the fit,
+        where it comes back as a transform coefficient and is applied to every
+        star. Two spellings of one band -- ``"R"`` and ``"RC"``, say -- are not
+        a different band.
 
     cat_color : tuple of two strings, optional
         Names of the two passbands whose difference is the color. The color is
         calculated in the order the passbands are given, so ``("R", "I")``
         means the ``mag_R`` column minus the ``mag_I`` column. As with
         ``cat_filter``, these are passband names rather than column names.
+        Defaults to the color conventionally used with ``cat_filter``, which
+        is ``("R", "I")`` for R and I, ``("B", "V")`` for B and V, and the
+        neighboring Sloan band for the Sloan ones. A band with no convention
+        recorded raises rather than being guessed at.
 
     vary : sequence of str, optional
         Which terms of the transform model to fit. Any term not named here is
@@ -718,6 +781,26 @@ def transform_to_catalog(
     freedom in **mag squared** -- the same name and a completely different
     scale, so values from a weighted and an unweighted fit must not be
     compared with each other.
+
+    The fit is weighted by the observed errors and the catalog's own errors
+    combined in quadrature, ``1 / sqrt(obs_error**2 + cat_error**2)``, wherever
+    the catalog has a ``mag_error_<cat_filter>`` column; by the observed errors
+    alone, with a log message naming the band, wherever it does not. A star
+    whose catalog error is missing or is not positive is left out of the fit,
+    exactly as one whose observed error is. Which bands have an error depends on the
+    catalog rather than on this function: `~stellarphot.CatalogData` builds
+    ``mag_error_<band>`` for the bands a catalog measured itself -- B, V, SG,
+    SR and SI for APASS DR9, the Sloan bands for refcat2 -- while the
+    Johnson-Cousins R and I are added afterwards by
+    `~stellarphot.utils.magnitude_system_transforms.transform_apass_bands` and
+    `~stellarphot.utils.magnitude_system_transforms.transform_refcat2_bands`,
+    which return magnitudes and no errors. So the fallback is the normal case
+    for R and I, the bands most often calibrated here, until issue #685
+    teaches those transforms to propagate errors. When the fallback is in use,
+    ``fit_redchi`` is the column to watch: an image whose stars scatter about
+    the transform by more than they claim to be uncertain reports a
+    ``fit_redchi`` well above one, and where the catalog's uncertainty is the
+    reason, weighting cannot know that but the scatter still shows up there.
 
     The reported uncertainties are scaled by ``fit_redchi``, because `lmfit`'s
     ``scale_covar`` is left on. They therefore describe the scatter actually
@@ -808,6 +891,32 @@ def transform_to_catalog(
             f"{sorted(set(observed_mags_grouped['passband']))}."
         )
 
+    # After the check above, not before it: a caller who got the observed
+    # passband name wrong should hear about the name rather than about the
+    # mismatch that follows from it, and checking the table before commenting
+    # on the arguments is the better order in any case.
+    cat_filter = obs_filter if cat_filter is None else cat_filter
+    if not _is_same_band(obs_filter, cat_filter):
+        raise ValueError(
+            f"Observed passband {obs_filter!r} and catalog passband "
+            f"{cat_filter!r} are different bands. Calibrating one against the "
+            "other makes the color difference between the two bands part of "
+            "the fit, which then reports it as a transform coefficient and "
+            "applies it to every star in the image. Leave cat_filter out to "
+            "use the observed passband, or transform the observations to the "
+            "catalog's band first."
+        )
+
+    if cat_color is None:
+        try:
+            cat_color = _CONVENTIONAL_COLOR[cat_filter]
+        except KeyError:
+            raise ValueError(
+                "No color is conventionally used with passband "
+                f"{cat_filter!r}, so cat_color must be given explicitly. The "
+                f"passbands with a default are {sorted(_CONVENTIONAL_COLOR)}."
+            ) from None
+
     # Output is built at the length of the whole table, not of the rows in
     # this passband, and is written by row index below. Rows that are never
     # written keep the NaN they start with.
@@ -854,6 +963,34 @@ def transform_to_catalog(
     # this table, and the invariant documented just above is what makes
     # writing by row index legal.
     result = observed_mags_grouped if in_place else observed_mags_grouped.copy()
+
+    # What is fit is the difference between an observed magnitude and a catalog
+    # one, so both of them contribute to how well each star constrains the fit,
+    # and the catalog says which of its stars it knows poorly. Weighting by the
+    # two errors combined is what replaced the magnitude cut this function used
+    # to make: a faint star is down-weighted by its errors rather than dropped
+    # at a limit drawn across the whole field.
+    #
+    # The column is decided once here rather than per image, since it depends
+    # only on the catalog and the band, and so is the log message when there
+    # is none -- it is a fact about the call rather than about any one image.
+    cat_error_column = f"mag_error_{cat_filter}"
+    if obs_error_column is None:
+        # The fit is unweighted at the caller's request, and was warned about
+        # above. Weighting it by the catalog errors alone would make it a
+        # weighted fit nobody asked for, and would quietly change what
+        # ``fit_redchi`` means.
+        cat_error_column = None
+    elif cat_error_column not in cat.colnames:
+        logger.warning(
+            f"The {cat_name} catalog has no {cat_error_column} column, so the "
+            "fit is weighted by the errors of the observations alone and how "
+            "well the catalog knows each star is not accounted for. Expect "
+            "this for the Johnson-Cousins R and I bands, which are transformed "
+            "from the catalog's native bands by a transform that does not yet "
+            "propagate errors; see issue #685."
+        )
+        cat_error_column = None
 
     for group_number, (file, one_image_all_bands) in enumerate(
         zip(
@@ -908,6 +1045,15 @@ def transform_to_catalog(
             # A non-positive or non-finite error gives a meaningless weight.
             good_dat = good_dat & np.isfinite(errors) & (errors > 0)
 
+        if cat_error_column is not None:
+            cat_error = _to_float_array(cat[cat_error_column][cat_idx])
+            # The same rule as for the observed errors just above, and for
+            # the same reasons: a catalog error of zero is an infinite
+            # weight, and a missing one makes the weight NaN, which
+            # poisons every residual in the image rather than only this
+            # star's.
+            good_cat = good_cat & np.isfinite(cat_error) & (cat_error > 0)
+
         # Both halves have to be good for the *same* star. Checking each on
         # its own is not enough: the two sets can be disjoint, which leaves
         # nothing to take the median of below.
@@ -932,7 +1078,16 @@ def transform_to_catalog(
         fit_color = model_color[good]
         offset = fit_mag if fit_diff else 0.0
         fit_data = cat_mag[good] - offset
-        weights = 1.0 / errors[good] if obs_error_column is not None else 1.0
+
+        if obs_error_column is None:
+            weights = 1.0
+        elif cat_error_column is None:
+            weights = 1.0 / errors[good]
+        else:
+            # In quadrature, because the residual being fit is the
+            # difference between a measured magnitude and a catalog one and
+            # is uncertain by both of them.
+            weights = 1.0 / np.hypot(errors[good], cat_error[good])
 
         # Fewer stars than terms has to be caught before the fit rather than
         # after it: with nothing left to fit, lmfit takes the square root of

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -11,6 +11,7 @@ from numpy.linalg import LinAlgError
 from uncertainties import correlated_values, unumpy
 
 from ..catalogs import apass_dr9, refcat2
+from ..settings.aavso_models import AAVSOFilters
 from .magnitude_system_transforms import transform_apass_bands, transform_refcat2_bands
 
 logger = logging.getLogger(__name__)
@@ -58,35 +59,57 @@ _FIT_REDCHI_COLUMN = "fit_redchi"
 _FIT_MATCH_ARCSEC = 1.0
 _CAL_MATCH_ARCSEC = 1.5
 
-# Passband names that mean the same physical band. Cousins R and I are each
-# written several ways, and `transform_refcat2_bands` really does add ``mag_R``
-# and ``mag_RC`` as copies of one column, so matching R observations against a
-# catalog's RC is one band spelled two ways rather than the mistake the check
-# that uses this exists to catch.
-_SAME_BAND = (frozenset({"R", "RC", "Rc"}), frozenset({"I", "IC", "Ic"}))
-
-# The color conventionally used with each passband, for a caller who names a
-# band but no color. Which color goes with a band is a convention rather than
-# something derivable, so a band that is not here has to be asked about rather
-# than guessed at. Every spelling of Cousins R and I is a key of its own,
-# because the band is looked up as the caller wrote it and is never rewritten
-# into one preferred spelling.
+# The color conventionally used with each canonical passband, for a caller
+# who names a band but no color. Which color goes with a band is a convention
+# rather than something derivable, so a band that is not here has to be asked
+# about rather than guessed at. Limited to the bands the two catalog fetches
+# below can actually supply -- apass_dr9 fetches B, V, R, I, SR, SG and SI,
+# refcat2 fetches B, V, R and I -- so U, SU and SZ are left out even though
+# AAVSO recognizes them: naming a color built from a band the catalog cannot
+# return would only replace this lookup's raise with a `KeyError` further on.
 _CONVENTIONAL_COLOR = {
-    "U": ("U", "B"),
     "B": ("B", "V"),
     "V": ("B", "V"),
     "R": ("R", "I"),
-    "RC": ("R", "I"),
-    "Rc": ("R", "I"),
     "I": ("R", "I"),
-    "IC": ("R", "I"),
-    "Ic": ("R", "I"),
-    "SU": ("SU", "SG"),
     "SG": ("SG", "SR"),
     "SR": ("SR", "SI"),
     "SI": ("SR", "SI"),
-    "SZ": ("SI", "SZ"),
 }
+
+
+def _canonical_passband(name):
+    """
+    The AAVSO-standard spelling of a passband name.
+
+    `~stellarphot.settings.aavso_models.AAVSOFilters` is the definitive list
+    of AAVSO passbands, and its members carry both the name a caller is
+    likely to type -- ``Rc`` and ``Ic`` for Cousins R and I -- and the value
+    that is AAVSO's own preferred spelling for it -- ``"R"`` and ``"I"``. This
+    matches ``name`` case-insensitively against both, so ``"Rc"``, ``"rc"``,
+    ``"RC"`` and ``"R"`` all resolve to the one member and come back as
+    ``"R"``. A name that matches nothing is not necessarily wrong -- callers
+    can and do use catalog-specific bands this function has never heard of --
+    so it is returned upper-cased rather than rejected, upper case being the
+    convention AAVSO passband names follow.
+
+    Parameters
+    ----------
+
+    name : str
+        Passband name as a caller wrote it.
+
+    Returns
+    -------
+    str
+        The canonical spelling of the same band.
+    """
+    upper = name.upper()
+    for member in AAVSOFilters:
+        if member.name.upper() == upper or member.value.upper() == upper:
+            return member.value
+    return upper
+
 
 # How strongly the terms of the fit may be correlated with each other before
 # their individual values stop meaning anything. See `_underdetermined_reason`,
@@ -423,28 +446,6 @@ def _calibrated_with_uncertainty(fit_result, covar, mag_inst, color, errors, fit
         return unumpy.nominal_values(calibrated), unumpy.std_devs(calibrated)
 
 
-def _is_same_band(one_filter, another_filter):
-    """
-    Whether two passband names name the same physical band.
-
-    Parameters
-    ----------
-
-    one_filter, another_filter : str
-        Passband names to compare.
-
-    Returns
-    -------
-    bool
-        `True` if the two names are the same, or are two spellings of one
-        band; see `_SAME_BAND`.
-    """
-    if one_filter == another_filter:
-        return True
-
-    return any(one_filter in band and another_filter in band for band in _SAME_BAND)
-
-
 def _check_known_terms(terms, argument_name):
     """
     Raise if any of ``terms`` is not a coefficient of the transform model.
@@ -694,22 +695,30 @@ def transform_to_catalog(
         Name of the passband in the catalog that should be matched to the
         instrumental magnitudes, e.g. ``"R"`` or ``"SR"``. This is a passband
         name, not a column name: the column used is ``mag_<cat_filter>``.
-        Defaults to ``obs_filter``, and naming a different band raises, since
-        calibrating observations in one band against catalog magnitudes in
-        another folds the color difference between the two bands into the fit,
-        where it comes back as a transform coefficient and is applied to every
-        star. Two spellings of one band -- ``"R"`` and ``"RC"``, say -- are not
-        a different band.
+        Passband spellings are canonicalized case-insensitively against
+        `~stellarphot.settings.aavso_models.AAVSOFilters`, so ``"R"`` and
+        ``"Rc"`` are one band rather than two. Defaults to ``obs_filter``,
+        and the default can never mismatch; naming a different band
+        explicitly is taken as deliberate -- unfiltered or DSLR observations
+        (AAVSO's CV and TG) are routinely calibrated against a catalog's V,
+        for instance, because there is no observed V to match against
+        instead -- but it warns, because calibrating observations in one band
+        against catalog magnitudes in another folds the color difference
+        between the two bands into the fit, where it comes back as a
+        transform coefficient and is applied to every star.
 
     cat_color : tuple of two strings, optional
         Names of the two passbands whose difference is the color. The color is
         calculated in the order the passbands are given, so ``("R", "I")``
         means the ``mag_R`` column minus the ``mag_I`` column. As with
-        ``cat_filter``, these are passband names rather than column names.
-        Defaults to the color conventionally used with ``cat_filter``, which
-        is ``("R", "I")`` for R and I, ``("B", "V")`` for B and V, and the
-        neighboring Sloan band for the Sloan ones. A band with no convention
-        recorded raises rather than being guessed at.
+        ``cat_filter``, these are passband names rather than column names, and
+        are canonicalized the same way. Only used, and therefore only
+        defaulted or checked, when a color term (``"c"`` or ``"d"``) is being
+        fit; see ``vary``. When it is, this defaults to the color
+        conventionally used with ``cat_filter``, which is ``("R", "I")`` for R
+        and I, ``("B", "V")`` for B and V, and the neighboring Sloan band for
+        the Sloan ones. A band with no convention recorded raises rather than
+        being guessed at.
 
     vary : sequence of str, optional
         Which terms of the transform model to fit. Any term not named here is
@@ -761,6 +770,14 @@ def transform_to_catalog(
         NaN wherever ``mag_cal`` is, for whatever reason, so a finite
         calibrated error always has a calibrated magnitude to go with it.
 
+        ``result.meta["transform_weighting"]`` records how the fit for this
+        call was weighted, keyed by ``obs_filter`` exactly as it was passed:
+        ``"combined"`` when the catalog had an error column for the band,
+        ``"observed"`` when it did not, and ``"unweighted"`` when
+        ``obs_error_column`` was not given. Keyed rather than flat because
+        this function is called once per passband on the same table, and a
+        flat entry would be overwritten by the next call.
+
     Notes
     -----
 
@@ -786,9 +803,12 @@ def transform_to_catalog(
     combined in quadrature, ``1 / sqrt(obs_error**2 + cat_error**2)``, wherever
     the catalog has a ``mag_error_<cat_filter>`` column; by the observed errors
     alone, with a log message naming the band, wherever it does not. A star
-    whose catalog error is missing or is not positive is left out of the fit,
-    exactly as one whose observed error is. Which bands have an error depends on the
-    catalog rather than on this function: `~stellarphot.CatalogData` builds
+    whose catalog error is missing, masked, NaN or not positive is not left
+    out of the fit for it -- the catalog simply does not know its own
+    uncertainty for that star, so its weight falls back to the observed error
+    alone, exactly as if the catalog had no error column at all. Which bands
+    have an error depends on the catalog rather than on this function:
+    `~stellarphot.CatalogData` builds
     ``mag_error_<band>`` for the bands a catalog measured itself -- B, V, SG,
     SR and SI for APASS DR9, the Sloan bands for refcat2 -- while the
     Johnson-Cousins R and I are added afterwards by
@@ -895,27 +915,43 @@ def transform_to_catalog(
     # passband name wrong should hear about the name rather than about the
     # mismatch that follows from it, and checking the table before commenting
     # on the arguments is the better order in any case.
-    cat_filter = obs_filter if cat_filter is None else cat_filter
-    if not _is_same_band(obs_filter, cat_filter):
-        raise ValueError(
+    cat_filter = _canonical_passband(obs_filter if cat_filter is None else cat_filter)
+    if _canonical_passband(obs_filter) != cat_filter:
+        # The default can never land here -- it is always obs_filter itself
+        # -- so a mismatch only happens when the caller named a different
+        # catalog band on purpose. That is a real workflow: unfiltered and
+        # DSLR observations (AAVSO's CV and TG) have no observed V to match,
+        # so they are calibrated against a catalog's V instead. What has to
+        # be said out loud is the cost of doing that -- the color difference
+        # between the two bands becomes part of the fit, comes back as a
+        # transform coefficient, and is applied to every star -- not whether
+        # it is allowed.
+        warnings.warn(
             f"Observed passband {obs_filter!r} and catalog passband "
-            f"{cat_filter!r} are different bands. Calibrating one against the "
-            "other makes the color difference between the two bands part of "
-            "the fit, which then reports it as a transform coefficient and "
-            "applies it to every star in the image. Leave cat_filter out to "
-            "use the observed passband, or transform the observations to the "
-            "catalog's band first."
+            f"{cat_filter!r} are different bands. The color difference "
+            "between the two bands becomes part of the fit, which reports it "
+            "as a transform coefficient and applies it to every star in the "
+            "image. This is fine for a deliberate choice, such as "
+            "calibrating unfiltered or DSLR observations against a catalog's "
+            "V, but if that was not the intent, leave cat_filter out to use "
+            "the observed passband, or transform the observations to the "
+            "catalog's band first.",
+            AstropyUserWarning,
+            stacklevel=2,
         )
 
-    if cat_color is None:
-        try:
-            cat_color = _CONVENTIONAL_COLOR[cat_filter]
-        except KeyError:
-            raise ValueError(
-                "No color is conventionally used with passband "
-                f"{cat_filter!r}, so cat_color must be given explicitly. The "
-                f"passbands with a default are {sorted(_CONVENTIONAL_COLOR)}."
-            ) from None
+    if cat_color is not None:
+        cat_color = tuple(_canonical_passband(band) for band in cat_color)
+    elif cat_filter in _CONVENTIONAL_COLOR:
+        cat_color = _CONVENTIONAL_COLOR[cat_filter]
+    elif fitting_color:
+        raise ValueError(
+            "No color is conventionally used with passband "
+            f"{cat_filter!r}, so cat_color must be given explicitly. The "
+            f"passbands with a default are {sorted(_CONVENTIONAL_COLOR)}."
+        )
+    # else: no color term is being fit, so the model never evaluates a color
+    # and cat_color is left `None` -- nothing needs it, so nothing is guessed.
 
     # Output is built at the length of the whole table, not of the rows in
     # this passband, and is written by row index below. Rows that are never
@@ -950,8 +986,37 @@ def transform_to_catalog(
             f"Unknown catalog name {cat_name}. Must be one of 'apass_dr9' or 'refcat2'."
         )
 
+    # cat_filter and cat_color are only ever strings until this point, so a
+    # band the catalog cannot supply -- "U" against apass_dr9 or refcat2,
+    # neither of which fetches it, is the obvious way -- would otherwise
+    # survive every check above and die in a bare `KeyError` only after the
+    # Vizier round trip just spent had already paid for it. Checked here,
+    # right after the columns exist to check against, so the message can name
+    # both what is missing and what the catalog actually has.
+    needed_bands = {cat_filter} if cat_color is None else {cat_filter, *cat_color}
+    available_bands = sorted(
+        name.removeprefix("mag_")
+        for name in cat.colnames
+        if name.startswith("mag_") and not name.startswith("mag_error_")
+    )
+    missing_bands = sorted(needed_bands - set(available_bands))
+    if missing_bands:
+        raise ValueError(
+            f"The {cat_name} catalog has no magnitude for passband(s) "
+            f"{missing_bands}, needed for cat_filter or cat_color. It has "
+            f"magnitudes for {available_bands}."
+        )
+
     cat_coords = SkyCoord(cat["ra"], cat["dec"], unit="degree")
-    cat["color"] = cat[f"mag_{cat_color[0]}"] - cat[f"mag_{cat_color[1]}"]
+    if cat_color is None:
+        # No color term is being fit -- see fitting_color above -- so the
+        # model never evaluates a color. An all-NaN column keeps color_cat
+        # honestly reporting "unknown" for every star, rather than a
+        # difference nobody asked for and the catalog was never checked to
+        # support.
+        cat["color"] = np.full(len(cat), np.nan)
+    else:
+        cat["color"] = cat[f"mag_{cat_color[0]}"] - cat[f"mag_{cat_color[1]}"]
 
     # Grouping a table reorders its rows, and the result below is either the
     # grouped table itself or a straight copy of it, so group number ``i``
@@ -981,7 +1046,10 @@ def transform_to_catalog(
         # weighted fit nobody asked for, and would quietly change what
         # ``fit_redchi`` means.
         cat_error_column = None
-    elif cat_error_column not in cat.colnames:
+        weighting_mode = "unweighted"
+    elif cat_error_column in cat.colnames:
+        weighting_mode = "combined"
+    else:
         logger.warning(
             f"The {cat_name} catalog has no {cat_error_column} column, so the "
             "fit is weighted by the errors of the observations alone and how "
@@ -991,6 +1059,14 @@ def transform_to_catalog(
             "propagate errors; see issue #685."
         )
         cat_error_column = None
+        weighting_mode = "observed"
+
+    # Recorded on the result rather than returned separately, keyed by
+    # obs_filter exactly as the caller passed it rather than as a flat entry,
+    # because this function is called once per passband on the same table --
+    # a flat entry would be overwritten by the next call, losing the first
+    # passband's mode.
+    result.meta.setdefault("transform_weighting", {})[obs_filter] = weighting_mode
 
     for group_number, (file, one_image_all_bands) in enumerate(
         zip(
@@ -1047,12 +1123,21 @@ def transform_to_catalog(
 
         if cat_error_column is not None:
             cat_error = _to_float_array(cat[cat_error_column][cat_idx])
-            # The same rule as for the observed errors just above, and for
-            # the same reasons: a catalog error of zero is an infinite
-            # weight, and a missing one makes the weight NaN, which
-            # poisons every residual in the image rather than only this
-            # star's.
-            good_cat = good_cat & np.isfinite(cat_error) & (cat_error > 0)
+            # Unlike the observed error just above, a catalog error the fit
+            # cannot use -- missing, masked, NaN, zero or negative -- does
+            # not mean the star's catalog magnitude is unusable, only that
+            # the catalog does not know its own uncertainty for it. Zero
+            # stands in for it instead of excluding the star: the weight
+            # below is ``1 / hypot(errors, cat_error)``, and ``hypot(x, 0)``
+            # is exactly ``x``, so the star ends up weighted by its observed
+            # error alone -- the same fallback used when the catalog has no
+            # error column for the band at all, just decided star by star
+            # instead of for the whole image. This is what keeps a catalog's
+            # single-observation stars, reported with zero error, in the fit
+            # exactly as they were before catalog-error weighting existed.
+            cat_error = np.where(
+                np.isfinite(cat_error) & (cat_error > 0), cat_error, 0.0
+            )
 
         # Both halves have to be good for the *same* star. Checking each on
         # its own is not enough: the two sets can be disjoint, which leaves

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -750,6 +750,11 @@ def _noisy_fit_result(module_mocker):
     result, _, _ = _fit_a_catalog(
         module_mocker, n_stars=50, sigma=0.02, seed=20260811, a=0.02, c=0.15
     )
+    # The patch has done its job once the fit is computed. Left in place it
+    # would outlive every later test in the module -- module_mocker unwinds at
+    # module teardown -- and hand the remote-data tests this fake catalog in
+    # place of the real fetch.
+    module_mocker.stopall()
     return result
 
 

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -3,12 +3,20 @@ import logging
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.table import Table, vstack
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
+from stellarphot.conftest import SERVER_DOWN_ERRORS
+
+from ...catalogs import apass_dr9, refcat2
 from ...core import PhotometryData
 from .. import magnitude_transforms
+from ..magnitude_system_transforms import (
+    transform_apass_bands,
+    transform_refcat2_bands,
+)
 from ..magnitude_transforms import (
     calibrated_from_instrumental,
     filter_transform,
@@ -156,6 +164,18 @@ _FAKE_CATALOG_ZERO_POINT = 20.0
 # the recovery tests allow.
 _FAKE_CATALOG_SCATTER = 1e-12
 
+# Error the synthetic catalog reports for each of its magnitudes. A real
+# catalog reports one for every band it measured itself, and the fit weights
+# by it, so a catalog with no errors at all is the exception rather than the
+# rule -- it is what a *transformed* band looks like, which the tests that
+# care about say explicitly by passing ``cat_error=None``. Small enough
+# against the observed errors used here that it changes no number any other
+# test in this file asserts on: the fit weights are 1/sqrt(obs^2 + cat^2), and
+# `lmfit` rescales the covariance by the reduced chi-square, so a catalog
+# error this far below the observed ones is invisible in both the fit and its
+# reported uncertainties.
+_FAKE_CATALOG_ERROR = 0.001
+
 
 def _generate_fake_catalog(
     n_stars,
@@ -167,6 +187,7 @@ def _generate_fake_catalog(
     coordinates=None,
     instrumental=None,
     color=None,
+    cat_error=_FAKE_CATALOG_ERROR,
 ):
     """
     Generate a catalog whose magnitudes follow the transform model.
@@ -203,10 +224,19 @@ def _generate_fake_catalog(
     color : `numpy.ndarray`, optional
         Color of each star. Random, but seeded, if not given.
 
+    cat_error : float or array-like, optional
+        Error to report for each catalog magnitude, in the
+        ``mag_error_R`` and ``mag_error_I`` columns a real catalog carries for
+        the bands it measured itself. Pass `None` for a catalog with no error
+        columns at all, which is what a band transformed from other bands
+        looks like -- and is what makes `transform_to_catalog` fall back to
+        weighting by the observed errors alone, with a warning.
+
     Returns
     -------
     catalog : `_FakeCatalogTable`
-        Catalog with columns ``ra``, ``dec``, ``mag_R`` and ``mag_I``.
+        Catalog with columns ``ra``, ``dec``, ``mag_R`` and ``mag_I``, and,
+        unless ``cat_error`` is `None`, ``mag_error_R`` and ``mag_error_I``.
 
     ra : `astropy.units.Quantity`
         Right ascension of each star.
@@ -257,7 +287,49 @@ def _generate_fake_catalog(
         }
     )
 
+    if cat_error is not None:
+        errors = np.broadcast_to(
+            np.asarray(cat_error, dtype=float), np.shape(cat_r)
+        ).copy()
+        catalog["mag_error_R"] = errors
+        catalog["mag_error_I"] = errors.copy()
+
     return catalog, ra, dec, instrumental
+
+
+def _catalog_bands_renamed(catalog, **new_from_old):
+    """
+    Copy a catalog's magnitudes under other passband names.
+
+    ``_catalog_bands_renamed(catalog, SR="R", SI="I")`` gives the catalog a
+    ``mag_SR`` column holding exactly what ``mag_R`` holds, along with the
+    matching ``mag_error_SR``, so that a catalog built in R and I can stand in
+    for one in any other pair of bands. Only the names change, so a fit
+    against the renamed band recovers exactly what it recovers against the
+    original.
+
+    Parameters
+    ----------
+
+    catalog : `_FakeCatalogTable`
+        Catalog to add the columns to. Modified in place.
+
+    **new_from_old
+        The new passband names, each with the name of the passband whose
+        columns it should copy.
+
+    Returns
+    -------
+    `_FakeCatalogTable`
+        The catalog, for convenience.
+    """
+    for new, old in new_from_old.items():
+        catalog[f"mag_{new}"] = catalog[f"mag_{old}"]
+        old_error = f"mag_error_{old}"
+        if old_error in catalog.colnames:
+            catalog[f"mag_error_{new}"] = catalog[old_error]
+
+    return catalog
 
 
 def _generate_observed_table(
@@ -419,11 +491,11 @@ def _run_transform_to_catalog(
     """
     _patch_catalog_fetch(mocker, catalog, cat_name=cat_name)
 
-    call_kwargs = {
-        "obs_error_column": "mag_error",
-        "cat_filter": "R",
-        "cat_color": ("R", "I"),
-    }
+    # Only the error column is supplied here. The catalog band and color are
+    # left to default from ``obs_filter``, because naming a catalog band that
+    # is not the observed one is now an error, and a helper that quietly
+    # passed ``cat_filter="R"`` would make every call for another band one.
+    call_kwargs = {"obs_error_column": "mag_error"}
     call_kwargs.update(kwargs)
 
     return transform_to_catalog(observed, obs_filter, cat_name=cat_name, **call_kwargs)
@@ -755,38 +827,265 @@ def test_transform_to_catalog_omitted_quadratic_term_degrades_gracefully(mocker)
     )
 
 
-def test_transform_to_catalog_weights_by_inverse_error(mocker):
-    # Every other fit here is of noiseless data with a single error value, and
-    # for a residual that reaches exactly zero the weights make no difference
-    # to where the fit lands -- so weighting by the error rather than by one
-    # over the error would pass the rest of this file. Here one star is wrong
-    # and says so with a large error: weighted correctly it is ignored,
-    # weighted backwards it takes over (z comes out near 18.5, not 20).
-    n_stars = 20
+def _one_star_with_a_large_error(mocker, n_stars=20, cat_error=_FAKE_CATALOG_ERROR):
+    """
+    Fit an image in which one star is wrong and says so with a large error.
+
+    The star's observed magnitude is 0.8 mag from where the catalog puts it,
+    which is close enough to survive the median-based outlier cut, so nothing
+    but the weighting can keep it from dragging the fit. Every other star is
+    measured well and agrees with the catalog.
+
+    Parameters
+    ----------
+
+    mocker : `pytest_mock.MockerFixture`
+        Fixture used to patch the catalog fetch.
+
+    n_stars : int, optional
+        Number of stars to generate.
+
+    cat_error : float or array-like or None, optional
+        Error the catalog reports for each of its magnitudes, passed to
+        `_generate_fake_catalog`.
+
+    Returns
+    -------
+    `astropy.table.Table`
+        The transformed observations.
+    """
     sigma = 1e-4
 
-    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
+    catalog, ra, dec, instrumental = _generate_fake_catalog(
+        n_stars, cat_error=cat_error
+    )
 
-    # Close enough to the other stars to survive the outlier cut, so only the
-    # weighting can keep it from dragging the fit.
     observed_mags = instrumental.copy()
     observed_mags[0] -= 0.8
 
     errors = np.full(n_stars, 0.001)
     errors[0] = 10.0
 
-    # The noise is an order of magnitude below the tolerances asserted here, so
-    # it changes nothing about what this test is asking; it is added only
+    # The noise is an order of magnitude below the tolerances asserted by the
+    # callers, so it changes nothing about what they ask; it is added only
     # because a residual of exactly zero is a state real data never reaches.
     observed = _generate_observed_table(
         ra, dec, observed_mags, noise_sigma=sigma, seed=8811, mag_error=errors
     )
 
-    result = _run_transform_to_catalog(mocker, catalog, observed)
+    return _run_transform_to_catalog(mocker, catalog, observed)
 
+
+def _assert_the_bad_star_was_ignored(result):
+    """
+    Assert a fit recovered the truth despite the badly measured star in it.
+
+    See `_one_star_with_a_large_error`, which builds the image this is asked
+    of. Weighted backwards the bad star takes over and ``z`` comes out near
+    18.5 rather than 20.
+    """
     np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-3)
     np.testing.assert_allclose(result["a"], 0.0, rtol=0, atol=1e-3)
     np.testing.assert_allclose(result["c"], 0.0, rtol=0, atol=1e-3)
+
+
+def test_transform_to_catalog_weights_by_inverse_error(mocker):
+    # Every other fit here is of noiseless data with a single error value, and
+    # for a residual that reaches exactly zero the weights make no difference
+    # to where the fit lands -- so weighting by the error rather than by one
+    # over the error would pass the rest of this file.
+    _assert_the_bad_star_was_ignored(_one_star_with_a_large_error(mocker))
+
+
+def test_transform_to_catalog_weights_by_inverse_error_without_catalog_errors(mocker):
+    # The same thing where the catalog supplies no errors of its own, which is
+    # the path the Johnson-Cousins bands take (see the log-message test below).
+    # The observed errors have to be used on their own there, and used the same
+    # way round -- the fallback is not a path that gets to behave differently.
+    result = _one_star_with_a_large_error(mocker, cat_error=None)
+
+    _assert_the_bad_star_was_ignored(result)
+
+
+def test_transform_to_catalog_weights_by_the_catalog_error_too(mocker):
+    # What is being fit is the difference between an observed magnitude and a
+    # catalog one, so a star the *catalog* barely knows constrains the fit as
+    # poorly as one the observation barely knows, and the catalog says which
+    # stars those are. This is what replaced the faintest_mag_for_transform
+    # cut #676 removed: the poorly known stars are down-weighted rather than a
+    # magnitude being drawn across the field. See issue #680.
+    n_stars = 20
+    sigma = 1e-4
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars)
+
+    # One star's observed magnitude is 0.8 mag from where the catalog puts it
+    # -- close enough to survive the median-based outlier cut -- and it is the
+    # catalog that is unsure about it. The observation is as good as any other.
+    observed_mags = instrumental.copy()
+    observed_mags[0] -= 0.8
+
+    catalog["mag_error_R"][0] = 10.0
+
+    observed = _generate_observed_table(
+        ra, dec, observed_mags, noise_sigma=sigma, seed=8811, mag_error=0.001
+    )
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-3)
+
+    # The other half: with no catalog errors to weight by, nothing marks that
+    # star out and it drags the fit. Without this the test above would pass on
+    # a version that ignored the catalog errors entirely.
+    del catalog["mag_error_R"]
+
+    unweighted = _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert abs(unweighted["z"][0] - _FAKE_CATALOG_ZERO_POINT) > 0.01
+
+
+def test_transform_to_catalog_combines_the_errors_in_quadrature(mocker):
+    # Which combination it is matters, and the test above cannot tell: adding
+    # the two errors, or taking the larger of them, would down-weight that
+    # star just as well. So run the same data twice, once against a catalog
+    # that supplies the errors and once with the test having folded them into
+    # the observed errors itself. The two fits must be identical bit for bit,
+    # because they are literally the same weights.
+    n_stars = 20
+    sigma = 0.02
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, a=0.02, c=0.15)
+
+    # Both errors vary from star to star, and in opposite directions, so no
+    # single-error rule reproduces the combination by accident.
+    cat_error = np.linspace(0.005, 0.05, n_stars)
+    obs_error = np.linspace(0.05, 0.005, n_stars)
+    catalog["mag_error_R"] = cat_error
+
+    observed = _generate_observed_table(
+        ra, dec, instrumental, noise_sigma=sigma, seed=97531, mag_error=obs_error
+    )
+    combined_by_the_code = _run_transform_to_catalog(mocker, catalog, observed)
+
+    del catalog["mag_error_R"]
+    pre_combined = _generate_observed_table(
+        ra,
+        dec,
+        instrumental,
+        noise_sigma=sigma,
+        seed=97531,
+        mag_error=np.hypot(obs_error, cat_error),
+    )
+
+    combined_by_the_test = _run_transform_to_catalog(mocker, catalog, pre_combined)
+
+    # Exact equality, not approximate: the fits saw the same magnitudes and
+    # the same weights, so anything but the same answer means the weights were
+    # built some other way. Only what the weights decide is compared --
+    # mag_cal_error is the star's own measurement error propagated, and the
+    # observed errors really are different between the two runs.
+    for column in ("a", "c", "z", "mag_cal"):
+        np.testing.assert_array_equal(
+            np.asarray(combined_by_the_code[column]),
+            np.asarray(combined_by_the_test[column]),
+            err_msg=column,
+        )
+
+
+def test_transform_to_catalog_warns_when_the_catalog_has_no_error_for_the_band(
+    mocker, caplog
+):
+    # The bands the shipped notebook calibrates in, R and I, are exactly the
+    # ones neither APASS nor refcat2 supplies errors for: they are transformed
+    # from the catalog's native bands by a transform that does not propagate
+    # errors yet. The fit still runs, weighted by the observed errors alone,
+    # and says which band it could not do better for. Issue #685 is the fix.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20, cat_error=None)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
+        result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    about_the_band = [
+        r for r in caplog.records if "mag_error_R" in r.message and "#685" in r.message
+    ]
+    # One message per call, not one per image: the column is missing from the
+    # catalog, which is a fact about the call rather than about an image.
+    assert len(about_the_band) == 1
+
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+
+
+def test_transform_to_catalog_negligible_catalog_error_changes_nothing(mocker):
+    # The other side of the fallback: adding catalog errors to the weighting
+    # must not have moved the answer for anyone whose catalog errors are too
+    # small to matter. A catalog error 27 orders of magnitude below the
+    # observed one gives the same numbers as no catalog error column at all,
+    # bit for bit, which is only true if the two paths do the same arithmetic.
+    n_stars = 20
+    sigma = 0.02
+
+    catalog, ra, dec, instrumental = _generate_fake_catalog(
+        n_stars, a=0.02, c=0.15, cat_error=1e-30
+    )
+    observed = _generate_observed_table(
+        ra, dec, instrumental, noise_sigma=sigma, seed=13579
+    )
+
+    negligible = _run_transform_to_catalog(mocker, catalog, observed)
+
+    del catalog["mag_error_R"]
+    absent = _run_transform_to_catalog(mocker, catalog, observed)
+
+    for column in _TRANSFORM_OUTPUT_COLUMNS:
+        np.testing.assert_array_equal(
+            np.asarray(negligible[column]),
+            np.asarray(absent[column]),
+            err_msg=column,
+        )
+
+
+@pytest.mark.parametrize("case", ["masked", "zero", "negative"])
+def test_transform_to_catalog_excludes_unusable_catalog_errors(mocker, case):
+    # A catalog error of zero is an infinite weight, and a missing one makes
+    # the weight NaN, which poisons every residual in the image rather than
+    # just that star's. Both have to be handled the way an unusable observed
+    # error already is -- the star is left out of the fit -- rather than being
+    # left to reach the fitter. See issue #680.
+    n_stars = 20
+    sigma = 1e-4
+
+    # Every star's catalog magnitude is poorly known, so that a star whose
+    # error is unusable would dominate the fit if it were let in.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, cat_error=0.5)
+
+    observed_mags = instrumental.copy()
+    observed_mags[0] -= 0.8
+
+    match case:
+        case "masked":
+            catalog["mag_error_R"] = np.ma.masked_array(
+                catalog["mag_error_R"], mask=np.arange(n_stars) == 0
+            )
+        case "zero":
+            catalog["mag_error_R"][0] = 0.0
+        case "negative":
+            catalog["mag_error_R"][0] = -0.02
+        case _:  # pragma: no cover
+            raise ValueError(f"Unknown case {case!r}")
+
+    observed = _generate_observed_table(
+        ra, dec, observed_mags, noise_sigma=sigma, seed=8811, mag_error=0.01
+    )
+
+    result = _run_transform_to_catalog(mocker, catalog, observed)
+
+    np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-2)
+
+    # The star is only kept out of the *fit*. Its own measurement is fine, so
+    # it is still calibrated, like a star with a bad observed error is.
+    assert np.isfinite(result["mag_cal"][0])
 
 
 def test_transform_to_catalog_reports_coefficient_uncertainties(_noisy_fit_result):
@@ -1793,11 +2092,68 @@ def test_transform_to_catalog_passband_not_in_table_raises(mocker):
     # Asking for a passband the table does not contain is a mistake, not an
     # empty result, and the message should say which passbands are there --
     # the usual cause is a name that differs from the one in the file.
+    #
+    # The catalog band is deliberately a different one, which makes this the
+    # test that pins the order of the two checks: the table is checked before
+    # the arguments are, so a caller who got the passband name wrong hears
+    # about the name rather than about a mismatch that is a consequence of it.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
     observed = _generate_observed_table(ra, dec, instrumental, passband="R")
 
     with pytest.raises(ValueError, match="No rows with passband 'B'"):
-        _run_transform_to_catalog(mocker, catalog, observed, obs_filter="B")
+        _run_transform_to_catalog(
+            mocker, catalog, observed, obs_filter="B", cat_filter="R"
+        )
+
+
+def test_transform_to_catalog_mismatched_passbands_raise(mocker):
+    # Calibrating V observations against the catalog's B is not a transform,
+    # it is a color error dressed up as one: the B - V of every star lands in
+    # the fit, comes back as a zero point and a color term, and is then
+    # applied to every star in the image. Nobody means to ask for that, so it
+    # is a mistake rather than an option. See issue #680.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    _catalog_bands_renamed(catalog, V="R", B="I")
+    observed = _generate_observed_table(ra, dec, instrumental, passband="V")
+
+    with pytest.raises(ValueError, match="passband 'V'.*passband 'B'"):
+        _run_transform_to_catalog(
+            mocker, catalog, observed, obs_filter="V", cat_filter="B"
+        )
+
+
+@pytest.mark.parametrize("cat_filter", ["R", "RC", "Rc"])
+def test_transform_to_catalog_accepts_equivalent_passband_names(mocker, cat_filter):
+    # The half that keeps the check above from being over-eager. Cousins R is
+    # written several ways, and refcat2's band transform really does add
+    # mag_R and mag_RC as copies of one column, so R against RC is one band
+    # spelled two ways rather than two bands.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    _catalog_bands_renamed(catalog, RC="R", Rc="R")
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed, cat_filter=cat_filter)
+
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+
+
+def test_transform_to_catalog_unknown_default_color_raises(mocker):
+    # The color that goes with a band is a convention rather than something
+    # derivable, so a band with no convention recorded has to be asked about
+    # instead of guessed at -- a wrong guess would name a column that is not
+    # there, and the KeyError that follows says nothing about what to do.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    _catalog_bands_renamed(catalog, TG="R")
+    observed = _generate_observed_table(ra, dec, instrumental, passband="TG")
+
+    with pytest.raises(ValueError, match="cat_color must be given"):
+        _run_transform_to_catalog(mocker, catalog, observed, obs_filter="TG")
+
+    # Naming the color is all it takes.
+    result = _run_transform_to_catalog(
+        mocker, catalog, observed, obs_filter="TG", cat_color=("R", "I")
+    )
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_TG"], rtol=0, atol=1e-6)
 
 
 def test_transform_to_catalog_skips_image_without_the_passband(mocker):
@@ -2102,18 +2458,41 @@ def test_transform_to_catalog_nans_error_where_there_is_no_magnitude(mocker):
     )
 
 
-def test_transform_to_catalog_default_catalog_columns(mocker):
-    # Every call site passes cat_filter and cat_color explicitly, so nothing
-    # ever executed the defaults. They name columns the catalog is indexed by
-    # as mag_<name>, which means they have to be passband names.
+@pytest.mark.parametrize(
+    "band, color",
+    [
+        # The band this was written for, and its conventional color.
+        ("R", ("R", "I")),
+        # A band whose conventional color is a different pair entirely, which
+        # is what stops the defaults being a pair of literals. Before this the
+        # default was ``cat_filter="R"``, so calibrating V without naming the
+        # catalog band silently fit V observations against catalog R.
+        ("V", ("B", "V")),
+    ],
+)
+def test_transform_to_catalog_default_catalog_columns(mocker, band, color):
+    # cat_filter and cat_color name columns the catalog is indexed by as
+    # mag_<name>, which means they have to be passband names. Left out, they
+    # follow the observed passband: the catalog band is the one that was
+    # observed, since anything else is an error, and the color is the pair
+    # conventionally used with it.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    observed = _generate_observed_table(ra, dec, instrumental)
+
+    # The catalog's own R stands in for the band being calibrated, and its I
+    # for the other half of the color pair. Which half that is depends on the
+    # band: V is the second of B - V and R is the first of R - I.
+    other = color[0] if color[1] == band else color[1]
+    _catalog_bands_renamed(catalog, **{band: "R", other: "I"})
+
+    observed = _generate_observed_table(ra, dec, instrumental, passband=band)
 
     _patch_catalog_fetch(mocker, catalog)
 
-    result = transform_to_catalog(observed, "R", obs_error_column="mag_error")
+    result = transform_to_catalog(observed, band, obs_error_column="mag_error")
 
-    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    np.testing.assert_allclose(
+        result["mag_cal"], catalog[f"mag_{band}"], rtol=0, atol=1e-6
+    )
 
 
 def test_transform_to_catalog_accepts_photometry_data(mocker):
@@ -2140,6 +2519,14 @@ def test_transform_to_catalog_accepts_photometry_data(mocker):
 
     catalog, ra, dec, instrumental = _generate_fake_catalog(len(photometry))
 
+    # The photometry is in Sloan r', which is a different passband from
+    # Cousins R however close the two are, so the catalog has to be asked for
+    # r' as well -- until this was fixed the test calibrated SR observations
+    # against catalog R, exactly the mistake #680 makes an error. Renaming the
+    # synthetic catalog's bands is enough: nothing here depends on the
+    # magnitudes being real ones.
+    _catalog_bands_renamed(catalog, SR="R", SI="I")
+
     # Real photometry has gaps in it -- stars that fell off the chip, or were
     # too faint to measure -- so keep some here.
     instrumental[:n_unmeasured] = np.nan
@@ -2159,7 +2546,7 @@ def test_transform_to_catalog_accepts_photometry_data(mocker):
     # ones stay NaN rather than turning into a number.
     np.testing.assert_allclose(
         result["mag_cal"][n_unmeasured:],
-        np.asarray(catalog["mag_R"])[n_unmeasured:],
+        np.asarray(catalog["mag_SR"])[n_unmeasured:],
         rtol=0,
         atol=1e-6,
     )
@@ -2176,3 +2563,172 @@ def test_transform_to_catalog_non_numeric_existing_column_raises(mocker):
 
     with pytest.raises(ValueError, match="'mag_cal' is already in the table"):
         _run_transform_to_catalog(mocker, catalog, observed)
+
+
+# Everything below runs only with --remote-data, in the single tox coverage
+# job that passes it. The rest of this file mocks the catalog fetch, which
+# leaves two things untested: the real Vizier query, and the real band
+# transform that turns a catalog's native passbands into Johnson-Cousins ones
+# -- in particular whether the masked entries it produces survive as masked
+# rather than as a fill value. See issue #680.
+
+# Center of the field the remote tests calibrate against: the north galactic
+# pole. The field matters more than it looks. `transform_to_catalog` searches
+# a hardcoded one degree around the first observation and
+# `CatalogData.from_vizier` asks for every row in that cone, so the test pulls
+# a full degree-radius catalog however small a field it builds observations
+# from -- see issue #686. At the galactic pole that cone holds as few stars as
+# any patch of sky does, which is what keeps the query to something Vizier
+# will answer in reasonable time.
+_REMOTE_FIELD_CENTER = SkyCoord(ra=192.85948 * u.degree, dec=27.12825 * u.degree)
+
+# Radius of the separate, small query that supplies the stars the fake
+# observations are built from. Deliberately far smaller than the one degree
+# above: the point is to observe a handful of real stars near the center, not
+# to reproduce the query under test.
+_REMOTE_OBSERVED_RADIUS = 10 * u.arcmin
+
+# Zero point the fake observations are built with, and the scatter added to
+# them. The scatter keeps the fit from being exactly degenerate and gives
+# `fit_redchi` and the covariance something to describe; the zero point is
+# inside the default expected range for z, so a healthy fit warns about
+# nothing.
+_REMOTE_ZERO_POINT = 20.0
+_REMOTE_SCATTER = 0.005
+
+# Range of catalog magnitude the observations are built from. The lower end
+# keeps every instrumental magnitude inside the -20 to -3 window the fit
+# accepts, and the span is wide enough that the terms of the transform can be
+# told apart from each other -- real stars' colors correlate with their
+# magnitudes, so a narrow range is how a fit to a real field goes degenerate.
+_REMOTE_MAG_RANGE = (10.5, 16.5)
+
+# Most stars the query returns are thrown away, evenly, to keep the fit quick
+# without narrowing the magnitude range sampling every Nth row preserves.
+_REMOTE_MAX_STARS = 150
+
+# Fewest stars, and fewest calibrated magnitudes, worth calling a result.
+_REMOTE_MIN_STARS = 20
+
+# The passbands and band transform each catalog is fetched with, mirroring
+# what `transform_to_catalog` asks for. Both native and transformed bands have
+# to be requested: `passband_columns` needs the native ones to transform from.
+_REMOTE_CATALOGS = {
+    "apass_dr9": (
+        apass_dr9,
+        ["B", "V", "R", "I", "SR", "SG", "SI"],
+        transform_apass_bands,
+    ),
+    "refcat2": (refcat2, ["B", "V", "R", "I"], transform_refcat2_bands),
+}
+
+# `ValueError` is in SERVER_DOWN_ERRORS, because the GAIA aperture service
+# reports failure that way, but `transform_to_catalog` also raises it for its
+# own reasons -- so xfailing on it around the call under test would turn a
+# real failure into a pass. The query inside that call is the only part that
+# can find the server down, and it cannot fail with a ValueError.
+_QUERY_DOWN_ERRORS = tuple(
+    error for error in SERVER_DOWN_ERRORS if error is not ValueError
+)
+
+
+@pytest.mark.remote_data
+@pytest.mark.parametrize("cat_name", sorted(_REMOTE_CATALOGS))
+def test_transform_to_catalog_against_a_real_catalog(cat_name):
+    fetch, passbands, transformer = _REMOTE_CATALOGS[cat_name]
+
+    try:
+        nearby = fetch(
+            _REMOTE_FIELD_CENTER,
+            radius=_REMOTE_OBSERVED_RADIUS,
+            clip_by_frame=False,
+            padding=0,
+        )
+    except SERVER_DOWN_ERRORS as e:
+        pytest.xfail(f"Vizier is down or misbehaving: {e}")
+
+    stars = nearby.passband_columns(passbands=passbands, transformer=transformer)
+
+    catalog_mag = np.ma.filled(np.ma.asarray(stars["mag_R"], dtype=float), np.nan)
+    no_catalog_mag = ~np.isfinite(catalog_mag)
+
+    # Stars the catalog has no R magnitude for are kept on purpose -- they are
+    # what this test exists to check -- and so are stars over a range of
+    # magnitude wide enough to fit.
+    in_range = (catalog_mag >= _REMOTE_MAG_RANGE[0]) & (
+        catalog_mag <= _REMOTE_MAG_RANGE[1]
+    )
+    stars = stars[in_range | no_catalog_mag]
+    if len(stars) > _REMOTE_MAX_STARS:
+        stars = stars[:: int(np.ceil(len(stars) / _REMOTE_MAX_STARS))]
+
+    catalog_mag = np.ma.filled(np.ma.asarray(stars["mag_R"], dtype=float), np.nan)
+    no_catalog_mag = ~np.isfinite(catalog_mag)
+
+    assert np.isfinite(catalog_mag).sum() >= _REMOTE_MIN_STARS, (
+        f"only {np.isfinite(catalog_mag).sum()} usable {cat_name} stars near "
+        f"{_REMOTE_FIELD_CENTER.to_string('hmsdms')}"
+    )
+
+    # A star with no catalog magnitude was still observed, so it needs an
+    # instrumental magnitude like any other; the middle of the field's range
+    # will do, since nothing here depends on its value.
+    instrumental = catalog_mag - _REMOTE_ZERO_POINT
+    instrumental[no_catalog_mag] = np.nanmedian(instrumental)
+
+    observed = _generate_observed_table(
+        u.Quantity(np.asarray(stars["ra"]), u.degree),
+        u.Quantity(np.asarray(stars["dec"]), u.degree),
+        instrumental,
+        noise_sigma=_REMOTE_SCATTER,
+        seed=680,
+    )
+
+    try:
+        # Neither catalog supplies an error for the Johnson-Cousins R it
+        # transforms into, which is the case issue #685 is about, so this
+        # logs a message about the band every time until that is fixed.
+        result = transform_to_catalog(
+            observed, "R", obs_error_column="mag_error", cat_name=cat_name
+        )
+    except _QUERY_DOWN_ERRORS as e:
+        pytest.xfail(f"Vizier is down or misbehaving: {e}")
+
+    calibrated = np.ma.getdata(result["mag_cal"])
+    finite = np.isfinite(calibrated)
+    assert finite.sum() >= _REMOTE_MIN_STARS
+
+    # The observations were built from the catalog's own magnitudes, so the
+    # fit should recover the zero point they were built with and give every
+    # star its catalog magnitude back.
+    assert result["z"][0] == pytest.approx(_REMOTE_ZERO_POINT, abs=0.5)
+
+    has_a_catalog_magnitude = finite & ~no_catalog_mag
+    recovered = np.abs(
+        calibrated[has_a_catalog_magnitude] - catalog_mag[has_a_catalog_magnitude]
+    )
+    # A percentile rather than a maximum: a real field contains variables and
+    # blends, and one star matched to the wrong catalog entry a degree-wide
+    # query turned up should not fail a test about the pipeline.
+    assert np.percentile(recovered, 90) < 0.05
+
+    # The fit's account of itself, which is only meaningful on data that
+    # scatters -- hence the noise added above.
+    for column in ("a_error", "c_error", "z_error", "fit_redchi"):
+        assert np.isfinite(result[column][0]), column
+        assert result[column][0] > 0, column
+
+    # The point of the whole test. A star the catalog has no magnitude for
+    # must come back with no magnitude, not with whatever the catalog's
+    # missing-value convention happens to be -- and it is only the real
+    # catalog and the real band transform that can say whether that survives.
+    if no_catalog_mag.any():
+        for column in ("mag_cal", "mag_cat"):
+            # np.ma.getdata rather than the column itself: `np.isnan` of a
+            # masked array is masked in turn, and `.all()` of that is True
+            # whatever the numbers underneath are -- exactly the check that
+            # passes when it should not.
+            missing = np.ma.getdata(result[column])[no_catalog_mag]
+            assert np.isnan(missing).all(), column
+            for fill_value in (-999, 1e20, 0.0):
+                assert not (missing == fill_value).any(), (column, fill_value)

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -18,6 +18,7 @@ from ..magnitude_system_transforms import (
     transform_refcat2_bands,
 )
 from ..magnitude_transforms import (
+    _to_float_array,
     calibrated_from_instrumental,
     filter_transform,
     transform_to_catalog,
@@ -297,11 +298,11 @@ def _generate_fake_catalog(
     return catalog, ra, dec, instrumental
 
 
-def _catalog_bands_renamed(catalog, **new_from_old):
+def _catalog_posing_as_bands(catalog, **new_from_old):
     """
     Copy a catalog's magnitudes under other passband names.
 
-    ``_catalog_bands_renamed(catalog, SR="R", SI="I")`` gives the catalog a
+    ``_catalog_posing_as_bands(catalog, SR="R", SI="I")`` gives the catalog a
     ``mag_SR`` column holding exactly what ``mag_R`` holds, along with the
     matching ``mag_error_SR``, so that a catalog built in R and I can stand in
     for one in any other pair of bands. Only the names change, so a fit
@@ -1007,7 +1008,10 @@ def test_transform_to_catalog_warns_when_the_catalog_has_no_error_for_the_band(
     # errors yet. The fit still runs, weighted by the observed errors alone,
     # and says which band it could not do better for. Issue #685 is the fix.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20, cat_error=None)
-    observed = _generate_observed_table(ra, dec, instrumental)
+    observed = _combine_observed_tables(
+        _generate_observed_table(ra, dec, instrumental, file_name="image_1.fit"),
+        _generate_observed_table(ra, dec, instrumental, file_name="image_2.fit"),
+    )
 
     with caplog.at_level(logging.WARNING, logger=_MAGNITUDE_TRANSFORMS_LOGGER):
         result = _run_transform_to_catalog(mocker, catalog, observed)
@@ -1019,15 +1023,22 @@ def test_transform_to_catalog_warns_when_the_catalog_has_no_error_for_the_band(
     # catalog, which is a fact about the call rather than about an image.
     assert len(about_the_band) == 1
 
-    np.testing.assert_allclose(result["mag_cal"], catalog["mag_R"], rtol=0, atol=1e-6)
+    # The result has one row per star per image, so repeat the catalog
+    # magnitudes for each image.
+    expected_mag = np.tile(catalog["mag_R"], 2)
+    np.testing.assert_allclose(result["mag_cal"], expected_mag, rtol=0, atol=1e-6)
 
 
 def test_transform_to_catalog_negligible_catalog_error_changes_nothing(mocker):
     # The other side of the fallback: adding catalog errors to the weighting
     # must not have moved the answer for anyone whose catalog errors are too
-    # small to matter. A catalog error 27 orders of magnitude below the
-    # observed one gives the same numbers as no catalog error column at all,
-    # bit for bit, which is only true if the two paths do the same arithmetic.
+    # small to matter. An extremely small catalog error -- one that is
+    # deliberately far below the observed errors -- allows
+    # ``np.hypot(err, 1e-30) == err`` to the last bit in float64, which is what
+    # makes exact bit-for-bit equality between the quadrature-weighted path and
+    # the observed-errors-only path a legitimate expectation. A plausible small
+    # catalog error would force tolerance-based comparison, which could not
+    # distinguish the two weighting code paths at all.
     n_stars = 20
     sigma = 0.02
 
@@ -1038,11 +1049,12 @@ def test_transform_to_catalog_negligible_catalog_error_changes_nothing(mocker):
         ra, dec, instrumental, noise_sigma=sigma, seed=13579
     )
 
-    negligible = _run_transform_to_catalog(mocker, catalog, observed)
+    negligible = _run_transform_to_catalog(mocker, catalog, observed, in_place=False)
 
     del catalog["mag_error_R"]
-    absent = _run_transform_to_catalog(mocker, catalog, observed)
+    absent = _run_transform_to_catalog(mocker, catalog, observed, in_place=False)
 
+    assert negligible is not absent
     for column in _TRANSFORM_OUTPUT_COLUMNS:
         np.testing.assert_array_equal(
             np.asarray(negligible[column]),
@@ -1051,46 +1063,66 @@ def test_transform_to_catalog_negligible_catalog_error_changes_nothing(mocker):
         )
 
 
-@pytest.mark.parametrize("case", ["masked", "zero", "negative"])
-def test_transform_to_catalog_excludes_unusable_catalog_errors(mocker, case):
-    # A catalog error of zero is an infinite weight, and a missing one makes
-    # the weight NaN, which poisons every residual in the image rather than
-    # just that star's. Both have to be handled the way an unusable observed
-    # error already is -- the star is left out of the fit -- rather than being
-    # left to reach the fitter. See issue #680.
+@pytest.mark.parametrize("case", ["masked", "zero", "negative", "nan"])
+def test_transform_to_catalog_treats_unusable_catalog_errors_as_observed_only(
+    mocker, case
+):
+    # A catalog error the fit cannot use -- masked, NaN, zero or negative --
+    # no longer drops the star from the fit. The catalog simply does not know
+    # its own uncertainty for that star, so the star is weighted by its
+    # observed error alone, exactly as an APASS star with a single, zero-error
+    # observation was before catalog-error weighting existed. See issue #680.
     n_stars = 20
     sigma = 1e-4
 
-    # Every star's catalog magnitude is poorly known, so that a star whose
-    # error is unusable would dominate the fit if it were let in.
+    # Every star's catalog magnitude is poorly known, so that a star weighted
+    # by its catalog error would be pulled off the true zero point if the
+    # substitution below were not happening.
     catalog, ra, dec, instrumental = _generate_fake_catalog(n_stars, cat_error=0.5)
 
     observed_mags = instrumental.copy()
     observed_mags[0] -= 0.8
 
-    match case:
-        case "masked":
-            catalog["mag_error_R"] = np.ma.masked_array(
-                catalog["mag_error_R"], mask=np.arange(n_stars) == 0
-            )
-        case "zero":
-            catalog["mag_error_R"][0] = 0.0
-        case "negative":
-            catalog["mag_error_R"][0] = -0.02
-        case _:  # pragma: no cover
-            raise ValueError(f"Unknown case {case!r}")
-
     observed = _generate_observed_table(
         ra, dec, observed_mags, noise_sigma=sigma, seed=8811, mag_error=0.01
     )
 
-    result = _run_transform_to_catalog(mocker, catalog, observed)
+    unusable_catalog = catalog.copy()
+    match case:
+        case "masked":
+            unusable_catalog["mag_error_R"] = np.ma.masked_array(
+                unusable_catalog["mag_error_R"], mask=np.arange(n_stars) == 0
+            )
+        case "zero":
+            unusable_catalog["mag_error_R"][0] = 0.0
+        case "negative":
+            unusable_catalog["mag_error_R"][0] = -0.02
+        case "nan":
+            unusable_catalog["mag_error_R"][0] = np.nan
+        case _:  # pragma: no cover
+            raise ValueError(f"Unknown case {case!r}")
 
-    np.testing.assert_allclose(result["z"], _FAKE_CATALOG_ZERO_POINT, rtol=0, atol=1e-2)
+    treated_as_unusable = _run_transform_to_catalog(
+        mocker, unusable_catalog, observed, in_place=False
+    )
 
-    # The star is only kept out of the *fit*. Its own measurement is fine, so
-    # it is still calibrated, like a star with a bad observed error is.
-    assert np.isfinite(result["mag_cal"][0])
+    # The reference run substitutes a catalog error so small that
+    # ``np.hypot(obs_err, 1e-30) == obs_err`` to the last bit in float64 --
+    # see `test_transform_to_catalog_negligible_catalog_error_changes_nothing`
+    # for why that makes exact equality a legitimate expectation here rather
+    # than an approximate one.
+    reference_catalog = catalog.copy()
+    reference_catalog["mag_error_R"][0] = 1e-30
+    reference = _run_transform_to_catalog(
+        mocker, reference_catalog, observed, in_place=False
+    )
+
+    for column in _TRANSFORM_OUTPUT_COLUMNS:
+        np.testing.assert_array_equal(
+            np.asarray(treated_as_unusable[column]),
+            np.asarray(reference[column]),
+            err_msg=column,
+        )
 
 
 def test_transform_to_catalog_reports_coefficient_uncertainties(_noisy_fit_result):
@@ -2111,30 +2143,39 @@ def test_transform_to_catalog_passband_not_in_table_raises(mocker):
         )
 
 
-def test_transform_to_catalog_mismatched_passbands_raise(mocker):
-    # Calibrating V observations against the catalog's B is not a transform,
-    # it is a color error dressed up as one: the B - V of every star lands in
-    # the fit, comes back as a zero point and a color term, and is then
-    # applied to every star in the image. Nobody means to ask for that, so it
-    # is a mistake rather than an option. See issue #680.
+def test_transform_to_catalog_mismatched_passbands_warns_and_proceeds(mocker):
+    # Calibrating V observations against the catalog's B folds the B - V of
+    # every star into the fit, which comes back as a zero point and a color
+    # term and is then applied to every star in the image. That is exactly
+    # what unfiltered and DSLR observations -- AAVSO's CV and TG -- need,
+    # because there is no observed V to match against instead, so naming a
+    # different catalog band explicitly is taken as deliberate rather than
+    # rejected. The contamination it can cause is the warning's job to flag,
+    # not the function's job to prevent. See issue #680.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    _catalog_bands_renamed(catalog, V="R", B="I")
+    _catalog_posing_as_bands(catalog, V="R", B="I")
     observed = _generate_observed_table(ra, dec, instrumental, passband="V")
 
-    with pytest.raises(ValueError, match="passband 'V'.*passband 'B'"):
-        _run_transform_to_catalog(
+    with pytest.warns(AstropyUserWarning, match="passband 'V'.*passband 'B'"):
+        result = _run_transform_to_catalog(
             mocker, catalog, observed, obs_filter="V", cat_filter="B"
         )
 
+    # The fit proceeds and calibrates against the named catalog band.
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_B"], rtol=0, atol=1e-6)
 
-@pytest.mark.parametrize("cat_filter", ["R", "RC", "Rc"])
+
+@pytest.mark.parametrize("cat_filter", ["R", "RC", "Rc", "rc"])
 def test_transform_to_catalog_accepts_equivalent_passband_names(mocker, cat_filter):
     # The half that keeps the check above from being over-eager. Cousins R is
     # written several ways, and refcat2's band transform really does add
     # mag_R and mag_RC as copies of one column, so R against RC is one band
-    # spelled two ways rather than two bands.
+    # spelled two ways rather than two bands. Canonicalization is
+    # case-insensitive, which is what "rc" exercises here. Because this suite
+    # turns warnings into errors, a passing call already proves the mismatch
+    # warning above was not raised for any of these spellings.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    _catalog_bands_renamed(catalog, RC="R", Rc="R")
+    _catalog_posing_as_bands(catalog, RC="R", Rc="R")
     observed = _generate_observed_table(ra, dec, instrumental)
 
     result = _run_transform_to_catalog(mocker, catalog, observed, cat_filter=cat_filter)
@@ -2146,9 +2187,11 @@ def test_transform_to_catalog_unknown_default_color_raises(mocker):
     # The color that goes with a band is a convention rather than something
     # derivable, so a band with no convention recorded has to be asked about
     # instead of guessed at -- a wrong guess would name a column that is not
-    # there, and the KeyError that follows says nothing about what to do.
+    # there, and the KeyError that follows says nothing about what to do. This
+    # only bites when a color term is actually being fit, which is what the
+    # default ``vary`` does.
     catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    _catalog_bands_renamed(catalog, TG="R")
+    _catalog_posing_as_bands(catalog, TG="R")
     observed = _generate_observed_table(ra, dec, instrumental, passband="TG")
 
     with pytest.raises(ValueError, match="cat_color must be given"):
@@ -2159,6 +2202,23 @@ def test_transform_to_catalog_unknown_default_color_raises(mocker):
         mocker, catalog, observed, obs_filter="TG", cat_color=("R", "I")
     )
     np.testing.assert_allclose(result["mag_cal"], catalog["mag_TG"], rtol=0, atol=1e-6)
+
+
+def test_transform_to_catalog_unknown_default_color_runs_without_color_term(mocker):
+    # The other side of the test above: with no color term in ``vary``, the
+    # model never needs a color, so a band with no conventional color does
+    # not have to raise -- it can only leave ``color_cat`` unknown, which is
+    # what it already is for a star the catalog has no color for.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    _catalog_posing_as_bands(catalog, TG="R")
+    observed = _generate_observed_table(ra, dec, instrumental, passband="TG")
+
+    result = _run_transform_to_catalog(
+        mocker, catalog, observed, obs_filter="TG", vary=("a", "z")
+    )
+
+    np.testing.assert_allclose(result["mag_cal"], catalog["mag_TG"], rtol=0, atol=1e-6)
+    assert np.isnan(result["color_cat"]).all()
 
 
 def test_transform_to_catalog_skips_image_without_the_passband(mocker):
@@ -2487,7 +2547,7 @@ def test_transform_to_catalog_default_catalog_columns(mocker, band, color):
     # for the other half of the color pair. Which half that is depends on the
     # band: V is the second of B - V and R is the first of R - I.
     other = color[0] if color[1] == band else color[1]
-    _catalog_bands_renamed(catalog, **{band: "R", other: "I"})
+    _catalog_posing_as_bands(catalog, **{band: "R", other: "I"})
 
     observed = _generate_observed_table(ra, dec, instrumental, passband=band)
 
@@ -2530,7 +2590,7 @@ def test_transform_to_catalog_accepts_photometry_data(mocker):
     # against catalog R, exactly the mistake #680 makes an error. Renaming the
     # synthetic catalog's bands is enough: nothing here depends on the
     # magnitudes being real ones.
-    _catalog_bands_renamed(catalog, SR="R", SI="I")
+    _catalog_posing_as_bands(catalog, SR="R", SI="I")
 
     # Real photometry has gaps in it -- stars that fell off the chip, or were
     # too faint to measure -- so keep some here.
@@ -2568,6 +2628,67 @@ def test_transform_to_catalog_non_numeric_existing_column_raises(mocker):
 
     with pytest.raises(ValueError, match="'mag_cal' is already in the table"):
         _run_transform_to_catalog(mocker, catalog, observed)
+
+
+def test_transform_to_catalog_records_weighting_mode_in_meta(mocker):
+    # Which errors were available to weight the fit by is a fact about the
+    # call, not about any one star, so it belongs in the table's meta rather
+    # than in a per-row column -- a caller reading mag_cal_error still needs
+    # to know whether it is backed by the catalog's own uncertainty or by the
+    # observed error alone.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed, in_place=False)
+    assert result.meta["transform_weighting"]["R"] == "combined"
+
+    del catalog["mag_error_R"]
+    result = _run_transform_to_catalog(mocker, catalog, observed, in_place=False)
+    assert result.meta["transform_weighting"]["R"] == "observed"
+
+    with pytest.warns(AstropyUserWarning, match="rror weighting"):
+        result = _run_transform_to_catalog(
+            mocker, catalog, observed, obs_error_column=None, in_place=False
+        )
+    assert result.meta["transform_weighting"]["R"] == "unweighted"
+
+
+def test_transform_to_catalog_weighting_meta_keeps_earlier_passbands(mocker):
+    # transform_to_catalog is called once per passband on the same table, so a
+    # flat key in meta would be overwritten by the second call. Keying by
+    # obs_filter, exactly as the caller passed it, is what keeps both calls'
+    # entries alive.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _two_passband_observations(ra, dec, instrumental)
+
+    result = _run_transform_to_catalog(mocker, catalog, observed, obs_filter="R")
+    result = _run_transform_to_catalog(
+        mocker, catalog, result, obs_filter="I", cat_filter="I"
+    )
+
+    assert result.meta["transform_weighting"] == {"R": "combined", "I": "combined"}
+
+
+def test_transform_to_catalog_missing_catalog_band_raises_clean_error(mocker):
+    # Asking for a band the catalog cannot supply used to pass every argument
+    # check, spend the Vizier round trip, and then die in a bare KeyError.
+    # The message should say plainly which band is missing and which ones the
+    # catalog actually has.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental, passband="V")
+
+    with pytest.warns(AstropyUserWarning, match="passband 'V'.*passband 'U'"):
+        with pytest.raises(ValueError, match=r"'U'.*'I', 'R'") as exc_info:
+            _run_transform_to_catalog(
+                mocker,
+                catalog,
+                observed,
+                obs_filter="V",
+                cat_filter="U",
+                cat_color=("R", "I"),
+            )
+
+    assert not isinstance(exc_info.value, KeyError)
 
 
 # Everything below runs only with --remote-data, in the single tox coverage
@@ -2649,12 +2770,12 @@ def test_transform_to_catalog_against_a_real_catalog(cat_name):
             clip_by_frame=False,
             padding=0,
         )
-    except SERVER_DOWN_ERRORS as e:
+    except _QUERY_DOWN_ERRORS as e:
         pytest.xfail(f"Vizier is down or misbehaving: {e}")
 
     stars = nearby.passband_columns(passbands=passbands, transformer=transformer)
 
-    catalog_mag = np.ma.filled(np.ma.asarray(stars["mag_R"], dtype=float), np.nan)
+    catalog_mag = _to_float_array(stars["mag_R"])
     no_catalog_mag = ~np.isfinite(catalog_mag)
 
     # Stars the catalog has no R magnitude for are kept on purpose -- they are
@@ -2667,8 +2788,22 @@ def test_transform_to_catalog_against_a_real_catalog(cat_name):
     if len(stars) > _REMOTE_MAX_STARS:
         stars = stars[:: int(np.ceil(len(stars) / _REMOTE_MAX_STARS))]
 
-    catalog_mag = np.ma.filled(np.ma.asarray(stars["mag_R"], dtype=float), np.nan)
+    catalog_mag = _to_float_array(stars["mag_R"])
     no_catalog_mag = ~np.isfinite(catalog_mag)
+
+    # Only apass_dr9 is required to have stars with no R magnitude: its native
+    # bands really are missing for some stars, and those stars are what the
+    # masked-row checks at the bottom exist for. refcat2's R is transformed
+    # from Sloan bands the catalog is essentially complete in, so this field
+    # -- and perhaps any field -- has no refcat2 star without one; the checks
+    # below then check nothing rather than failing a premise the catalog
+    # cannot meet.
+    if cat_name == "apass_dr9":
+        assert no_catalog_mag.any(), (
+            "No stars with missing catalog magnitudes in the selected field. "
+            "Either the band transform stopped producing masked catalog "
+            "entries or the test field needs re-choosing."
+        )
 
     assert np.isfinite(catalog_mag).sum() >= _REMOTE_MIN_STARS, (
         f"only {np.isfinite(catalog_mag).sum()} usable {cat_name} stars near "
@@ -2727,13 +2862,12 @@ def test_transform_to_catalog_against_a_real_catalog(cat_name):
     # must come back with no magnitude, not with whatever the catalog's
     # missing-value convention happens to be -- and it is only the real
     # catalog and the real band transform that can say whether that survives.
-    if no_catalog_mag.any():
-        for column in ("mag_cal", "mag_cat"):
-            # np.ma.getdata rather than the column itself: `np.isnan` of a
-            # masked array is masked in turn, and `.all()` of that is True
-            # whatever the numbers underneath are -- exactly the check that
-            # passes when it should not.
-            missing = np.ma.getdata(result[column])[no_catalog_mag]
-            assert np.isnan(missing).all(), column
-            for fill_value in (-999, 1e20, 0.0):
-                assert not (missing == fill_value).any(), (column, fill_value)
+    for column in ("mag_cal", "mag_cat"):
+        # np.ma.getdata rather than the column itself: `np.isnan` of a
+        # masked array is masked in turn, and `.all()` of that is True
+        # whatever the numbers underneath are -- exactly the check that
+        # passes when it should not.
+        missing = np.ma.getdata(result[column])[no_catalog_mag]
+        assert np.isnan(missing).all(), column
+        for fill_value in (-999, 1e20, 0.0):
+            assert not (missing == fill_value).any(), (column, fill_value)


### PR DESCRIPTION
Closes #680.

Stacked on #682, #683, #684 and #687 — please merge those first; this branch
contains their commits.

Three things #680 asked for.

### (a) A mismatched passband pair is always a mistake, so raise

Calibrating an SR observation against a Cousins R catalog magnitude is not a
judgement call, it is a bug — and nothing stopped it. `transform_to_catalog` now
raises `ValueError` naming both bands, with `R`/`RC`/`Rc` and `I`/`IC`/`Ic`
treated as the same band, so the check is not over-eager about spelling.

The check sits **immediately after** the existing "No rows with passband" check.
That ordering is deliberate: it keeps `..._passband_not_in_table_raises` getting
the error it expects, and validating the table before commenting on the
arguments is the better order anyway.

`cat_filter` and `cat_color` now default to `None` rather than to `"R"` and
`("R", "I")`. Leaving the literal would have turned every call that omits
`cat_filter` for a non-R band into a hard error — a gratuitous break.
`cat_filter` resolves to `obs_filter`, and `cat_color` to that band's
conventional pair (U→U−B, B/V→B−V, R/I→R−I, SG→SG−SR, SR/SI→SR−SI, …). A band
with no conventional pair raises and asks for `cat_color`, rather than dying on
a `KeyError` for a missing column.

One existing test was doing the mistaken thing: `..._accepts_photometry_data`
calibrated `obs_filter="SR"` against `cat_filter="R"`. Sloan r′ and Cousins R
genuinely are different bands, so that is fixed rather than suppressed.

### (b) Weighting, not a magnitude cut

#676 removed `faintest_mag_for_transform` and left nothing in its place. The
replacement is to weight the fit by `1/√(obs_error² + cat_error²)` — a faint
star with a large catalog error contributes less, without a cliff edge at an
arbitrary magnitude.

The catch, and the reason this warns: `CatalogData.passband_columns` emits
`mag_error_<band>` only for a catalog's *native* passbands.
`transform_apass_bands` / `transform_refcat2_bands` add Johnson–Cousins `mag_R`
and `mag_I` afterwards and return no errors. So the combined weighting works for
APASS's B, V, SG, SR, SI and **not** for R and I — the default and the shipped
notebook's main use. That path falls back to the observed errors alone and warns
once per call naming the band, citing #685, which is the follow-up for teaching
the band transformers to propagate errors.

A missing or non-positive catalog error is excluded from the fit, the same way a
bad observed error already was, rather than becoming an infinite weight.

### (c) End-to-end against real catalogs

`remote_data` tests against APASS DR9 and refcat2 — the first time this function
has been exercised against a catalog it did not build itself. They run only in
the single `tox -e coverage -- --remote-data=any` job.

The point of them is the masked-row check: a real catalog has rows with no
magnitude, and those must come back NaN in `mag_cal` and `mag_cat` — **and not
as any of the usual fill values** (`-999`, `1e20`, `0.0`), because `np.isnan` on
a filled column is exactly the check that would silently pass.

Field choice mattered more than it looks. `transform_to_catalog` hardcodes
`radius=1 * u.degree` and `from_vizier` uses `row_limit=-1` (filed as #686), so
the test pulls a full degree-radius cone however small a field it asks for.
Hence the north galactic pole, where that cone is survivable, with a comment
saying so.

### Notes for review

- **These two tests are unrun.** There is no network in the environment they
  were written in. The body was dry-run against a synthetic masked catalog, so
  the array logic, masked-row assertions and `pytest.warns` all execute — what
  is unverified is the real query, the real band transform, and the field's
  actual star counts. Worth eyeballing the first live run.
- The masked-row block is guarded by `if no_catalog_mag.any()`, so it cannot
  fail if the field has no masked rows — but that also means the headline check
  silently does nothing in that case.
- `ValueError` is in `SERVER_DOWN_ERRORS`, so the tests deliberately narrow the
  exception set around the `transform_to_catalog` call; a real failure cannot be
  xfailed away.
- The synthetic test catalog now carries `mag_error_R`/`mag_error_I` by default.
  That was the honest fix for ~60 tests rather than blanket `pytest.warns` — a
  real catalog does supply errors for bands it measured — and no numeric
  expectation moved, because `scale_covar=True` makes a uniform catalog error
  invisible in every reported uncertainty.
- **Behaviour change for existing users:** passing `cat_filter` for a different
  band than `obs_filter` is now a hard error. The shipped notebook passes the
  same band for both, so it is unaffected.

---

*This PR description was written by Claude at @mwcraig's direction.*
