### PR TITLE
Believe the quoted weights in the transit fit's uncertainties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,12 @@ Other Changes and Additions
   time. It no longer passes ``cat_filter`` and ``cat_color``, which
   ``transform_to_catalog`` now works out for itself, and its unused imports
   have been dropped. [#677, #680]
++ ``TransitModelFit`` now follows the same convention: a weighted fit's
+  ``stderr`` values believe the quoted errors rather than being rescaled
+  to a reduced chi-square of one, and the new ``fit_redchi`` and
+  ``fit_excess_scatter`` attributes report the mismatch instead. The
+  diagnostics both fits share live in the new
+  ``stellarphot.utils.fit_diagnostics`` module. [#699]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,11 +147,11 @@ Other Changes and Additions
   time. It no longer passes ``cat_filter`` and ``cat_color``, which
   ``transform_to_catalog`` now works out for itself, and its unused imports
   have been dropped. [#677, #680]
-+ ``TransitModelFit`` now follows the same convention: a weighted fit's
-  ``stderr`` values believe the quoted errors rather than being rescaled
-  to a reduced chi-square of one, and the new ``fit_redchi`` and
-  ``fit_excess_scatter`` attributes report the mismatch instead. The
-  diagnostics both fits share live in the new
++ ``TransitModelFit`` now follows the convention #690 adopted for
+  ``transform_to_catalog``: a weighted fit's ``stderr`` values believe the
+  quoted errors rather than being rescaled to a reduced chi-square of one,
+  and the new ``fit_redchi`` and ``fit_excess_scatter`` attributes report
+  the mismatch instead. The diagnostics both fits share live in the new
   ``stellarphot.utils.fit_diagnostics`` module. [#699]
 
 Bug Fixes

--- a/docs/stellarphot/api_reference.rst
+++ b/docs/stellarphot/api_reference.rst
@@ -21,3 +21,4 @@ All of the classes and functions defined in `stellarphot` are listed below, grou
 .. automodapi:: stellarphot.transit_fitting.io
 .. automodapi:: stellarphot.transit_fitting.plotting
 .. automodapi:: stellarphot.utils
+.. automodapi:: stellarphot.utils.fit_diagnostics

--- a/pixi.lock
+++ b/pixi.lock
@@ -225,6 +225,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/c4/71cf2bd4374cc17e015413462be8051fe08bc49e077b7d48072fff4e465d/astropy_healpix-2.0.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -521,6 +522,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
@@ -815,6 +817,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/34/074f367d5699a1008b24c50acc1539f05f2cfc881b1901f4b110d57eae20/astropy-8.0.1-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
@@ -1104,6 +1107,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a3/2e/235b4d96619931192c91660805e5e49242389742a7a82c27665021db690c/numpy-2.3.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
@@ -3038,6 +3042,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/71cf2bd4374cc17e015413462be8051fe08bc49e077b7d48072fff4e465d/astropy_healpix-2.0.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
@@ -3195,6 +3200,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/80/69a84af0b35d55a859cde38e16b71553840a156bdf7dc4b767ec2b2d2829/astropy-8.0.1-cp311-abi3-macosx_10_9_x86_64.whl
@@ -3348,6 +3354,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/34/074f367d5699a1008b24c50acc1539f05f2cfc881b1901f4b110d57eae20/astropy-8.0.1-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
@@ -3502,6 +3509,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/2e/235b4d96619931192c91660805e5e49242389742a7a82c27665021db690c/numpy-2.3.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
@@ -10683,6 +10691,7 @@ packages:
   - ipyfilechooser ; extra == 'all'
   - ipywidgets ; extra == 'all'
   - jupyter-app-launcher>=0.3.0 ; extra == 'all'
+  - mako ; extra == 'all'
   - papermill ; extra == 'all'
   - pytransit ; extra == 'all'
   - astro-image-display-api>=0.3.0 ; extra == 'docs'
@@ -10700,6 +10709,7 @@ packages:
   - sphinx-astropy[confv2] ; extra == 'docs'
   - sphinx-design ; extra == 'docs'
   - sphinxcontrib-mermaid ; extra == 'docs'
+  - mako ; extra == 'exoplanet'
   - pytransit ; extra == 'exoplanet'
   - astro-image-display-api>=0.3.0 ; extra == 'gui'
   - astrowidgets>=0.6 ; extra == 'gui'
@@ -19160,6 +19170,16 @@ packages:
   version: 2026.6.3
   sha256: 3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+  name: mako
+  version: 1.4.1
+  sha256: a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617
+  requires_dist:
+  - markupsafe>=2.0
+  - pytest ; extra == 'testing'
+  - babel ; extra == 'babel'
+  - lingua>=4.16 ; extra == 'lingua'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
   name: mdit-py-plugins
   version: 0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ gui = [
 exoplanet = [
     "pytransit",  # lmfit, the other half of the transit fitter, is a core
                   # dependency because the magnitude transform needs it too
+    "mako",  # pyopencl >= 2026.1.3, which pytransit imports, imports mako at
+             # module level but only lists it under its own test extra
 ]
 # Everything a user needs for the full interactive experience.
 all = [

--- a/stellarphot/notebooks/tess-initial-model-fit.ipynb
+++ b/stellarphot/notebooks/tess-initial-model-fit.ipynb
@@ -327,6 +327,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The uncertainties above are measured against the flux errors as quoted (`weights = 1 / error`); they are not rescaled to make the reduced chi-square come out one. Check whether those errors describe the data: `mod.fit_redchi` well above one, or `mod.fit_excess_scatter` comparable to the errors, means the quoted errors -- and so the `stderr` values above -- are too small."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Compare detrending options by BIC\n",
     "\n",

--- a/stellarphot/notebooks/tess-second-model-fit.ipynb
+++ b/stellarphot/notebooks/tess-second-model-fit.ipynb
@@ -320,6 +320,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The uncertainties above are measured against the flux errors as quoted (`weights = 1 / error`); they are not rescaled to make the reduced chi-square come out one. Check whether those errors describe the data: `mod.fit_redchi` well above one, or `mod.fit_excess_scatter` comparable to the errors, means the quoted errors -- and so the `stderr` values above -- are too small."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Model fit with binning"
    ]
   },

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -5,6 +5,8 @@ from astropy import units as u
 from astropy.table import Table
 from pydantic import BaseModel
 
+from ..utils.fit_diagnostics import excess_scatter
+
 try:
     from pytransit import RoadRunnerModel
 except ImportError:  # pragma: no cover
@@ -98,6 +100,19 @@ class TransitModelFit:
         Result of the most recent call to ``fit``, including fit statistics
         like ``bic`` and ``nvarys``. ``None`` until ``fit`` has been run.
 
+    fit_redchi : float or None
+        Reduced chi-square of the most recent fit: the summed squared
+        residuals per degree of freedom, in units of the quoted errors when
+        ``weights`` are set and in flux units squared otherwise. ``None``
+        until ``fit`` has been run.
+
+    fit_excess_scatter : float or None
+        Scatter, in the units of ``data``, that would have to be added in
+        quadrature to every point's quoted error to bring ``fit_redchi`` to
+        one; zero when the residuals are already no larger than the errors
+        claim, and NaN for an unweighted fit. ``None`` until ``fit`` has
+        been run.
+
     times, airmass, width, spp, data, weights : array-like or None
         Independent variables and data for the fit; see the property
         docstrings.
@@ -111,6 +126,17 @@ class TransitModelFit:
     set. Enable them via `TransitModelOptions`, directly (e.g.
     ``mod.params["airmass_trend"].vary = True``) or with
     ``compare_detrend_options(apply_best=True)``.
+
+    The parameter uncertainties of a weighted fit are measured against the
+    flux errors as quoted (``weights = 1 / error``): lmfit's default of
+    rescaling the covariance so that the reduced chi-square comes out one
+    is turned off, as it is in
+    `~stellarphot.utils.magnitude_transforms.transform_to_catalog` (issues
+    #690 and #699). Errors quoted ten times too small therefore give
+    ``stderr`` values ten times too small -- and a ``fit_redchi`` near 100
+    and a ``fit_excess_scatter`` near the real noise to say so. An
+    unweighted fit keeps the rescaling, since it has no quoted errors and
+    the residuals are then its only estimate of the noise.
 
     Examples
     --------
@@ -128,6 +154,11 @@ class TransitModelFit:
 
         print(mod.params["rp"].value, mod.params["rp"].stderr)
         print(result.bic)
+
+        # Do the flux errors describe the data? A reduced chi-square well
+        # above one, and an excess scatter comparable to the errors, say
+        # they are too small -- and so are the stderr values above.
+        print(mod.fit_redchi, mod.fit_excess_scatter)
 
         # Which detrending parameters does the BIC favor?
         bic_table = mod.compare_detrend_options()
@@ -160,6 +191,8 @@ class TransitModelFit:
         self.weights = None
         self.params = _default_params()
         self.fit_result = None
+        self.fit_redchi = None
+        self.fit_excess_scatter = None
         self._detrend_parameters = set()
         self._all_detrend_params = ["airmass", "width", "spp"]
 
@@ -331,10 +364,22 @@ class TransitModelFit:
         # handles a starting value that sits exactly on a bound (the default
         # inclination of 90 degrees is on its upper bound); MINPACK leastsq
         # does not.
+        #
+        # The stderr of a weighted fit is taken at face value rather than
+        # rescaled so that its reduced chi-square is one: lmfit's default
+        # ``scale_covar=True`` would make that rescaling silently, and so
+        # erase the one statistic that shows whether the quoted flux errors
+        # describe the data. A mismatch is reported in ``fit_redchi`` and
+        # ``fit_excess_scatter`` instead, the same convention as
+        # ``transform_to_catalog`` (issues #690 and #699). An unweighted fit
+        # has no quoted errors to believe, so the rescaling stays on there,
+        # with redchi -- in flux units squared -- as the one estimate of the
+        # noise available.
         return lmfit.minimize(
             self._residual,
             params,
             method="least_squares",
+            scale_covar=self.weights is None,
             args=(
                 covariates["airmass"],
                 covariates["width"],
@@ -491,7 +536,16 @@ class TransitModelFit:
         ------
         ValueError
             If the times or the data have not been set. If the fit itself
-            raises, ``params`` and ``fit_result`` are left untouched.
+            raises, ``params``, ``fit_result``, ``fit_redchi`` and
+            ``fit_excess_scatter`` are left untouched.
+
+        Notes
+        -----
+        When ``weights`` are set, the uncertainties written to ``params`` are
+        measured against the errors as quoted, not rescaled to force the
+        reduced chi-square to one (lmfit's ``scale_covar`` is off). Whether
+        the quoted errors describe the data is reported instead, in
+        ``fit_redchi`` and ``fit_excess_scatter``; see the class docstring.
         """
         if self.times is None:
             raise ValueError("The times must be set before trying to fit.")
@@ -500,7 +554,18 @@ class TransitModelFit:
 
         result = self._run_fit(self.params)
 
+        # Every diagnostic is computed before any state is assigned, so a
+        # fit that raises leaves the instance exactly as it was.
+        if self.weights is None:
+            sigma = None
+        else:
+            sigma = 1 / np.asarray(self.weights, dtype=float)
+        redchi = result.redchi
+        excess = excess_scatter(result, sigma, self.weights, redchi_quoted=redchi)
+
         self.fit_result = result
+        self.fit_redchi = redchi
+        self.fit_excess_scatter = excess
 
         # Copy the best-fit values and uncertainties back into the user's
         # parameters without touching vary/min/max, so user choices (e.g. a

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.table import Table
 from pydantic import BaseModel
 
-from ..utils.fit_diagnostics import excess_scatter
+from ..utils.fit_diagnostics import excess_scatter, quoted_redchi
 
 try:
     from pytransit import RoadRunnerModel
@@ -112,6 +112,12 @@ class TransitModelFit:
         one; zero when the residuals are already no larger than the errors
         claim, and NaN for an unweighted fit. ``None`` until ``fit`` has
         been run.
+
+        Both attributes describe the most recent call to ``fit``.
+        ``compare_detrend_options()`` alone does not update them, since it
+        fits each candidate combination directly; called with
+        ``apply_best=True`` it does, because it finishes by calling ``fit``
+        on the winning combination.
 
     times, airmass, width, spp, data, weights : array-like or None
         Independent variables and data for the fit; see the property
@@ -549,8 +555,12 @@ class TransitModelFit:
         if self.weights is None:
             sigma = None
         else:
-            sigma = 1 / np.asarray(self.weights, dtype=float)
-        redchi = result.redchi
+            # A weight of zero -- lmfit's idiom for excluding a point -- maps
+            # to an infinite sigma here; quoted_redchi and excess_scatter
+            # both drop such points rather than dividing by that weight.
+            with np.errstate(divide="ignore"):
+                sigma = 1 / np.asarray(self.weights, dtype=float)
+        redchi = quoted_redchi(result, sigma, self.weights)
         excess = excess_scatter(result, sigma, self.weights, redchi_quoted=redchi)
 
         self.fit_result = result

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -365,16 +365,8 @@ class TransitModelFit:
         # inclination of 90 degrees is on its upper bound); MINPACK leastsq
         # does not.
         #
-        # The stderr of a weighted fit is taken at face value rather than
-        # rescaled so that its reduced chi-square is one: lmfit's default
-        # ``scale_covar=True`` would make that rescaling silently, and so
-        # erase the one statistic that shows whether the quoted flux errors
-        # describe the data. A mismatch is reported in ``fit_redchi`` and
-        # ``fit_excess_scatter`` instead, the same convention as
-        # ``transform_to_catalog`` (issues #690 and #699). An unweighted fit
-        # has no quoted errors to believe, so the rescaling stays on there,
-        # with redchi -- in flux units squared -- as the one estimate of the
-        # noise available.
+        # scale_covar is off for a weighted fit so that stderr believes the
+        # quoted errors; see the class Notes (issues #690 and #699).
         return lmfit.minimize(
             self._residual,
             params,
@@ -541,11 +533,9 @@ class TransitModelFit:
 
         Notes
         -----
-        When ``weights`` are set, the uncertainties written to ``params`` are
-        measured against the errors as quoted, not rescaled to force the
-        reduced chi-square to one (lmfit's ``scale_covar`` is off). Whether
-        the quoted errors describe the data is reported instead, in
-        ``fit_redchi`` and ``fit_excess_scatter``; see the class docstring.
+        The uncertainties written to ``params`` believe the quoted errors;
+        ``fit_redchi`` and ``fit_excess_scatter`` say whether the data does.
+        See the class Notes.
         """
         if self.times is None:
             raise ValueError("The times must be set before trying to fit.")

--- a/stellarphot/transit_fitting/core.py
+++ b/stellarphot/transit_fitting/core.py
@@ -536,12 +536,6 @@ class TransitModelFit:
             If the times or the data have not been set. If the fit itself
             raises, ``params``, ``fit_result``, ``fit_redchi`` and
             ``fit_excess_scatter`` are left untouched.
-
-        Notes
-        -----
-        The uncertainties written to ``params`` believe the quoted errors;
-        ``fit_redchi`` and ``fit_excess_scatter`` say whether the data does.
-        See the class Notes.
         """
         if self.times is None:
             raise ValueError("The times must be set before trying to fit.")
@@ -561,7 +555,7 @@ class TransitModelFit:
             with np.errstate(divide="ignore"):
                 sigma = 1 / np.asarray(self.weights, dtype=float)
         redchi = quoted_redchi(result, sigma, self.weights)
-        excess = excess_scatter(result, sigma, self.weights, redchi_quoted=redchi)
+        excess = excess_scatter(result, sigma, self.weights)
 
         self.fit_result = result
         self.fit_redchi = redchi

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -702,3 +702,70 @@ def test_failed_fit_leaves_state_untouched(monkeypatch):
     }
     assert params_before == params_after
     assert getattr(tmod, "fit_result", None) is fit_result_before
+
+
+# Noise in the fit-diagnostic tests below: large enough that a fit with
+# under-quoted weights is unambiguously far from its errors, small enough
+# that the fit still converges on the right transit.
+_DIAGNOSTIC_NOISE_DEV = 0.01
+
+
+def _fit_with_uniform_weights(quoted_error):
+    # A transit fit of the same noisy light curve, every point quoted with
+    # the same error -- ``None`` for an unweighted fit -- so the diagnostics
+    # tests differ only in what the points claim about themselves.
+    tmod = _make_transit_model_with_data(noise_dev=_DIAGNOSTIC_NOISE_DEV)
+    if quoted_error is not None:
+        tmod.weights = np.full(len(tmod.data), 1.0 / quoted_error)
+    tmod.fit()
+    return tmod
+
+
+def test_fit_stderr_believes_quoted_weights():
+    # With scale_covar off, stderr scales with the quoted error rather than
+    # being rescaled to whatever the residuals imply (issues #690 and #699):
+    # quoting errors ten times too small makes stderr ten times too small,
+    # and the reduced chi-square says so.
+    truthful = _fit_with_uniform_weights(_DIAGNOSTIC_NOISE_DEV)
+    underquoted = _fit_with_uniform_weights(_DIAGNOSTIC_NOISE_DEV / 10)
+
+    # Loose enough to cover the two fits converging along slightly
+    # different paths, far tighter than the factor of ten at stake.
+    assert underquoted.params["rp"].stderr == pytest.approx(
+        0.1 * truthful.params["rp"].stderr, rel=1e-2
+    )
+    assert underquoted.fit_redchi == pytest.approx(100, rel=0.3)
+
+
+def test_fit_reports_excess_scatter():
+    quoted_error = 0.002
+    underquoted = _fit_with_uniform_weights(quoted_error)
+    truthful = _fit_with_uniform_weights(_DIAGNOSTIC_NOISE_DEV)
+
+    expected_excess = np.sqrt(_DIAGNOSTIC_NOISE_DEV**2 - quoted_error**2)
+    assert underquoted.fit_excess_scatter == pytest.approx(expected_excess, rel=0.15)
+    assert truthful.fit_excess_scatter == 0.0
+
+
+def test_fit_diagnostics_for_an_unweighted_fit():
+    # Without weights there are no errors to be excessive with respect to,
+    # and lmfit's redchi (in flux units squared) is reported as is. The
+    # covariance is then still scaled by redchi -- the only estimate of the
+    # noise available -- so stderr is what a fit quoting the true noise
+    # would give, times the square root of that fit's reduced chi-square,
+    # which is how far the realized noise of this seed sits from nominal.
+    unweighted = _fit_with_uniform_weights(None)
+    truthful = _fit_with_uniform_weights(_DIAGNOSTIC_NOISE_DEV)
+
+    assert np.isnan(unweighted.fit_excess_scatter)
+    assert unweighted.fit_redchi == unweighted.fit_result.redchi
+    assert unweighted.params["rp"].stderr == pytest.approx(
+        truthful.params["rp"].stderr * np.sqrt(truthful.fit_redchi), rel=1e-2
+    )
+
+
+def test_diagnostics_are_none_before_fit():
+    tmod = _make_transit_model_with_data(noise_dev=_DIAGNOSTIC_NOISE_DEV)
+
+    assert tmod.fit_redchi is None
+    assert tmod.fit_excess_scatter is None

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -4,7 +4,6 @@ from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 
 from stellarphot.transit_fitting import TransitModelFit
-from stellarphot.utils.fit_diagnostics import quoted_redchi
 
 pytest.importorskip("pytransit")
 pytest.importorskip("lmfit")
@@ -718,8 +717,8 @@ def _fit_with_uniform_weights(quoted_error, zero_weight_index=None):
     #
     # ``zero_weight_index`` zeroes one point's weight, lmfit's idiom for
     # excluding it -- exercising the fit-diagnostics' zero-weight handling
-    # (issue #702) in a real fit rather than only in the unit tests of
-    # `~stellarphot.utils.fit_diagnostics`.
+    # (caught in review of PR #702) in a real fit rather than only in the
+    # unit tests of `~stellarphot.utils.fit_diagnostics`.
     tmod = _make_transit_model_with_data(noise_dev=_DIAGNOSTIC_NOISE_DEV)
     if quoted_error is not None:
         weights = np.full(len(tmod.data), 1.0 / quoted_error)
@@ -781,10 +780,6 @@ def test_fit_succeeds_with_a_zero_weight_point():
 
     assert np.isfinite(tmod.fit_excess_scatter)
     assert tmod.fit_excess_scatter > 0.0
-
-    with np.errstate(divide="ignore"):
-        sigma = 1.0 / tmod.weights
-    assert tmod.fit_redchi == quoted_redchi(tmod.fit_result, sigma, tmod.weights)
 
 
 def test_diagnostics_are_none_before_fit():

--- a/stellarphot/transit_fitting/tests/test_transit_model_fit.py
+++ b/stellarphot/transit_fitting/tests/test_transit_model_fit.py
@@ -4,6 +4,7 @@ from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 
 from stellarphot.transit_fitting import TransitModelFit
+from stellarphot.utils.fit_diagnostics import quoted_redchi
 
 pytest.importorskip("pytransit")
 pytest.importorskip("lmfit")
@@ -710,13 +711,21 @@ def test_failed_fit_leaves_state_untouched(monkeypatch):
 _DIAGNOSTIC_NOISE_DEV = 0.01
 
 
-def _fit_with_uniform_weights(quoted_error):
+def _fit_with_uniform_weights(quoted_error, zero_weight_index=None):
     # A transit fit of the same noisy light curve, every point quoted with
     # the same error -- ``None`` for an unweighted fit -- so the diagnostics
     # tests differ only in what the points claim about themselves.
+    #
+    # ``zero_weight_index`` zeroes one point's weight, lmfit's idiom for
+    # excluding it -- exercising the fit-diagnostics' zero-weight handling
+    # (issue #702) in a real fit rather than only in the unit tests of
+    # `~stellarphot.utils.fit_diagnostics`.
     tmod = _make_transit_model_with_data(noise_dev=_DIAGNOSTIC_NOISE_DEV)
     if quoted_error is not None:
-        tmod.weights = np.full(len(tmod.data), 1.0 / quoted_error)
+        weights = np.full(len(tmod.data), 1.0 / quoted_error)
+        if zero_weight_index is not None:
+            weights[zero_weight_index] = 0.0
+        tmod.weights = weights
     tmod.fit()
     return tmod
 
@@ -762,6 +771,20 @@ def test_fit_diagnostics_for_an_unweighted_fit():
     assert unweighted.params["rp"].stderr == pytest.approx(
         truthful.params["rp"].stderr * np.sqrt(truthful.fit_redchi), rel=1e-2
     )
+
+
+def test_fit_succeeds_with_a_zero_weight_point():
+    # Under-quoted so redchi > 1, matching the branch of excess_scatter that
+    # actually calls brentq rather than the early zero return.
+    quoted_error = _DIAGNOSTIC_NOISE_DEV / 10
+    tmod = _fit_with_uniform_weights(quoted_error, zero_weight_index=0)
+
+    assert np.isfinite(tmod.fit_excess_scatter)
+    assert tmod.fit_excess_scatter > 0.0
+
+    with np.errstate(divide="ignore"):
+        sigma = 1.0 / tmod.weights
+    assert tmod.fit_redchi == quoted_redchi(tmod.fit_result, sigma, tmod.weights)
 
 
 def test_diagnostics_are_none_before_fit():

--- a/stellarphot/utils/fit_diagnostics.py
+++ b/stellarphot/utils/fit_diagnostics.py
@@ -3,15 +3,33 @@ Diagnostics of a weighted least-squares fit: how the residuals compare to the
 uncertainties the points were quoted with.
 
 Shared by `~stellarphot.utils.magnitude_transforms.transform_to_catalog` and
-`~stellarphot.transit_fitting.TransitModelFit`, both of which fit with
-``scale_covar=False`` (issues #690 and #699) and report these numbers instead
-of letting `lmfit` rescale the covariance to make the reduced chi-square one.
+`~stellarphot.transit_fitting.TransitModelFit`, both of which turn off the
+rescaling for a weighted fit (issues #690 and #699) and report these numbers
+instead of letting `lmfit` rescale the covariance to make the reduced
+chi-square one.
 """
 
 import numpy as np
 from scipy.optimize import brentq
 
 __all__ = ["excess_scatter", "quoted_redchi"]
+
+
+def _unweighted_residual(fit_result, sigma, weights):
+    """
+    Undo the weighting of ``fit_result.residual`` and drop zero-weight points.
+
+    A weight of zero is `lmfit`'s idiom for excluding a point: its weighted
+    residual is zero and its sigma (``1 / weight``) is infinite, so it would
+    divide out to ``0 / 0``. Those points contribute nothing to chi-square,
+    so they are dropped from the sums instead of divided by. ``weights`` may
+    be a scalar.
+    """
+    residual = np.asarray(fit_result.residual, dtype=float)
+    w = np.broadcast_to(np.asarray(weights, dtype=float), residual.shape)
+    good = w != 0
+    sigma = np.broadcast_to(np.asarray(sigma, dtype=float), w.shape)[good]
+    return residual[good] / w[good], sigma
 
 
 def quoted_redchi(fit_result, sigma, weights):
@@ -61,13 +79,17 @@ def quoted_redchi(fit_result, sigma, weights):
     if sigma is None:
         return fit_result.redchi
 
-    residual = np.asarray(fit_result.residual) / weights
+    residual, sigma = _unweighted_residual(fit_result, sigma, weights)
     # The same operand order as `excess_scatter`'s bracket function at zero
     # excess -- ``residual**2 / sigma**2``, not ``(residual / sigma)**2``.
     # The gate there compares this value to one, and a value that disagreed
     # with the bracket by one ULP around it could hand
     # `~scipy.optimize.brentq` two negative endpoints -- a `ValueError`.
-    return float(np.sum(residual**2 / sigma**2) / fit_result.nfree)
+    #
+    # Divide by max(1, nfree), matching lmfit's own redchi convention (its
+    # `_calculate_statistics`) so a fit with no degrees of freedom left
+    # reports chisqr rather than raising or returning inf.
+    return float(np.sum(residual**2 / sigma**2) / max(1, fit_result.nfree))
 
 
 def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
@@ -76,10 +98,11 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
 
     The value ``s`` at which adding ``s`` in quadrature to each point's
     uncertainty brings the reduced chi-square to one: how far the points sit
-    from the model over and above what they claim to be uncertain by. Real
-    contributors seen in it, in a magnitude transform, include flat-field
-    gradients and the catalog's own photometry, neither of which any
-    weighting scheme can fix; see issue #694.
+    from the model over and above what they claim to be uncertain by. In
+    `~stellarphot.utils.magnitude_transforms.transform_to_catalog`'s case,
+    real contributors seen in it include flat-field gradients and the
+    catalog's own photometry, neither of which any weighting scheme can fix;
+    see issue #694.
 
     Parameters
     ----------
@@ -105,9 +128,10 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
     Returns
     -------
     float
-        The excess scatter in magnitudes; zero when the residuals are already
-        no larger than the errors claim, and NaN for an unweighted fit, whose
-        residuals have no errors to be excessive with respect to.
+        The excess scatter, in the units of ``sigma``; zero when the
+        residuals are already no larger than the errors claim, and NaN for
+        an unweighted fit, whose residuals have no errors to be excessive
+        with respect to.
 
     Notes
     -----
@@ -150,7 +174,7 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
     # Undo the weighting: lmfit's residual is the model minus the data times
     # the weights, and what is needed here is the difference itself, so that
     # it can be divided by the sigmas as quoted rather than as floored.
-    residual = np.asarray(fit_result.residual) / weights
+    residual, sigma = _unweighted_residual(fit_result, sigma, weights)
 
     def reduced_chi_square_less_one(excess):
         return np.sum(residual**2 / (sigma**2 + excess**2)) / fit_result.nfree - 1.0

--- a/stellarphot/utils/fit_diagnostics.py
+++ b/stellarphot/utils/fit_diagnostics.py
@@ -1,0 +1,176 @@
+"""
+Diagnostics of a weighted least-squares fit: how the residuals compare to the
+uncertainties the points were quoted with.
+
+Shared by `~stellarphot.utils.magnitude_transforms.transform_to_catalog` and
+`~stellarphot.transit_fitting.TransitModelFit`, both of which fit with
+``scale_covar=False`` (issues #690 and #699) and report these numbers instead
+of letting `lmfit` rescale the covariance to make the reduced chi-square one.
+"""
+
+import numpy as np
+from scipy.optimize import brentq
+
+__all__ = ["excess_scatter", "quoted_redchi"]
+
+
+def quoted_redchi(fit_result, sigma, weights):
+    """
+    Reduced chi-square measured against the uncertainties as quoted.
+
+    Parameters
+    ----------
+
+    fit_result : `lmfit.minimizer.MinimizerResult`
+        The fit to describe.
+
+    sigma : `numpy.ndarray` or None
+        Uncertainty of each point that was fit, as quoted -- before the
+        floor, if any. `None` for an unweighted fit, whose ``redchi`` involves no
+        sigmas and is reported as `lmfit` computed it.
+
+    weights : `numpy.ndarray` or float
+        Weight the fit gave each residual, floor included. Unused when
+        ``sigma`` is `None`.
+
+    Returns
+    -------
+    float
+        The reduced chi-square of the reported fit against the quoted
+        uncertainties.
+
+    Notes
+    -----
+    `lmfit`'s ``redchi`` is measured against the sigmas the fit actually
+    divided by. A caller that floors those sigmas -- as
+    `~stellarphot.utils.magnitude_transforms.transform_to_catalog` does with
+    ``min_fit_sigma`` -- would otherwise see that floor understate how far
+    the residuals sit from the errors that were quoted: a fit whose quoted
+    errors are far too small would report a small, healthy-looking value for
+    exactly the case the statistic exists to catch. Undoing the weighting
+    and dividing by the raw sigma instead keeps the floor where it belongs:
+    on each point's leverage in the fit, and nowhere in the reporting. A
+    caller with no floor passes the same sigmas the fit used and gets
+    ``fit_result.redchi`` back, to rounding.
+
+    This is also the value `excess_scatter` gates on: whether any scatter
+    needs inventing at all is exactly the question of whether this reduced
+    chi-square already sits at or below one, so the two share this one
+    computation rather than each summing the same quantity independently.
+    """
+    if sigma is None:
+        return fit_result.redchi
+
+    residual = np.asarray(fit_result.residual) / weights
+    # The same operand order as `excess_scatter`'s bracket function at zero
+    # excess -- ``residual**2 / sigma**2``, not ``(residual / sigma)**2``.
+    # The gate there compares this value to one, and a value that disagreed
+    # with the bracket by one ULP around it could hand
+    # `~scipy.optimize.brentq` two negative endpoints -- a `ValueError`.
+    return float(np.sum(residual**2 / sigma**2) / fit_result.nfree)
+
+
+def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
+    """
+    Scatter that would have to be added to every sigma to explain the residuals.
+
+    The value ``s`` at which adding ``s`` in quadrature to each point's
+    uncertainty brings the reduced chi-square to one: how far the points sit
+    from the model over and above what they claim to be uncertain by. Real
+    contributors seen in it, in a magnitude transform, include flat-field
+    gradients and the catalog's own photometry, neither of which any
+    weighting scheme can fix; see issue #694.
+
+    Parameters
+    ----------
+
+    fit_result : `lmfit.minimizer.MinimizerResult`
+        The fit to describe. Its ``residual`` is the weighted residual, i.e.
+        already multiplied by ``weights``.
+
+    sigma : `numpy.ndarray` or None
+        Uncertainty of each point as quoted, before any floor the caller
+        applied, so the excess is measured against what the errors claim
+        rather than against the floor. `None` for an unweighted fit.
+
+    weights : `numpy.ndarray` or float
+        Weight the fit gave each residual, floor included. Unused when
+        ``sigma`` is `None`.
+
+    redchi_quoted : float, optional
+        ``quoted_redchi(fit_result, sigma, weights)`` for this fit, if the
+        caller already has it -- computed here otherwise. Ignored when
+        ``sigma`` is `None`.
+
+    Returns
+    -------
+    float
+        The excess scatter in magnitudes; zero when the residuals are already
+        no larger than the errors claim, and NaN for an unweighted fit, whose
+        residuals have no errors to be excessive with respect to.
+
+    Notes
+    -----
+    Reported rather than folded into the weights. A fit that absorbs its own
+    excess scatter has a reduced chi-square of one by construction, which
+    destroys the one diagnostic that revealed any of this.
+
+    The best-fit residuals are held fixed rather than the model being refit
+    with the widened sigmas. Refitting would move them, but a scatter term
+    that is the same for every point barely changes where a fit lands -- it
+    rescales the weights nearly uniformly -- and holding them fixed keeps this
+    a description of the fit that was actually reported.
+
+    Callers such as
+    `~stellarphot.utils.magnitude_transforms.transform_to_catalog` pass
+    ``redchi_quoted`` in so that the value gating this function is the
+    exact float they report as ``fit_redchi``,
+    rather than a second sum of the same quantity that could round
+    differently by a few ULPs around 1.0.
+    """
+    if sigma is None or fit_result.nfree <= 0:
+        # Nothing was divided by anything, so "how far the residuals sit from
+        # what the points claim" has no meaning. NaN rather than zero, which
+        # would say the errors were checked and found adequate.
+        return np.nan
+
+    if redchi_quoted is None:
+        redchi_quoted = quoted_redchi(fit_result, sigma, weights)
+
+    if redchi_quoted - 1.0 <= 0.0:
+        # The points are already no further from the model than they claim to
+        # be uncertain, so no excess is needed and none is invented. The gate
+        # is the same computation reported as fit_redchi, not a second sum
+        # of the same quantity that could disagree with it by a few ULPs
+        # around 1.0 -- and a gate that passed while both bracket endpoints
+        # below evaluate negative would be a `ValueError` from
+        # `~scipy.optimize.brentq`.
+        return 0.0
+
+    # Undo the weighting: lmfit's residual is the model minus the data times
+    # the weights, and what is needed here is the difference itself, so that
+    # it can be divided by the sigmas as quoted rather than as floored.
+    residual = np.asarray(fit_result.residual) / weights
+
+    def reduced_chi_square_less_one(excess):
+        return np.sum(residual**2 / (sigma**2 + excess**2)) / fit_result.nfree - 1.0
+
+    # A bracket rather than a guess. The function falls monotonically from a
+    # positive value at zero -- the branch above ruled out the alternative --
+    # and at this upper bound every ``sigma**2 + excess**2`` is at least
+    # ``excess**2``, so the sum is at most ``nfree`` and the function is at
+    # most zero. So a root lies between them.
+    upper = np.sqrt(np.sum(residual**2) / fit_result.nfree)
+    upper_value = reduced_chi_square_less_one(upper)
+
+    if upper_value >= 0.0:
+        # Mathematically ``upper_value`` is at most zero, by the argument
+        # above -- so a positive value here only means it landed close
+        # enough to zero that rounding pushed it over, which happens when
+        # ``sigma`` sits many orders of magnitude below the residuals.
+        # ``upper`` is then the root already, to within that same rounding,
+        # and handing `~scipy.optimize.brentq` two endpoints that evaluate
+        # to the same sign would raise `ValueError` instead of finding it.
+        return float(upper)
+
+    return float(brentq(reduced_chi_square_less_one, 0.0, upper))

--- a/stellarphot/utils/fit_diagnostics.py
+++ b/stellarphot/utils/fit_diagnostics.py
@@ -67,32 +67,19 @@ def quoted_redchi(fit_result, sigma, weights):
     errors are far too small would report a small, healthy-looking value for
     exactly the case the statistic exists to catch. Undoing the weighting
     and dividing by the raw sigma instead keeps the floor where it belongs:
-    on each point's leverage in the fit, and nowhere in the reporting. A
-    caller with no floor passes the same sigmas the fit used and gets
-    ``fit_result.redchi`` back, to rounding.
-
-    This is also the value `excess_scatter` gates on: whether any scatter
-    needs inventing at all is exactly the question of whether this reduced
-    chi-square already sits at or below one, so the two share this one
-    computation rather than each summing the same quantity independently.
+    on each point's leverage in the fit, and nowhere in the reporting.
     """
     if sigma is None:
         return fit_result.redchi
 
     residual, sigma = _unweighted_residual(fit_result, sigma, weights)
-    # The same operand order as `excess_scatter`'s bracket function at zero
-    # excess -- ``residual**2 / sigma**2``, not ``(residual / sigma)**2``.
-    # The gate there compares this value to one, and a value that disagreed
-    # with the bracket by one ULP around it could hand
-    # `~scipy.optimize.brentq` two negative endpoints -- a `ValueError`.
-    #
     # Divide by max(1, nfree), matching lmfit's own redchi convention (its
     # `_calculate_statistics`) so a fit with no degrees of freedom left
     # reports chisqr rather than raising or returning inf.
-    return float(np.sum(residual**2 / sigma**2) / max(1, fit_result.nfree))
+    return float(np.sum((residual / sigma) ** 2) / max(1, fit_result.nfree))
 
 
-def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
+def excess_scatter(fit_result, sigma, weights):
     """
     Scatter that would have to be added to every sigma to explain the residuals.
 
@@ -120,11 +107,6 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
         Weight the fit gave each residual, floor included. Unused when
         ``sigma`` is `None`.
 
-    redchi_quoted : float, optional
-        ``quoted_redchi(fit_result, sigma, weights)`` for this fit, if the
-        caller already has it -- computed here otherwise. Ignored when
-        ``sigma`` is `None`.
-
     Returns
     -------
     float
@@ -144,32 +126,12 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
     that is the same for every point barely changes where a fit lands -- it
     rescales the weights nearly uniformly -- and holding them fixed keeps this
     a description of the fit that was actually reported.
-
-    Callers such as
-    `~stellarphot.utils.magnitude_transforms.transform_to_catalog` pass
-    ``redchi_quoted`` in so that the value gating this function is the
-    exact float they report as ``fit_redchi``,
-    rather than a second sum of the same quantity that could round
-    differently by a few ULPs around 1.0.
     """
     if sigma is None or fit_result.nfree <= 0:
         # Nothing was divided by anything, so "how far the residuals sit from
         # what the points claim" has no meaning. NaN rather than zero, which
         # would say the errors were checked and found adequate.
         return np.nan
-
-    if redchi_quoted is None:
-        redchi_quoted = quoted_redchi(fit_result, sigma, weights)
-
-    if redchi_quoted - 1.0 <= 0.0:
-        # The points are already no further from the model than they claim to
-        # be uncertain, so no excess is needed and none is invented. The gate
-        # is the same computation reported as fit_redchi, not a second sum
-        # of the same quantity that could disagree with it by a few ULPs
-        # around 1.0 -- and a gate that passed while both bracket endpoints
-        # below evaluate negative would be a `ValueError` from
-        # `~scipy.optimize.brentq`.
-        return 0.0
 
     # Undo the weighting: lmfit's residual is the model minus the data times
     # the weights, and what is needed here is the difference itself, so that
@@ -179,22 +141,14 @@ def excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
     def reduced_chi_square_less_one(excess):
         return np.sum(residual**2 / (sigma**2 + excess**2)) / fit_result.nfree - 1.0
 
-    # A bracket rather than a guess. The function falls monotonically from a
-    # positive value at zero -- the branch above ruled out the alternative --
-    # and at this upper bound every ``sigma**2 + excess**2`` is at least
-    # ``excess**2``, so the sum is at most ``nfree`` and the function is at
-    # most zero. So a root lies between them.
-    upper = np.sqrt(np.sum(residual**2) / fit_result.nfree)
-    upper_value = reduced_chi_square_less_one(upper)
+    if reduced_chi_square_less_one(0.0) <= 0.0:
+        # The points are already no further from the model than they claim to
+        # be uncertain, so no excess is needed and none is invented.
+        return 0.0
 
-    if upper_value >= 0.0:
-        # Mathematically ``upper_value`` is at most zero, by the argument
-        # above -- so a positive value here only means it landed close
-        # enough to zero that rounding pushed it over, which happens when
-        # ``sigma`` sits many orders of magnitude below the residuals.
-        # ``upper`` is then the root already, to within that same rounding,
-        # and handing `~scipy.optimize.brentq` two endpoints that evaluate
-        # to the same sign would raise `ValueError` instead of finding it.
-        return float(upper)
-
+    # The function falls monotonically from a positive value at zero. At
+    # ``upper`` every ``sigma**2 + excess**2`` is at least ``4 * rms**2``, so
+    # the sum is at most ``nfree / 4`` and the function is at most -3/4:
+    # comfortably negative, so a root lies between the two.
+    upper = 2 * np.sqrt(np.sum(residual**2) / fit_result.nfree)
     return float(brentq(reduced_chi_square_less_one, 0.0, upper))

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -343,7 +343,7 @@ def _underdetermined_reason(fit_result, vary):
     return None
 
 
-def _fit_diagnostics(fit_result, sigma, weights, redchi_quoted, cat_error_usable):
+def _fit_diagnostics(fit_result, sigma, weights, cat_error_usable):
     """
     Describe how one image's fit was weighted, as opposed to where it landed.
 
@@ -367,10 +367,6 @@ def _fit_diagnostics(fit_result, sigma, weights, redchi_quoted, cat_error_usable
         Weight the fit gave each residual, floor included -- the caller's
         own ``weights``, not something re-derived from ``sigma``. The scalar
         ``1.0`` for an unweighted fit.
-
-    redchi_quoted : float
-        ``fit_redchi`` for this fit -- `quoted_redchi` of the three
-        arguments above -- passed through to `excess_scatter`.
 
     cat_error_usable : `numpy.ndarray` or None
         Boolean mask over the stars that were fit: whether each one's
@@ -404,9 +400,7 @@ def _fit_diagnostics(fit_result, sigma, weights, redchi_quoted, cat_error_usable
     return {
         _FIT_CAT_ERROR_MISSING_COLUMN: missing_fraction,
         _FIT_MAX_WEIGHT_SHARE_COLUMN: max_weight_share,
-        _FIT_EXCESS_SCATTER_COLUMN: excess_scatter(
-            fit_result, sigma, weights, redchi_quoted
-        ),
+        _FIT_EXCESS_SCATTER_COLUMN: excess_scatter(fit_result, sigma, weights),
     }
 
 
@@ -1461,12 +1455,7 @@ def transform_to_catalog(
             # value with a negative standard deviation.
             star_errors = np.where(np.isfinite(errors) & (errors > 0), errors, np.nan)
 
-        # Computed once and shared with `_fit_diagnostics` below, so the
-        # value reported here as ``fit_redchi`` is the exact float that
-        # gates ``fit_excess_scatter`` too, rather than two independent sums
-        # of the same quantity that could round differently.
-        redchi_quoted = quoted_redchi(fit_result, sigma, weights)
-        fit_redchis[rows] = redchi_quoted
+        fit_redchis[rows] = quoted_redchi(fit_result, sigma, weights)
 
         # How the fit was weighted, rather than where it landed. Written
         # alongside ``fit_redchi`` because they are the numbers that say
@@ -1476,7 +1465,6 @@ def transform_to_catalog(
             fit_result,
             sigma,
             weights,
-            redchi_quoted,
             None if cat_error_column is None else cat_error_usable[good],
         )
         for name, value in diagnostics.items():

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -8,11 +8,11 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.linalg import LinAlgError
-from scipy.optimize import brentq
 from uncertainties import correlated_values, unumpy
 
 from ..catalogs import apass_dr9, refcat2
 from ..settings.aavso_models import AAVSOFilters
+from .fit_diagnostics import excess_scatter, quoted_redchi
 from .magnitude_system_transforms import transform_apass_bands, transform_refcat2_bands
 
 logger = logging.getLogger(__name__)
@@ -369,8 +369,8 @@ def _fit_diagnostics(fit_result, sigma, weights, redchi_quoted, cat_error_usable
         ``1.0`` for an unweighted fit.
 
     redchi_quoted : float
-        ``fit_redchi`` for this fit -- `_quoted_redchi` of the three
-        arguments above -- passed through to `_excess_scatter`.
+        ``fit_redchi`` for this fit -- `quoted_redchi` of the three
+        arguments above -- passed through to `excess_scatter`.
 
     cat_error_usable : `numpy.ndarray` or None
         Boolean mask over the stars that were fit: whether each one's
@@ -404,167 +404,10 @@ def _fit_diagnostics(fit_result, sigma, weights, redchi_quoted, cat_error_usable
     return {
         _FIT_CAT_ERROR_MISSING_COLUMN: missing_fraction,
         _FIT_MAX_WEIGHT_SHARE_COLUMN: max_weight_share,
-        _FIT_EXCESS_SCATTER_COLUMN: _excess_scatter(
+        _FIT_EXCESS_SCATTER_COLUMN: excess_scatter(
             fit_result, sigma, weights, redchi_quoted
         ),
     }
-
-
-def _quoted_redchi(fit_result, sigma, weights):
-    """
-    Reduced chi-square measured against the uncertainties as quoted.
-
-    Parameters
-    ----------
-
-    fit_result : `lmfit.minimizer.MinimizerResult`
-        The fit to describe.
-
-    sigma : `numpy.ndarray` or None
-        Uncertainty of each star that was fit, as quoted -- before the
-        floor. `None` for an unweighted fit, whose ``redchi`` involves no
-        sigmas and is reported as `lmfit` computed it.
-
-    weights : `numpy.ndarray` or float
-        Weight the fit gave each residual, floor included. Unused when
-        ``sigma`` is `None`.
-
-    Returns
-    -------
-    float
-        The reduced chi-square of the reported fit against the quoted
-        uncertainties.
-
-    Notes
-    -----
-    `lmfit`'s ``redchi`` is measured against the sigmas the fit actually
-    divided by, which are floored at ``min_fit_sigma``. Below the floor that
-    understates how far the residuals sit from the errors that were quoted
-    -- an image whose quoted errors are far too small would report a small,
-    healthy-looking value for exactly the case the statistic exists to
-    catch. Undoing the weighting and dividing by the raw sigma instead keeps
-    the floor where it belongs: on each star's leverage in the fit, and
-    nowhere in the reporting.
-
-    This is also the value `_excess_scatter` gates on: whether any scatter
-    needs inventing at all is exactly the question of whether this reduced
-    chi-square already sits at or below one, so the two share this one
-    computation rather than each summing the same quantity independently.
-    """
-    if sigma is None:
-        return fit_result.redchi
-
-    residual = np.asarray(fit_result.residual) / weights
-    # The same operand order as `_excess_scatter`'s bracket function at zero
-    # excess -- ``residual**2 / sigma**2``, not ``(residual / sigma)**2``.
-    # The gate there compares this value to one, and a value that disagreed
-    # with the bracket by one ULP around it could hand
-    # `~scipy.optimize.brentq` two negative endpoints -- a `ValueError`.
-    return float(np.sum(residual**2 / sigma**2) / fit_result.nfree)
-
-
-def _excess_scatter(fit_result, sigma, weights, redchi_quoted=None):
-    """
-    Scatter that would have to be added to every sigma to explain the residuals.
-
-    The value ``s`` at which adding ``s`` in quadrature to each star's
-    uncertainty brings the reduced chi-square to one: how far the stars sit
-    from the model over and above what they claim to be uncertain by. Real
-    contributors seen in it include flat-field gradients and the catalog's
-    own photometry, neither of which any weighting scheme can fix; see
-    issue #694.
-
-    Parameters
-    ----------
-
-    fit_result : `lmfit.minimizer.MinimizerResult`
-        The fit to describe. Its ``residual`` is the weighted residual, i.e.
-        already multiplied by ``weights``.
-
-    sigma : `numpy.ndarray` or None
-        Uncertainty of each star as quoted, before the ``min_fit_sigma``
-        floor, so the excess is measured against what the errors claim
-        rather than against the floor. `None` for an unweighted fit.
-
-    weights : `numpy.ndarray` or float
-        Weight the fit gave each residual, floor included. Unused when
-        ``sigma`` is `None`.
-
-    redchi_quoted : float, optional
-        ``_quoted_redchi(fit_result, sigma, weights)`` for this fit, if the
-        caller already has it -- computed here otherwise. Ignored when
-        ``sigma`` is `None`.
-
-    Returns
-    -------
-    float
-        The excess scatter in magnitudes; zero when the residuals are already
-        no larger than the errors claim, and NaN for an unweighted fit, whose
-        residuals have no errors to be excessive with respect to.
-
-    Notes
-    -----
-    Reported rather than folded into the weights. A fit that absorbs its own
-    excess scatter has a reduced chi-square of one by construction, which
-    destroys the one diagnostic that revealed any of this.
-
-    The best-fit residuals are held fixed rather than the model being refit
-    with the widened sigmas. Refitting would move them, but a scatter term
-    that is the same for every star barely changes where a fit lands -- it
-    rescales the weights nearly uniformly -- and holding them fixed keeps this
-    a description of the fit that was actually reported.
-
-    `transform_to_catalog` passes ``redchi_quoted`` in so that the value
-    gating this function is the exact float it reports as ``fit_redchi``,
-    rather than a second sum of the same quantity that could round
-    differently by a few ULPs around 1.0.
-    """
-    if sigma is None or fit_result.nfree <= 0:
-        # Nothing was divided by anything, so "how far the residuals sit from
-        # what the stars claim" has no meaning. NaN rather than zero, which
-        # would say the errors were checked and found adequate.
-        return np.nan
-
-    if redchi_quoted is None:
-        redchi_quoted = _quoted_redchi(fit_result, sigma, weights)
-
-    if redchi_quoted - 1.0 <= 0.0:
-        # The stars are already no further from the model than they claim to
-        # be uncertain, so no excess is needed and none is invented. The gate
-        # is the same computation reported as fit_redchi, not a second sum
-        # of the same quantity that could disagree with it by a few ULPs
-        # around 1.0 -- and a gate that passed while both bracket endpoints
-        # below evaluate negative would be a `ValueError` from
-        # `~scipy.optimize.brentq`.
-        return 0.0
-
-    # Undo the weighting: lmfit's residual is the model minus the data times
-    # the weights, and what is needed here is the difference itself, so that
-    # it can be divided by the sigmas as quoted rather than as floored.
-    residual = np.asarray(fit_result.residual) / weights
-
-    def reduced_chi_square_less_one(excess):
-        return np.sum(residual**2 / (sigma**2 + excess**2)) / fit_result.nfree - 1.0
-
-    # A bracket rather than a guess. The function falls monotonically from a
-    # positive value at zero -- the branch above ruled out the alternative --
-    # and at this upper bound every ``sigma**2 + excess**2`` is at least
-    # ``excess**2``, so the sum is at most ``nfree`` and the function is at
-    # most zero. So a root lies between them.
-    upper = np.sqrt(np.sum(residual**2) / fit_result.nfree)
-    upper_value = reduced_chi_square_less_one(upper)
-
-    if upper_value >= 0.0:
-        # Mathematically ``upper_value`` is at most zero, by the argument
-        # above -- so a positive value here only means it landed close
-        # enough to zero that rounding pushed it over, which happens when
-        # ``sigma`` sits many orders of magnitude below the residuals.
-        # ``upper`` is then the root already, to within that same rounding,
-        # and handing `~scipy.optimize.brentq` two endpoints that evaluate
-        # to the same sign would raise `ValueError` instead of finding it.
-        return float(upper)
-
-    return float(brentq(reduced_chi_square_less_one, 0.0, upper))
 
 
 def _coefficient_uncertainties(fit_result):
@@ -722,7 +565,8 @@ def _calibrated_with_uncertainty(
     high there is deliberate.
 
     The excess scatter is added after the propagation, not to the star's
-    measurement error before it. `_excess_scatter` measures it in
+    measurement error before it.
+    `~stellarphot.utils.fit_diagnostics.excess_scatter` measures it in
     calibrated-magnitude residual space -- against ``hypot(errors,
     cat_error)`` with no ``1 + a`` factor -- so adding it before the
     propagation would scale it by a ``1 + a`` sensitivity it already
@@ -1621,7 +1465,7 @@ def transform_to_catalog(
         # value reported here as ``fit_redchi`` is the exact float that
         # gates ``fit_excess_scatter`` too, rather than two independent sums
         # of the same quantity that could round differently.
-        redchi_quoted = _quoted_redchi(fit_result, sigma, weights)
+        redchi_quoted = quoted_redchi(fit_result, sigma, weights)
         fit_redchis[rows] = redchi_quoted
 
         # How the fit was weighted, rather than where it landed. Written

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -14,13 +14,13 @@ from stellarphot.conftest import SERVER_DOWN_ERRORS
 from ...catalogs import apass_dr9, refcat2
 from ...core import PhotometryData
 from .. import magnitude_transforms
+from ..fit_diagnostics import excess_scatter
 from ..magnitude_system_transforms import (
     transform_apass_bands,
     transform_refcat2_bands,
 )
 from ..magnitude_transforms import (
     _MIN_FIT_SIGMA,
-    _excess_scatter,
     _to_float_array,
     calibrated_from_instrumental,
     filter_transform,
@@ -1972,7 +1972,7 @@ def test_excess_scatter_returns_zero_when_redchi_is_barely_above_one():
         redchi=np.nextafter(1.0, 2.0),
     )
 
-    assert _excess_scatter(fit_result, sigma, 1.0 / sigma) == 0.0
+    assert excess_scatter(fit_result, sigma, 1.0 / sigma) == 0.0
 
 
 def test_excess_scatter_survives_an_upper_bracket_that_rounds_positive():
@@ -1996,7 +1996,7 @@ def test_excess_scatter_survives_an_upper_bracket_that_rounds_positive():
 
     fit_result = SimpleNamespace(residual=residual, nfree=residual.size)
 
-    result = _excess_scatter(fit_result, sigma, 1.0)
+    result = excess_scatter(fit_result, sigma, 1.0)
 
     assert np.isfinite(result)
     assert result == pytest.approx(np.sqrt(np.mean(residual**2)))

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -2030,12 +2030,6 @@ def _fit_result_with_zero_weight(raw_residual_good, sigma_good, nfree):
     return fit_result, sigma, weights
 
 
-def _expected_quoted_redchi(raw_residual_good, sigma_good, nfree):
-    raw_residual_good = np.asarray(raw_residual_good, dtype=float)
-    sigma_good = np.asarray(sigma_good, dtype=float)
-    return float(np.sum(raw_residual_good**2 / sigma_good**2) / nfree)
-
-
 @pytest.mark.parametrize(
     "raw_residual, expect_redchi_above_one",
     [(np.full(4, 1.5), True), (np.full(4, 0.1), False)],
@@ -2051,8 +2045,7 @@ def test_quoted_redchi_ignores_a_zero_weight_point(
 
     result = quoted_redchi(fit_result, sigma, weights)
 
-    expected = _expected_quoted_redchi(raw_residual, sigma_good, nfree)
-    assert result == pytest.approx(expected)
+    assert result == pytest.approx(np.sum(raw_residual**2 / sigma_good**2) / nfree)
     assert (result > 1.0) == expect_redchi_above_one
 
 

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -14,7 +14,7 @@ from stellarphot.conftest import SERVER_DOWN_ERRORS
 from ...catalogs import apass_dr9, refcat2
 from ...core import PhotometryData
 from .. import magnitude_transforms
-from ..fit_diagnostics import excess_scatter
+from ..fit_diagnostics import excess_scatter, quoted_redchi
 from ..magnitude_system_transforms import (
     transform_apass_bands,
     transform_refcat2_bands,
@@ -2000,6 +2000,119 @@ def test_excess_scatter_survives_an_upper_bracket_that_rounds_positive():
 
     assert np.isfinite(result)
     assert result == pytest.approx(np.sqrt(np.mean(residual**2)))
+
+
+def _fit_result_with_zero_weight(raw_residual_good, sigma_good, nfree):
+    """
+    A fake fit result with one zero-weight point appended.
+
+    Zero weight is `lmfit`'s idiom for excluding a point: its weighted
+    residual is zero and, since ``sigma = 1 / weight``, its sigma is
+    infinite. Neither `quoted_redchi` nor `excess_scatter` should raise or
+    warn dividing by that weight, and the dropped point should not
+    contribute to either sum.
+
+    Returns
+    -------
+    fit_result, sigma, weights
+        Arrays one longer than ``raw_residual_good``, with the zero-weight
+        point last.
+    """
+    weights_good = 1.0 / np.asarray(sigma_good, dtype=float)
+    weighted_residual_good = weights_good * np.asarray(raw_residual_good, dtype=float)
+
+    residual = np.append(weighted_residual_good, 0.0)
+    weights = np.append(weights_good, 0.0)
+    with np.errstate(divide="ignore"):
+        sigma = 1.0 / weights
+
+    fit_result = SimpleNamespace(residual=residual, nfree=nfree)
+    return fit_result, sigma, weights
+
+
+def _expected_quoted_redchi(raw_residual_good, sigma_good, nfree):
+    raw_residual_good = np.asarray(raw_residual_good, dtype=float)
+    sigma_good = np.asarray(sigma_good, dtype=float)
+    return float(np.sum(raw_residual_good**2 / sigma_good**2) / nfree)
+
+
+@pytest.mark.parametrize(
+    "raw_residual, expect_redchi_above_one",
+    [(np.full(4, 1.5), True), (np.full(4, 0.1), False)],
+)
+def test_quoted_redchi_ignores_a_zero_weight_point(
+    raw_residual, expect_redchi_above_one
+):
+    sigma_good = np.full(4, 1.0)
+    nfree = 4
+    fit_result, sigma, weights = _fit_result_with_zero_weight(
+        raw_residual, sigma_good, nfree
+    )
+
+    result = quoted_redchi(fit_result, sigma, weights)
+
+    expected = _expected_quoted_redchi(raw_residual, sigma_good, nfree)
+    assert result == pytest.approx(expected)
+    assert (result > 1.0) == expect_redchi_above_one
+
+
+def test_quoted_redchi_with_nfree_zero_matches_lmfits_chisqr_convention():
+    # A fit with as many varied parameters as points has no degrees of
+    # freedom left. lmfit's own redchi is then chisqr / max(1, nfree) rather
+    # than a division by zero (its `_calculate_statistics`); quoted_redchi
+    # should agree instead of raising ZeroDivisionError or returning inf.
+    residual = np.array([1.0, 2.0, 3.0])
+    sigma = np.array([1.0, 1.0, 1.0])
+    weights = np.array([1.0, 1.0, 1.0])
+    fit_result = SimpleNamespace(residual=residual, nfree=0)
+
+    result = quoted_redchi(fit_result, sigma, weights)
+
+    expected_chisqr = np.sum((residual / weights) ** 2 / sigma**2)
+    assert np.isfinite(result)
+    assert result == pytest.approx(expected_chisqr)
+
+
+def test_excess_scatter_ignores_a_zero_weight_point_when_redchi_is_above_one():
+    raw_residual = np.full(4, 1.5)
+    sigma_good = np.full(4, 1.0)
+    nfree = 4
+
+    reference = SimpleNamespace(residual=(1.0 / sigma_good) * raw_residual, nfree=nfree)
+    expected = excess_scatter(reference, sigma_good, 1.0 / sigma_good)
+
+    fit_result, sigma, weights = _fit_result_with_zero_weight(
+        raw_residual, sigma_good, nfree
+    )
+    result = excess_scatter(fit_result, sigma, weights)
+
+    assert np.isfinite(result)
+    assert result > 0.0
+    assert result == pytest.approx(expected)
+
+
+def test_excess_scatter_ignores_a_zero_weight_point_when_redchi_is_at_or_below_one():
+    raw_residual = np.full(4, 0.1)
+    sigma_good = np.full(4, 1.0)
+    nfree = 4
+
+    fit_result, sigma, weights = _fit_result_with_zero_weight(
+        raw_residual, sigma_good, nfree
+    )
+    result = excess_scatter(fit_result, sigma, weights)
+
+    assert result == 0.0
+
+
+def test_excess_scatter_accepts_a_scalar_weight_with_an_array_sigma():
+    # A scalar weight must still broadcast through the zero-weight mask.
+    residual = np.array([0.5, -1.5, 2.0, -0.5])
+    sigma = np.array([1.0, 1.0, 1.0, 1.0])
+    fit_result = SimpleNamespace(residual=residual, nfree=residual.size)
+
+    result = excess_scatter(fit_result, sigma, 1.0)
+
+    assert np.isfinite(result)
 
 
 @pytest.mark.parametrize("n_zero", [0, 5, 20])

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,8 @@ deps =
     # test envs so those tests run rather than skip. (lmfit, the other half of
     # the transit fitter, is a core dependency and so arrives on its own.)
     test: pytransit
+    # See the exoplanet extra in pyproject.toml for why.
+    test: mako
 extras =
     test: test
     build_docs: docs
@@ -47,6 +49,7 @@ passenv = {[testenv]passenv}
 deps =
     coverage: pytest-cov
     pytransit
+    mako
 extras =
     coverage: test
 commands =


### PR DESCRIPTION
Closes #699 — brings `TransitModelFit` onto the uncertainty convention #696 adopted for `transform_to_catalog`.

- `_run_fit` passes `scale_covar=self.weights is None`: a weighted fit's `stderr` values now believe the quoted flux errors; an unweighted fit keeps the rescaling since the residuals are its only noise estimate. Before this, errors quoted 10× too small gave the *same* `stderr` (the failing test showed 0.01133 vs 0.01135).
- New attributes `fit_redchi` and `fit_excess_scatter` (None before `fit()`, NaN excess when unweighted), computed before any state is assigned so a failing fit still leaves the instance untouched.
- `_quoted_redchi`/`_excess_scatter` move from `magnitude_transforms.py` to a new `stellarphot.utils.fit_diagnostics` module as public `quoted_redchi`/`excess_scatter` (numpy + `scipy.optimize.brentq` only; automodapi entry added; docs build with `-W` passes). No behaviour change on the transform side.
- `compare_detrend_options` unchanged (BIC is independent of `scale_covar`). No weight floor in this PR.
- Tests: stderr ratio 0.1 between under-quoted and truthful weights with `fit_redchi ≈ 100`; excess ≈ `sqrt(noise² − quoted²)`; unweighted stderr = truthful stderr × `sqrt(fit_redchi)` (the exact relation `scale_covar` implements); attributes None before fit.
- One markdown cell added after `mod.params` in both TESS model-fit notebooks; CHANGES entry.

This PR was written by Claude Code at Matt's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RURMHNvNLcGuqnx4u7D4V
