### PR TITLE
Derive the catalog search radius from the observed field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -157,13 +157,11 @@ Other Changes and Additions
   and the new ``fit_redchi`` and ``fit_excess_scatter`` attributes report
   the mismatch instead. The diagnostics both fits share live in the new
   ``stellarphot.utils.fit_diagnostics`` module. [#699]
-+ ``transform_to_catalog()`` gains a ``search_radius`` argument. By default the
-  catalog cone search is now centered on the centroid of the observed positions
-  and sized to enclose them plus a one arcminute margin, instead of a fixed one
-  degree around the first observed star, so calibrating a small field no longer
-  pulls a degree-wide catalog from Vizier. A table whose positions span more
-  than a degree now warns, since the cone derived from it is one no call could
-  previously produce. [#686]
++ ``transform_to_catalog()`` now fetches its catalog from a cone around the
+  positions observed in the fitted passband, instead of a fixed degree around
+  the first observed star, so a small field no longer pulls a degree-wide
+  catalog. Pass the new ``search_radius`` to set the cone size instead; a
+  derived cone wider than a degree warns. [#686]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -157,6 +157,13 @@ Other Changes and Additions
   and the new ``fit_redchi`` and ``fit_excess_scatter`` attributes report
   the mismatch instead. The diagnostics both fits share live in the new
   ``stellarphot.utils.fit_diagnostics`` module. [#699]
++ ``transform_to_catalog()`` gains a ``search_radius`` argument. By default the
+  catalog cone search is now centered on the centroid of the observed positions
+  and sized to enclose them plus a one arcminute margin, instead of a fixed one
+  degree around the first observed star, so calibrating a small field no longer
+  pulls a degree-wide catalog from Vizier. A table whose positions span more
+  than a degree now warns, since the cone derived from it is one no call could
+  previously produce. [#686]
 
 Bug Fixes
 ^^^^^^^^^

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 import lmfit
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, UnitSphericalRepresentation
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.linalg import LinAlgError
 from uncertainties import correlated_values, unumpy
@@ -96,6 +96,24 @@ _FIT_DIAGNOSTIC_COLUMNS = (
 # to calibrate everything else against.
 _FIT_MATCH_ARCSEC = 1.0
 _CAL_MATCH_ARCSEC = 1.5
+
+# Added to the radius of the cone the calibration catalog is fetched from, so
+# that the cone is a little larger than the field the observations cover. A
+# star at the very edge of the field still has to find its catalog counterpart
+# inside the cone, and a counterpart is at most `_CAL_MATCH_ARCSEC` away, so an
+# arcminute is generous for that alone. It is also what gives a field whose
+# positions span nothing at all -- a single star, or one image of one target --
+# a cone of a sensible size rather than of no size.
+_CATALOG_RADIUS_MARGIN = 1 * u.arcmin
+
+# Derived cone size above which the caller is told what is about to be asked
+# of Vizier. One degree because that is exactly what the radius used to be
+# fixed at: a cone wider than this is one no call could previously produce,
+# and a field that large is usually a mosaic, or ra/dec columns holding more
+# than one field's worth of stars, rather than a single image. Only a cone
+# that came out this wide on its own is worth a warning -- an explicit
+# `search_radius` is a deliberate choice and passes without comment.
+_WIDE_FIELD_RADIUS = 1 * u.degree
 
 # The color conventionally used with each canonical passband, for a caller
 # who names a band but no color. Which color goes with a band is a convention
@@ -277,6 +295,93 @@ def _to_float_array(values):
         )
 
     return (filled * unit).to_value(u.mag)
+
+
+def _to_degree_array(values):
+    """
+    Convert a coordinate column to plain degrees, masked entries becoming NaN.
+
+    The sibling of `_to_float_array` for angles rather than magnitudes: that
+    one raises for a unit like ``deg``, since a magnitude column carrying one
+    is a mistake, and coordinate columns carry one routinely.
+
+    Parameters
+    ----------
+
+    values : array-like
+        Values to convert. May be a `~astropy.table.MaskedColumn` or a
+        `~astropy.units.Quantity`. Values with no unit are taken to be in
+        degrees, which is the convention the ``ra`` and ``dec`` columns of a
+        photometry table follow.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        Float array of degrees, NaN wherever the input was masked.
+    """
+    unit = getattr(values, "unit", None)
+    filled = np.asarray(
+        np.ma.filled(np.ma.asarray(values, dtype=float), np.nan), dtype=float
+    )
+
+    return filled if unit is None else (filled * unit).to_value(u.degree)
+
+
+def _observed_field(ra, dec):
+    """
+    Find the patch of sky the observed positions cover.
+
+    Parameters
+    ----------
+
+    ra, dec : array-like
+        Right ascension and declination of the observed positions, in the
+        form `_to_degree_array` accepts.
+
+    Returns
+    -------
+    center : `astropy.coordinates.SkyCoord`
+        Centroid of the positions.
+
+    radius : `astropy.units.Quantity`
+        Angular radius about ``center`` enclosing every position, plus
+        `_CATALOG_RADIUS_MARGIN`.
+
+    Raises
+    ------
+    `ValueError`
+        If no position has both a finite right ascension and a finite
+        declination.
+
+    Notes
+    -----
+
+    The center is the mean of the positions' unit cartesian vectors rather
+    than the mean of their right ascensions and declinations. The latter is
+    wrong across the RA = 0 wrap, and wrong by half the sky: a field
+    straddling it averages to the antipode, and a cone drawn there holds none
+    of the stars it was meant to hold.
+
+    A row is dropped unless both of its coordinates are usable, since half a
+    position places nothing, and a masked or NaN entry left in would poison
+    the mean rather than merely be ignored by it.
+    """
+    ra_degree = _to_degree_array(ra)
+    dec_degree = _to_degree_array(dec)
+    usable = np.isfinite(ra_degree) & np.isfinite(dec_degree)
+    if not usable.any():
+        raise ValueError(
+            "No observed position has both a finite ra and a finite dec, so "
+            "there is no field to search a catalog around."
+        )
+
+    coords = SkyCoord(ra_degree[usable], dec_degree[usable], unit="degree")
+    direction = coords.cartesian.mean().represent_as(UnitSphericalRepresentation)
+    center = SkyCoord(
+        direction.lon, direction.lat, frame=coords.frame.replicate_without_data()
+    )
+
+    return center, coords.separation(center).max() + _CATALOG_RADIUS_MARGIN
 
 
 def _underdetermined_reason(fit_result, vary):
@@ -842,6 +947,7 @@ def transform_to_catalog(
     in_place=True,
     fit_diff=True,
     min_fit_sigma=_MIN_FIT_SIGMA,
+    search_radius=None,
 ):
     """
     Transform a set of instrumental magnitudes to a standard system using either
@@ -949,6 +1055,12 @@ def transform_to_catalog(
         :ref:`calibration-fit-quality` for how the floor reaches the
         reported uncertainties.
 
+    search_radius : `astropy.units.Quantity`, optional
+        Angular radius of the cone the calibration catalog is fetched from,
+        which must be a positive, finite angle. Defaults to the radius that
+        encloses every observed position, plus a one arcminute margin, about
+        the centroid of those positions. See Notes.
+
     Returns
     -------
 
@@ -1039,6 +1151,18 @@ def transform_to_catalog(
     ``mag_cal_error`` is NaN, rather than falling back to the measurement
     error alone, for an image whose fit left no usable covariance behind.
 
+    The catalog is fetched once per call, from a cone centered on the
+    centroid of the observed positions and just large enough to hold them
+    all. It used to be a fixed degree around whichever star happened to be
+    first in the table, so a call asked Vizier for every row of a degree-wide
+    cone however small the field really was; see issue #686.
+    ``search_radius`` is therefore the way to make the cone deliberately
+    *larger* than the field -- to calibrate against stars outside it, say --
+    rather than the way to keep a query small, which the default already
+    does. A derived cone wider than a degree warns, since a table covering
+    that much sky is usually more than one field; passing ``search_radius``
+    says the size was intended and silences it.
+
     How the fit is weighted, what the floor does and does not reach, how to
     read the diagnostics and the coefficient uncertainties, and what the
     catalog contributes that none of these columns carry are described in
@@ -1065,6 +1189,23 @@ def transform_to_catalog(
             f"{min_fit_sigma}. Pass 0 to apply no floor to the uncertainties "
             "the fit weights by."
         )
+
+    # Checked here rather than where the cone is actually drawn, so that an
+    # argument the caller can fix without leaving their keyboard does not cost
+    # them a Vizier round trip first.
+    if search_radius is not None:
+        search_radius = u.Quantity(search_radius)
+        if not search_radius.unit.is_equivalent(u.degree):
+            raise ValueError(
+                "search_radius must be an angle, such as 5 * u.arcmin, got "
+                f"{search_radius!r}."
+            )
+        if not np.isfinite(search_radius.value) or search_radius.value <= 0:
+            raise ValueError(
+                "search_radius must be a positive, finite angle, got "
+                f"{search_radius!r}. Leave it out to search the field the "
+                "observations cover."
+            )
 
     # Preserve the order the caller gave, minus any duplicates.
     vary = tuple(dict.fromkeys(vary))
@@ -1158,17 +1299,37 @@ def transform_to_catalog(
     cat_mags = np.full(n_rows, np.nan)
     cat_colors = np.full(n_rows, np.nan)
 
-    one_coord = SkyCoord(
-        observed_mags_grouped["ra"][0], observed_mags_grouped["dec"][0], unit="degree"
+    # Every row of the table, rather than only the rows in this passband:
+    # the images in it are of one field, and one cone drawn around all of
+    # them serves the calls for the other passbands too.
+    field_center, field_radius = _observed_field(
+        observed_mags_grouped["ra"], observed_mags_grouped["dec"]
     )
+    if search_radius is None:
+        search_radius = field_radius
+        if search_radius > _WIDE_FIELD_RADIUS:
+            warnings.warn(
+                f"The observed positions span {field_radius.to(u.degree):.2f}, "
+                "so the catalog will be fetched from a cone that wide and the "
+                "query may be slow. That is usually a table holding more than "
+                "one field; if it is not, pass search_radius to set the cone "
+                "size yourself.",
+                AstropyUserWarning,
+                stacklevel=2,
+            )
+
     if cat_name == "apass_dr9":
-        cat = apass_dr9(one_coord, radius=1 * u.degree, clip_by_frame=False, padding=0)
+        cat = apass_dr9(
+            field_center, radius=search_radius, clip_by_frame=False, padding=0
+        )
         cat = cat.passband_columns(
             passbands=["B", "V", "R", "I", "SR", "SG", "SI"],
             transformer=transform_apass_bands,
         )
     elif cat_name == "refcat2":
-        cat = refcat2(one_coord, radius=1 * u.degree, clip_by_frame=False, padding=0)
+        cat = refcat2(
+            field_center, radius=search_radius, clip_by_frame=False, padding=0
+        )
         cat = cat.passband_columns(
             # Catalog native passbands will be automatically
             # made to.

--- a/stellarphot/utils/magnitude_transforms.py
+++ b/stellarphot/utils/magnitude_transforms.py
@@ -115,6 +115,12 @@ _CATALOG_RADIUS_MARGIN = 1 * u.arcmin
 # `search_radius` is a deliberate choice and passes without comment.
 _WIDE_FIELD_RADIUS = 1 * u.degree
 
+# The catalogs `transform_to_catalog` knows how to fetch. Named here so that
+# the check of the caller's `cat_name`, which happens up front alongside the
+# other argument checks, and the fetch itself, which happens much further
+# down, cannot drift apart.
+_CATALOG_NAMES = ("apass_dr9", "refcat2")
+
 # The color conventionally used with each canonical passband, for a caller
 # who names a band but no color. Which color goes with a band is a convention
 # rather than something derivable, so a band that is not here has to be asked
@@ -1057,9 +1063,9 @@ def transform_to_catalog(
 
     search_radius : `astropy.units.Quantity`, optional
         Angular radius of the cone the calibration catalog is fetched from,
-        which must be a positive, finite angle. Defaults to the radius that
-        encloses every observed position, plus a one arcminute margin, about
-        the centroid of those positions. See Notes.
+        which must be a single positive, finite angle. Defaults to the radius
+        that encloses every position observed in ``obs_filter``, plus a one
+        arcminute margin, about the centroid of those positions. See Notes.
 
     Returns
     -------
@@ -1152,10 +1158,14 @@ def transform_to_catalog(
     error alone, for an image whose fit left no usable covariance behind.
 
     The catalog is fetched once per call, from a cone centered on the
-    centroid of the observed positions and just large enough to hold them
-    all. It used to be a fixed degree around whichever star happened to be
-    first in the table, so a call asked Vizier for every row of a degree-wide
-    cone however small the field really was; see issue #686.
+    centroid of the positions observed in ``obs_filter`` and just large
+    enough to hold them all. Rows in other passbands are left out of it:
+    they are never matched against the catalog, so sizing the cone from them
+    only costs sky -- and the field of view can shift a little between bands
+    even when the images are of one target. It used to be a fixed degree
+    around whichever star happened to be first in the table, so a call asked
+    Vizier for every row of a degree-wide cone however small the field really
+    was; see issue #686.
     ``search_radius`` is therefore the way to make the cone deliberately
     *larger* than the field -- to calibrate against stars outside it, say --
     rather than the way to keep a query small, which the default already
@@ -1200,12 +1210,22 @@ def transform_to_catalog(
                 "search_radius must be an angle, such as 5 * u.arcmin, got "
                 f"{search_radius!r}."
             )
+        if not search_radius.isscalar:
+            raise ValueError(
+                f"search_radius must be a single angle, got {search_radius!r}."
+            )
         if not np.isfinite(search_radius.value) or search_radius.value <= 0:
             raise ValueError(
                 "search_radius must be a positive, finite angle, got "
                 f"{search_radius!r}. Leave it out to search the field the "
                 "observations cover."
             )
+
+    if cat_name not in _CATALOG_NAMES:
+        raise ValueError(
+            f"Unknown catalog name {cat_name}. Must be one of "
+            f"{' or '.join(repr(name) for name in _CATALOG_NAMES)}."
+        )
 
     # Preserve the order the caller gave, minus any duplicates.
     vary = tuple(dict.fromkeys(vary))
@@ -1299,21 +1319,21 @@ def transform_to_catalog(
     cat_mags = np.full(n_rows, np.nan)
     cat_colors = np.full(n_rows, np.nan)
 
-    # Every row of the table, rather than only the rows in this passband:
-    # the images in it are of one field, and one cone drawn around all of
-    # them serves the calls for the other passbands too.
+    # Only the rows in this passband: they are the only ones ever matched
+    # against the catalog, so they are the only ones the cone has to cover.
     field_center, field_radius = _observed_field(
-        observed_mags_grouped["ra"], observed_mags_grouped["dec"]
+        observed_mags_grouped["ra"][in_passband],
+        observed_mags_grouped["dec"][in_passband],
     )
     if search_radius is None:
         search_radius = field_radius
         if search_radius > _WIDE_FIELD_RADIUS:
             warnings.warn(
-                f"The observed positions span {field_radius.to(u.degree):.2f}, "
-                "so the catalog will be fetched from a cone that wide and the "
-                "query may be slow. That is usually a table holding more than "
-                "one field; if it is not, pass search_radius to set the cone "
-                "size yourself.",
+                "The catalog will be fetched from a cone of radius "
+                f"{field_radius.to(u.degree):.2f} about the center of the "
+                "observed positions, and a query that wide may be slow. That "
+                "is usually a table holding more than one field; if it is "
+                "not, pass search_radius to set the cone size yourself.",
                 AstropyUserWarning,
                 stacklevel=2,
             )
@@ -1336,10 +1356,11 @@ def transform_to_catalog(
             passbands=["B", "V", "R", "I"],
             transformer=transform_refcat2_bands,
         )
-    else:
-        raise ValueError(
-            f"Unknown catalog name {cat_name}. Must be one of 'apass_dr9' or 'refcat2'."
-        )
+    else:  # pragma: no cover
+        # Unreachable: `cat_name` was checked against `_CATALOG_NAMES` above.
+        # Kept so that adding a name to that tuple without adding a branch
+        # here fails loudly rather than leaving `cat` unbound.
+        raise ValueError(f"No catalog fetch is implemented for {cat_name}.")
 
     # cat_filter and cat_color are only ever strings until this point, so a
     # band the catalog cannot supply -- "U" against apass_dr9 or refcat2,

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from types import SimpleNamespace
 
 import numpy as np
@@ -513,32 +512,6 @@ def _run_transform_to_catalog(
     call_kwargs.update(kwargs)
 
     return transform_to_catalog(observed, obs_filter, cat_name=cat_name, **call_kwargs)
-
-
-def _fetch_call_args(cat_name="apass_dr9"):
-    """
-    Return the field center and radius the patched catalog fetch was called
-    with.
-
-    Parameters
-    ----------
-
-    cat_name : str, optional
-        Name of the catalog fetch to inspect, patched onto
-        `~stellarphot.utils.magnitude_transforms` by `_patch_catalog_fetch`.
-
-    Returns
-    -------
-    center : `astropy.coordinates.SkyCoord`
-        The field center the fetch was called with, i.e. its first
-        positional argument.
-
-    radius : `astropy.units.Quantity`
-        The cone search radius the fetch was called with, i.e. its
-        ``radius`` keyword argument.
-    """
-    call_args = getattr(magnitude_transforms, cat_name).call_args
-    return call_args.args[0], call_args.kwargs["radius"]
 
 
 # Every output column whose value comes from the catalog entry a star was
@@ -1171,7 +1144,7 @@ def test_to_float_array_leaves_unitless_input_alone():
     np.testing.assert_array_equal(converted, [1.0, np.nan])
 
 
-def test__observed_field_single_star_gets_the_margin_as_its_radius():
+def test_observed_field_single_star_gets_the_margin_as_its_radius():
     # This is why the margin exists at all: without it, a single-star field
     # -- max separation from its own centroid is exactly zero -- would ask
     # for a zero-radius cone and never find its own star in the catalog.
@@ -1184,7 +1157,7 @@ def test__observed_field_single_star_gets_the_margin_as_its_radius():
     assert u.allclose(radius, _CATALOG_RADIUS_MARGIN, atol=1e-6 * u.arcsec)
 
 
-def test__observed_field_center_survives_the_ra_wrap():
+def test_observed_field_center_survives_the_ra_wrap():
     # A naive mean of the RA values of 359.9 and 0.1 degrees is 180 degrees
     # -- the far side of the sky from both stars -- which would ask for a
     # cone containing neither of them. Averaging the unit cartesian vectors
@@ -1201,32 +1174,25 @@ def test__observed_field_center_survives_the_ra_wrap():
 
 
 @pytest.mark.parametrize("case", ["nan", "masked"])
-def test__observed_field_ignores_positions_that_are_not_finite(case):
+def test_observed_field_ignores_positions_that_are_not_finite(case):
     # A NaN or masked entry in either column must drop the whole row, not
     # just poison the mean -- checked here by comparing against the field
-    # computed from the good rows alone.
+    # computed from the good rows alone. Two extra rows, one with a bad ra
+    # and one with a bad dec, confirm a row is dropped even when it has one
+    # finite coordinate.
     ra_good = u.Quantity([180.0, 180.01, 179.99], u.degree)
     dec_good = u.Quantity([45.0, 45.01, 44.99], u.degree)
     center_good, radius_good = _observed_field(ra_good, dec_good)
 
+    ra_values = np.concatenate([ra_good.value, [180.5, 180.5]])
+    dec_values = np.concatenate([dec_good.value, [45.5, 45.5]])
     if case == "nan":
-        # One extra row with a bad ra, one with a bad dec: both must be
-        # dropped even though each has one finite coordinate.
-        ra = u.Quantity(np.concatenate([ra_good.value, [np.nan, 180.5]]), u.degree)
-        dec = u.Quantity(np.concatenate([dec_good.value, [45.5, np.nan]]), u.degree)
+        ra_values[3], dec_values[4] = np.nan, np.nan
+        ra = u.Quantity(ra_values, u.degree)
+        dec = u.Quantity(dec_values, u.degree)
     else:
-        # Same idea with masks instead of NaNs: one extra row masked in ra,
-        # one masked in dec.
-        ra = MaskedColumn(
-            np.concatenate([ra_good.value, [180.5, 180.5]]),
-            mask=[False, False, False, True, False],
-            unit=u.degree,
-        )
-        dec = MaskedColumn(
-            np.concatenate([dec_good.value, [45.5, 45.5]]),
-            mask=[False, False, False, False, True],
-            unit=u.degree,
-        )
+        ra = MaskedColumn(ra_values, mask=[False] * 3 + [True, False], unit=u.degree)
+        dec = MaskedColumn(dec_values, mask=[False] * 4 + [True], unit=u.degree)
 
     center, radius = _observed_field(ra, dec)
 
@@ -1234,7 +1200,7 @@ def test__observed_field_ignores_positions_that_are_not_finite(case):
     assert u.allclose(radius, radius_good)
 
 
-def test__observed_field_raises_when_no_position_is_finite():
+def test_observed_field_raises_when_no_position_is_finite():
     ra = u.Quantity([np.nan, np.nan], u.degree)
     dec = u.Quantity([np.nan, np.nan], u.degree)
 
@@ -2908,12 +2874,13 @@ def test_transform_to_catalog_default_radius_encloses_observations(mocker):
     observed = _generate_observed_table(ra, dec, instrumental)
 
     _run_transform_to_catalog(mocker, catalog, observed)
-    center, radius = _fetch_call_args()
+    center = magnitude_transforms.apass_dr9.call_args.args[0]
+    radius = magnitude_transforms.apass_dr9.call_args.kwargs["radius"]
 
     # The field here spans under an arcminute and does not cross the RA
     # wrap, so a plain mean of the columns is an independent check of the
     # centroid -- the wrap case, where a plain mean fails, is covered by
-    # test__observed_field_center_survives_the_ra_wrap above.
+    # test_observed_field_center_survives_the_ra_wrap above.
     expected_center = SkyCoord(
         np.mean(observed["ra"]), np.mean(observed["dec"]), unit="degree"
     )
@@ -2923,7 +2890,6 @@ def test_transform_to_catalog_default_radius_encloses_observations(mocker):
         center
     )
     assert u.allclose(radius, separations.max() + _CATALOG_RADIUS_MARGIN)
-    assert (separations <= radius).all()
 
     # The point of the issue: `_generate_star_coordinates` lays the stars on
     # a grid 10 arcsec apart, so a 20-star field is under an arcminute
@@ -2936,7 +2902,7 @@ def test_transform_to_catalog_explicit_radius_is_used(mocker):
     observed = _generate_observed_table(ra, dec, instrumental)
 
     _run_transform_to_catalog(mocker, catalog, observed, search_radius=5 * u.arcmin)
-    _, radius = _fetch_call_args()
+    radius = magnitude_transforms.apass_dr9.call_args.kwargs["radius"]
 
     # 5 arcmin is far larger than the derived radius for this field (well
     # under an arcminute), so this also confirms the explicit value really
@@ -2944,18 +2910,41 @@ def test_transform_to_catalog_explicit_radius_is_used(mocker):
     assert u.allclose(radius, 5 * u.arcmin)
 
 
+def test_transform_to_catalog_cone_covers_only_the_fitted_passband(mocker):
+    # Only the rows in ``obs_filter`` are ever matched against the catalog,
+    # so drawing the cone around the whole table would be issue #686 again
+    # through a different door: a night of several targets in several bands
+    # would pull a multi-degree catalog to calibrate one arcminute of sky.
+    # The two bands here sit some twenty degrees apart, which no single
+    # cone around both could be mistaken for.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    in_band = _generate_observed_table(ra, dec, instrumental, passband="R")
+
+    other_ra, other_dec = _generate_star_coordinates(
+        20, ra_start=200 * u.degree, dec_start=25 * u.degree
+    )
+    other_band = _generate_observed_table(
+        other_ra, other_dec, instrumental, passband="I", file_name="image_2.fit"
+    )
+
+    _run_transform_to_catalog(
+        mocker, catalog, _combine_observed_tables(in_band, other_band), obs_filter="R"
+    )
+    center = magnitude_transforms.apass_dr9.call_args.args[0]
+    radius = magnitude_transforms.apass_dr9.call_args.kwargs["radius"]
+
+    expected_center = SkyCoord(
+        np.mean(in_band["ra"]), np.mean(in_band["dec"]), unit="degree"
+    )
+    assert center.separation(expected_center) < 1 * u.arcsec
+
+    # The R field alone is under an arcminute across, so the cone is a hair
+    # over the margin -- and nowhere near large enough to reach the I stars.
+    assert radius < 2 * u.arcmin
+
+
 def _wide_field_observations():
-    """
-    Build observations spread over a field wider than `_WIDE_FIELD_RADIUS`.
-
-    Returns
-    -------
-    catalog : `_FakeCatalogTable`
-        Synthetic catalog covering the positions.
-
-    observed : `astropy.table.Table`
-        Observations of those positions, grouped by file.
-    """
+    """Observations spread over a field wider than `_WIDE_FIELD_RADIUS`."""
     # 20 stars on a grid 40 arcmin apart span about two degrees, so the cone
     # drawn around them comes out well over the one degree that used to be
     # hardcoded -- which is exactly the case the warning is about.
@@ -2965,52 +2954,61 @@ def _wide_field_observations():
     return catalog, _generate_observed_table(ra, dec, instrumental)
 
 
-def test_transform_to_catalog_warns_when_the_derived_cone_is_wide(mocker):
+@pytest.mark.parametrize(
+    "wide_field, search_radius, expect_warn",
+    [(False, None, False), (True, None, True), (True, 3 * u.degree, False)],
+    ids=["ordinary_field", "derived_wide_cone", "explicit_wide_radius"],
+)
+def test_transform_to_catalog_warns_only_for_a_derived_wide_cone(
+    mocker, recwarn, wide_field, search_radius, expect_warn
+):
     # A field this wide is almost always a mosaic, or ra/dec columns that
     # hold more than one field's worth of stars. Before the cone was derived
     # such a table quietly got a one degree catalog and calibrated against
     # whatever fell inside it; now it gets a cone that really covers the
-    # table, which is correct but is also a query worth hearing about.
-    catalog, observed = _wide_field_observations()
+    # table, which is correct but is also a query worth hearing about --
+    # unless the caller asked for that width on purpose.
+    if wide_field:
+        catalog, observed = _wide_field_observations()
+    else:
+        catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+        observed = _generate_observed_table(ra, dec, instrumental)
 
-    with pytest.warns(AstropyUserWarning, match="search_radius"):
-        _run_transform_to_catalog(mocker, catalog, observed)
+    kwargs = {} if search_radius is None else {"search_radius": search_radius}
+    _run_transform_to_catalog(mocker, catalog, observed, **kwargs)
 
-    _, radius = _fetch_call_args()
-    assert radius > _WIDE_FIELD_RADIUS
-
-
-def test_transform_to_catalog_does_not_warn_for_an_ordinary_field(mocker):
-    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
-    observed = _generate_observed_table(ra, dec, instrumental)
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _run_transform_to_catalog(mocker, catalog, observed)
-
-    assert not [
-        warning for warning in caught if "search_radius" in str(warning.message)
+    caught = [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, AstropyUserWarning)
+        and "search_radius" in str(w.message)
     ]
-
-
-def test_transform_to_catalog_does_not_warn_for_an_explicit_wide_radius(mocker):
-    # Asking for a wide cone on purpose is not something to be warned about;
-    # only a cone that came out wide on its own is.
-    catalog, observed = _wide_field_observations()
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _run_transform_to_catalog(mocker, catalog, observed, search_radius=3 * u.degree)
-
-    assert not [
-        warning for warning in caught if "search_radius" in str(warning.message)
-    ]
+    assert bool(caught) is expect_warn
+    if expect_warn:
+        radius = magnitude_transforms.apass_dr9.call_args.kwargs["radius"]
+        assert radius > _WIDE_FIELD_RADIUS
 
 
 @pytest.mark.parametrize(
     "bad_radius",
-    [0.1, 5 * u.meter, -1 * u.arcmin, 0 * u.arcmin, np.nan * u.arcmin],
-    ids=["no_unit", "wrong_unit", "negative", "zero", "nan"],
+    [
+        0.1,
+        5 * u.meter,
+        -1 * u.arcmin,
+        0 * u.arcmin,
+        np.nan * u.arcmin,
+        u.Quantity([5], u.arcmin),
+        u.Quantity([5, 6], u.arcmin),
+    ],
+    ids=[
+        "no_unit",
+        "wrong_unit",
+        "negative",
+        "zero",
+        "nan",
+        "single_element_array",
+        "multi_element_array",
+    ],
 )
 def test_transform_to_catalog_rejects_a_bad_search_radius(mocker, bad_radius):
     # Validating up front, before the catalog fetch, means a bad argument

--- a/stellarphot/utils/tests/test_magnitude_transforms.py
+++ b/stellarphot/utils/tests/test_magnitude_transforms.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from types import SimpleNamespace
 
 import numpy as np
@@ -20,7 +21,10 @@ from ..magnitude_system_transforms import (
     transform_refcat2_bands,
 )
 from ..magnitude_transforms import (
+    _CATALOG_RADIUS_MARGIN,
     _MIN_FIT_SIGMA,
+    _WIDE_FIELD_RADIUS,
+    _observed_field,
     _to_float_array,
     calibrated_from_instrumental,
     filter_transform,
@@ -509,6 +513,32 @@ def _run_transform_to_catalog(
     call_kwargs.update(kwargs)
 
     return transform_to_catalog(observed, obs_filter, cat_name=cat_name, **call_kwargs)
+
+
+def _fetch_call_args(cat_name="apass_dr9"):
+    """
+    Return the field center and radius the patched catalog fetch was called
+    with.
+
+    Parameters
+    ----------
+
+    cat_name : str, optional
+        Name of the catalog fetch to inspect, patched onto
+        `~stellarphot.utils.magnitude_transforms` by `_patch_catalog_fetch`.
+
+    Returns
+    -------
+    center : `astropy.coordinates.SkyCoord`
+        The field center the fetch was called with, i.e. its first
+        positional argument.
+
+    radius : `astropy.units.Quantity`
+        The cone search radius the fetch was called with, i.e. its
+        ``radius`` keyword argument.
+    """
+    call_args = getattr(magnitude_transforms, cat_name).call_args
+    return call_args.args[0], call_args.kwargs["radius"]
 
 
 # Every output column whose value comes from the catalog entry a star was
@@ -1139,6 +1169,77 @@ def test_to_float_array_leaves_unitless_input_alone():
     converted = _to_float_array(masked)
     assert type(converted) is np.ndarray
     np.testing.assert_array_equal(converted, [1.0, np.nan])
+
+
+def test__observed_field_single_star_gets_the_margin_as_its_radius():
+    # This is why the margin exists at all: without it, a single-star field
+    # -- max separation from its own centroid is exactly zero -- would ask
+    # for a zero-radius cone and never find its own star in the catalog.
+    ra = u.Quantity([180.0], u.degree)
+    dec = u.Quantity([45.0], u.degree)
+
+    center, radius = _observed_field(ra, dec)
+
+    assert center.separation(SkyCoord(ra[0], dec[0])) < 1 * u.mas
+    assert u.allclose(radius, _CATALOG_RADIUS_MARGIN, atol=1e-6 * u.arcsec)
+
+
+def test__observed_field_center_survives_the_ra_wrap():
+    # A naive mean of the RA values of 359.9 and 0.1 degrees is 180 degrees
+    # -- the far side of the sky from both stars -- which would ask for a
+    # cone containing neither of them. Averaging the unit cartesian vectors
+    # instead puts the center at the true midpoint, RA 0.
+    ra = u.Quantity([359.9, 0.1], u.degree)
+    dec = u.Quantity([0.0, 0.0], u.degree)
+
+    center, radius = _observed_field(ra, dec)
+
+    assert abs(center.ra.wrap_at(180 * u.degree)) < 1 * u.arcsec
+    assert u.allclose(
+        radius, 0.1 * u.degree + _CATALOG_RADIUS_MARGIN, atol=1 * u.arcsec
+    )
+
+
+@pytest.mark.parametrize("case", ["nan", "masked"])
+def test__observed_field_ignores_positions_that_are_not_finite(case):
+    # A NaN or masked entry in either column must drop the whole row, not
+    # just poison the mean -- checked here by comparing against the field
+    # computed from the good rows alone.
+    ra_good = u.Quantity([180.0, 180.01, 179.99], u.degree)
+    dec_good = u.Quantity([45.0, 45.01, 44.99], u.degree)
+    center_good, radius_good = _observed_field(ra_good, dec_good)
+
+    if case == "nan":
+        # One extra row with a bad ra, one with a bad dec: both must be
+        # dropped even though each has one finite coordinate.
+        ra = u.Quantity(np.concatenate([ra_good.value, [np.nan, 180.5]]), u.degree)
+        dec = u.Quantity(np.concatenate([dec_good.value, [45.5, np.nan]]), u.degree)
+    else:
+        # Same idea with masks instead of NaNs: one extra row masked in ra,
+        # one masked in dec.
+        ra = MaskedColumn(
+            np.concatenate([ra_good.value, [180.5, 180.5]]),
+            mask=[False, False, False, True, False],
+            unit=u.degree,
+        )
+        dec = MaskedColumn(
+            np.concatenate([dec_good.value, [45.5, 45.5]]),
+            mask=[False, False, False, False, True],
+            unit=u.degree,
+        )
+
+    center, radius = _observed_field(ra, dec)
+
+    assert center.separation(center_good) < 1 * u.mas
+    assert u.allclose(radius, radius_good)
+
+
+def test__observed_field_raises_when_no_position_is_finite():
+    ra = u.Quantity([np.nan, np.nan], u.degree)
+    dec = u.Quantity([np.nan, np.nan], u.degree)
+
+    with pytest.raises(ValueError, match="finite"):
+        _observed_field(ra, dec)
 
 
 def test_transform_to_catalog_tolerates_units_on_the_error_column(mocker):
@@ -2798,6 +2899,131 @@ def test_transform_to_catalog_unknown_catalog_raises():
         )
 
 
+def test_transform_to_catalog_default_radius_encloses_observations(mocker):
+    # Issue #686: the catalog cone used to be hardcoded to the first observed
+    # row and 1 degree, regardless of how large or small the field actually
+    # is. With no ``search_radius`` given, the cone should instead be
+    # centered on the observed field and sized to just enclose it.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    _run_transform_to_catalog(mocker, catalog, observed)
+    center, radius = _fetch_call_args()
+
+    # The field here spans under an arcminute and does not cross the RA
+    # wrap, so a plain mean of the columns is an independent check of the
+    # centroid -- the wrap case, where a plain mean fails, is covered by
+    # test__observed_field_center_survives_the_ra_wrap above.
+    expected_center = SkyCoord(
+        np.mean(observed["ra"]), np.mean(observed["dec"]), unit="degree"
+    )
+    assert center.separation(expected_center) < 1 * u.arcsec
+
+    separations = SkyCoord(observed["ra"], observed["dec"], unit="degree").separation(
+        center
+    )
+    assert u.allclose(radius, separations.max() + _CATALOG_RADIUS_MARGIN)
+    assert (separations <= radius).all()
+
+    # The point of the issue: `_generate_star_coordinates` lays the stars on
+    # a grid 10 arcsec apart, so a 20-star field is under an arcminute
+    # across, and must no longer pull a degree-wide catalog.
+    assert radius < 1 * u.degree
+
+
+def test_transform_to_catalog_explicit_radius_is_used(mocker):
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    _run_transform_to_catalog(mocker, catalog, observed, search_radius=5 * u.arcmin)
+    _, radius = _fetch_call_args()
+
+    # 5 arcmin is far larger than the derived radius for this field (well
+    # under an arcminute), so this also confirms the explicit value really
+    # overrode the derived one rather than coinciding with it by chance.
+    assert u.allclose(radius, 5 * u.arcmin)
+
+
+def _wide_field_observations():
+    """
+    Build observations spread over a field wider than `_WIDE_FIELD_RADIUS`.
+
+    Returns
+    -------
+    catalog : `_FakeCatalogTable`
+        Synthetic catalog covering the positions.
+
+    observed : `astropy.table.Table`
+        Observations of those positions, grouped by file.
+    """
+    # 20 stars on a grid 40 arcmin apart span about two degrees, so the cone
+    # drawn around them comes out well over the one degree that used to be
+    # hardcoded -- which is exactly the case the warning is about.
+    coordinates = _generate_star_coordinates(20, separation=40 * u.arcmin)
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20, coordinates=coordinates)
+
+    return catalog, _generate_observed_table(ra, dec, instrumental)
+
+
+def test_transform_to_catalog_warns_when_the_derived_cone_is_wide(mocker):
+    # A field this wide is almost always a mosaic, or ra/dec columns that
+    # hold more than one field's worth of stars. Before the cone was derived
+    # such a table quietly got a one degree catalog and calibrated against
+    # whatever fell inside it; now it gets a cone that really covers the
+    # table, which is correct but is also a query worth hearing about.
+    catalog, observed = _wide_field_observations()
+
+    with pytest.warns(AstropyUserWarning, match="search_radius"):
+        _run_transform_to_catalog(mocker, catalog, observed)
+
+    _, radius = _fetch_call_args()
+    assert radius > _WIDE_FIELD_RADIUS
+
+
+def test_transform_to_catalog_does_not_warn_for_an_ordinary_field(mocker):
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _run_transform_to_catalog(mocker, catalog, observed)
+
+    assert not [
+        warning for warning in caught if "search_radius" in str(warning.message)
+    ]
+
+
+def test_transform_to_catalog_does_not_warn_for_an_explicit_wide_radius(mocker):
+    # Asking for a wide cone on purpose is not something to be warned about;
+    # only a cone that came out wide on its own is.
+    catalog, observed = _wide_field_observations()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _run_transform_to_catalog(mocker, catalog, observed, search_radius=3 * u.degree)
+
+    assert not [
+        warning for warning in caught if "search_radius" in str(warning.message)
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_radius",
+    [0.1, 5 * u.meter, -1 * u.arcmin, 0 * u.arcmin, np.nan * u.arcmin],
+    ids=["no_unit", "wrong_unit", "negative", "zero", "nan"],
+)
+def test_transform_to_catalog_rejects_a_bad_search_radius(mocker, bad_radius):
+    # Validating up front, before the catalog fetch, means a bad argument
+    # costs nothing more than raising -- not a wasted Vizier round trip.
+    catalog, ra, dec, instrumental = _generate_fake_catalog(20)
+    observed = _generate_observed_table(ra, dec, instrumental)
+
+    with pytest.raises(ValueError):
+        _run_transform_to_catalog(mocker, catalog, observed, search_radius=bad_radius)
+
+    assert magnitude_transforms.apass_dr9.call_count == 0
+
+
 def test_transform_to_catalog_fixes_unvaried_terms(mocker):
     # Terms that are not varied are held at exactly zero. Faking a fixed
     # parameter with a narrow box, as the old bounds did, leaves them near
@@ -3896,19 +4122,19 @@ def test_transform_to_catalog_missing_catalog_band_raises_clean_error(mocker):
 # rather than as a fill value. See issue #680.
 
 # Center of the field the remote tests calibrate against: the north galactic
-# pole. The field matters more than it looks. `transform_to_catalog` searches
-# a hardcoded one degree around the first observation and
-# `CatalogData.from_vizier` asks for every row in that cone, so the test pulls
-# a full degree-radius catalog however small a field it builds observations
-# from -- see issue #686. At the galactic pole that cone holds as few stars as
-# any patch of sky does, which is what keeps the query to something Vizier
-# will answer in reasonable time.
+# pole, where the sky is about as sparse as it gets. The cone
+# `transform_to_catalog` draws is now sized to the field it is handed rather
+# than fixed at a degree (issue #686), so this choice no longer has to rescue
+# a degree-wide query. What it still buys is a quick answer to the separate
+# query below, which asks `CatalogData.from_vizier` for every row in ten
+# arcminutes.
 _REMOTE_FIELD_CENTER = SkyCoord(ra=192.85948 * u.degree, dec=27.12825 * u.degree)
 
-# Radius of the separate, small query that supplies the stars the fake
-# observations are built from. Deliberately far smaller than the one degree
-# above: the point is to observe a handful of real stars near the center, not
-# to reproduce the query under test.
+# Radius of the separate query that supplies the stars the fake observations
+# are built from. It is this radius, rather than anything inside the function
+# under test, that now decides how much sky the test covers: the cone that
+# function draws is derived from these stars' own positions, so it comes out
+# barely larger than this.
 _REMOTE_OBSERVED_RADIUS = 10 * u.arcmin
 
 # Zero point the fake observations are built with, and the scatter added to
@@ -4045,8 +4271,8 @@ def test_transform_to_catalog_against_a_real_catalog(cat_name):
         calibrated[has_a_catalog_magnitude] - catalog_mag[has_a_catalog_magnitude]
     )
     # A percentile rather than a maximum: a real field contains variables and
-    # blends, and one star matched to the wrong catalog entry a degree-wide
-    # query turned up should not fail a test about the pipeline.
+    # blends, and one star matched to the wrong catalog entry should not fail
+    # a test about the pipeline.
     assert np.percentile(recovered, 90) < 0.05
 
     # The fit's account of itself, which is only meaningful on data that


### PR DESCRIPTION
Closes #686

`transform_to_catalog()` fetched its calibration catalog from a cone fixed at one degree around whichever star happened to be first in the table, and `CatalogData.from_vizier` asks for every row in that cone — so a small field pulled a degree-wide catalog no matter how small it really was.

## What changed

The cone is now **centered on the centroid of the observed positions** and **sized to enclose every one of them plus a one arcminute margin**. The centroid is the mean of the positions' unit cartesian vectors, so a field straddling RA 0 does not average to the antipode the way a plain mean of RA would.

A new `search_radius` keyword takes an explicit angle instead. It is validated up front — before the query — so a bad value costs a raise rather than a Vizier round trip.

A *derived* cone wider than one degree warns. That is a cone no call could previously produce, and a table covering that much sky is usually more than one field's worth of `ra`/`dec`. An explicit `search_radius` is a deliberate choice and passes without comment.

## Effect

Measured at the north galactic pole — the sparsest patch of sky there is, so an ordinary field improves by more:

| | rows returned | `remote_data` test |
|---|---|---|
| `main` (1 degree) | 5778 | 9.6 s |
| this branch (11 arcmin) | 222 | 5.6 s |

## Notes

- `row_limit=-1` in `from_vizier` is deliberately left alone; the cone now bounds the row count.
- `_to_float_array` could not be reused for `ra`/`dec` — it raises `UnitConversionError` for any unit that is neither dimensionless nor mag-equivalent, and coordinate columns carry `deg`. A sibling `_to_degree_array` handles angles.
- The `remote_data` test's field comment explained the old degree-wide workaround and has been rewritten. The galactic-pole field itself is kept: it still buys a quick answer to the *separate* ten-arcminute query that supplies the observed stars.

## Testing

12 new tests for the derived and explicit radius, the argument validation, and `_observed_field` itself (single star, the RA wrap, masked/NaN positions, no finite position); 3 more for the wide-field warning. Full suite: 1018 passed. The `remote_data` test passes against both catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zVojGsHye1BX8afuo9Yig
